### PR TITLE
Neighbour discovery initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 build/*
 .vscode/*
+worker_*.dot
+src/*.swp
+src/*.swo
+src/nodes/*.swp
+src/nodes/*.swo

--- a/1
+++ b/1
@@ -1,0 +1,125 @@
+#include <rte_common.h>
+#include <rte_ethdev.h>
+#include <rte_graph.h>
+#include <rte_graph_worker.h>
+#include <rte_mbuf.h>
+#include <rte_ether.h>
+#include "node_api.h"
+#include "nodes/ipv6_nd_node.h"
+#include "dp_lpm.h"
+#include "dp_mbuf_dyn.h"
+#include "dp_debug.h"
+
+
+struct ipv6_nd_node_main ipv6_nd_node;
+
+static int ipv6_nd_node_init(const struct rte_graph *graph, struct rte_node *node)
+{
+	struct ipv6_nd_node_ctx *ctx = (struct ipv6_nd_node_ctx *)node->ctx;
+
+	ctx->next = IPV6_ND_NEXT_DROP;
+	RTE_SET_USED(graph);
+
+	return 0;
+}
+
+static __rte_always_inline int handle_nd(struct rte_mbuf *m) 
+{
+	struct rte_ether_hdr *req_eth_hdr;
+	struct rte_ipv6_hdr *req_ipv6_hdr;
+	struct nd_msg *nd_msg;
+	struct icmp6hdr *req_icmp6_hdr;
+	uint8_t* own_ip6 = dp_get_ip6(m->port);
+
+	req_eth_hdr = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+	req_ipv6_hdr = (struct rte_ipv6_hdr*) (req_eth_hdr + 1);
+	nd_msg = (struct nd_msg*) (req_ipv6_hdr + 1);
+
+	if((memcmp((void*)nd_msg->target, (void*)own_ip6,16)) != 0) {
+		print_addr(own_ip6);
+		print_addr(req_ipv6_hdr->dst_addr);
+		printf("\n");
+		return 0;
+	}
+	rte_ether_addr_copy(&req_eth_hdr->s_addr, &req_eth_hdr->d_addr);
+	rte_memcpy(req_eth_hdr->s_addr.addr_bytes, dp_get_mac(m->port), 6);
+
+	rte_memcpy(req_ipv6_hdr->dst_addr, req_ipv6_hdr->src_addr,16);
+	rte_memcpy(req_ipv6_hdr->src_addr, own_ip6,16);
+
+	dp_set_neigh_mac(m->port, &req_eth_hdr->d_addr);
+	dp_set_neigh_ip6(m->port, req_ipv6_hdr->dst_addr);
+	
+	req_icmp6_hdr = &(nd_msg->icmph);
+	uint8_t type = req_icmp6_hdr->icmp6_type ;
+
+	if( type != NDISC_NEIGHBOUR_SOLICITATION) {
+		return 0;
+
+	}
+	req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
+	req_icmp6_hdr->icmp6_solicited	= 1;
+	req_icmp6_hdr->icmp6_override	= 1;
+
+	// set target lladdr option and MAC
+	nd_msg->opt[0] = ND_OPT_TARGET_LL_ADDR;
+	nd_msg->opt[1] = ND_OPT_LEN_OCTET_1;
+	rte_memcpy(&nd_msg->opt[2],req_eth_hdr->s_addr.addr_bytes,6);
+
+	//L4 cksum calculation 
+	req_icmp6_hdr->icmp6_cksum	= 0;
+	req_icmp6_hdr->icmp6_cksum = rte_ipv6_udptcp_cksum(req_ipv6_hdr,req_icmp6_hdr);
+
+	printf("NA msg: type: %d\n",req_icmp6_hdr->icmp6_type);
+
+	return 1;
+
+} 
+
+
+static __rte_always_inline uint16_t ipv6_nd_node_process(struct rte_graph *graph				, struct rte_node *node, void **objs,uint16_t cnt)
+{
+	struct rte_mbuf *mbuf0, **pkts;
+	int i;
+
+	pkts = (struct rte_mbuf **)objs;
+
+
+	for (i = 0; i < cnt; i++) {
+		mbuf0 = pkts[i];
+		init_dp_mbuf_priv1(mbuf0);
+		if (handle_nd(mbuf0))
+			rte_node_enqueue_x1(graph, node, ipv6_nd_node.next_index[mbuf0->port] , *objs);
+		else
+			rte_node_enqueue_x1(graph, node, IPV6_ND_NEXT_DROP, *objs);
+	}	
+
+	return cnt;
+}
+
+int ipv6_nd_set_next(uint16_t port_id, uint16_t next_index)
+{
+
+	ipv6_nd_node.next_index[port_id] = next_index;
+	return 0;
+}
+
+
+static struct rte_node_register ipv6_nd_node_base = {
+	.name = "ipv6_nd",
+	.init = ipv6_nd_node_init,
+	.process = ipv6_nd_node_process,
+
+	.nb_edges = IPV6_ND_NEXT_MAX,
+	.next_nodes =
+		{
+			[IPV6_ND_NEXT_DROP] = "drop",
+		},
+};
+
+struct rte_node_register *ipv6_nd_node_get(void)
+{
+	return &ipv6_nd_node_base;
+}
+
+RTE_NODE_REGISTER(ipv6_nd_node_base);

--- a/include/dp_debug.h
+++ b/include/dp_debug.h
@@ -1,0 +1,29 @@
+#ifndef _DP_DEBUG_H_
+#define _DP_DEBUG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RTE_ETHER_ADDR_PRT_FMT     "%02X:%02X:%02X:%02X:%02X:%02X"
+#define RTE_ETHER_ADDR_BYTES(mac_addrs) ((mac_addrs)->addr_bytes[0]), \
+                        ((mac_addrs)->addr_bytes[1]), \
+                        ((mac_addrs)->addr_bytes[2]), \
+                        ((mac_addrs)->addr_bytes[3]), \
+                        ((mac_addrs)->addr_bytes[4]), \
+                        ((mac_addrs)->addr_bytes[5])
+
+
+void print_addr(uint8_t data_arr[])
+{
+    for (int i=0;i<16;i++)
+    {
+        printf("0x%02x ", data_arr[i]);
+    }
+    printf("\n");
+}
+
+#ifdef __cpluscplus
+}
+#endif
+#endif

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -22,20 +22,26 @@ extern "C" {
 #define IPV4_L3FWD_LPM_MAX_RULES	1024
 #define IPV4_L3FWD_LPM_NUMBER_TBL8S	(1 << 8)
 
+
 struct macip_entry {
 	struct rte_ether_addr	own_mac;
 	struct rte_ether_addr	neigh_mac;
-	uint32_t				own_ip;
-	uint32_t				neigh_ip;
-	uint8_t					depth;
+	uint32_t	own_ip;
+	uint32_t	neigh_ip;
+	uint8_t	depth;
+	uint8_t	own_ipv6[16];
+	uint8_t	neigh_ipv6[16];
 };
 
 void setup_lpm(const int socketid);
 int lpm_get_ip4_dst_port(const struct rte_ipv4_hdr *ipv4_hdr, int socketid);
 
 uint32_t dp_get_ip4(uint16_t portid);
+uint8_t* dp_get_ip6(uint16_t portid);
 int dp_add_route(uint16_t portid, uint32_t ip, uint8_t depth, int socketid);
 void dp_set_ip4(uint16_t portid, uint32_t ip, uint8_t depth, int socketid);
+void dp_set_ip6(uint16_t portid, uint8_t* ipv6, uint8_t depth, int socketid);
+void dp_set_neigh_ip6(uint16_t portid, uint8_t* ipv6);
 void dp_set_mac(uint16_t portid);
 struct rte_ether_addr *dp_get_mac(uint16_t portid);
 void dp_set_neigh_mac(uint16_t portid, struct rte_ether_addr* neigh);

--- a/include/nodes/ipv6_nd_node.h
+++ b/include/nodes/ipv6_nd_node.h
@@ -1,0 +1,95 @@
+#ifndef __INCLUDE_IPV6_ND_NODE_H__
+#define __INCLUDE_IPV6_ND_NODE_H__
+
+#include "dpdk_layer.h"
+//#include <linux/icmpv6.h>
+//#include <linux/in6.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*
+ *	ICMP codes for neighbour discovery messages
+ */
+#define NDISC_NEIGHBOUR_SOLICITATION	135
+#define NDISC_NEIGHBOUR_ADVERTISEMENT	136
+
+#define ND_OPT_LEN_OCTET_1	1
+
+/*
+ *	ndisc options
+ */
+
+enum {
+	__ND_OPT_PREFIX_INFO_END = 0,
+	ND_OPT_SOURCE_LL_ADDR = 1,	/* RFC2461 */
+	ND_OPT_TARGET_LL_ADDR = 2
+};
+
+
+struct icmp6hdr {
+
+	uint8_t	icmp6_type;
+	uint8_t	icmp6_code;
+	uint16_t	icmp6_cksum;
+
+	union {
+
+		struct icmpv6_nd_advt {
+			uint32_t	reserved:5,
+					override:1,
+					solicited:1,
+					router:1,
+					reserved2:24;
+		} u_nd_advt;
+
+		struct icmpv6_nd_ra {
+			uint8_t	hop_limit;
+			uint8_t	reserved:3,
+					router_pref:2,
+					home_agent:1,
+					other:1,
+					managed:1;
+
+			uint16_t	rt_lifetime;
+		} u_nd_ra;
+
+	} icmp6_dataun;
+#define icmp6_router		icmp6_dataun.u_nd_advt.router
+#define icmp6_solicited		icmp6_dataun.u_nd_advt.solicited
+#define icmp6_override		icmp6_dataun.u_nd_advt.override
+#define icmp6_ndiscreserved	icmp6_dataun.u_nd_advt.reserved
+#define icmp6_hop_limit		icmp6_dataun.u_nd_ra.hop_limit
+};
+
+
+struct nd_msg {
+	struct icmp6hdr	icmph;
+	struct in6_addr	target;
+	uint8_t	opt[];
+};
+
+
+enum
+{
+	IPV6_ND_NEXT_DROP,
+	IPV6_ND_NEXT_MAX
+};
+
+struct ipv6_nd_node_ctx
+{
+	uint16_t next;
+};
+
+struct ipv6_nd_node_main {
+	uint16_t next_index[DP_MAX_PORTS];
+};
+
+struct rte_node_register *ipv6_nd_node_get(void);
+int ipv6_nd_set_next(uint16_t port_id, uint16_t next_index);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -14,10 +14,23 @@ static struct rte_ether_addr pf_neigh_mac =
 								.addr_bytes[5] = 0xfb,
 								};
 
+static uint8_t port_ip6s[DP_MAX_PORTS][16] = {
+	{0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0xb8,0x66,0xc7,0xff,0xfe,0xd5,0xce,0x25},
+	{0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0xb8,0x66,0xc7,0xff,0xfe,0xd5,0xce,0x25},
+	{0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0xb8,0x66,0xc7,0xff,0xfe,0xd5,0xce,0x25}
+};
+
 uint32_t dp_get_ip4(uint16_t portid)
 {
 	RTE_VERIFY(portid < DP_MAX_PORTS);
 	return mac_ip_table[portid].own_ip;
+}
+
+
+uint8_t* dp_get_ip6(uint16_t portid)
+{
+	RTE_VERIFY(portid < DP_MAX_PORTS);
+	return mac_ip_table[portid].own_ipv6;
 }
 
 int dp_add_route(uint16_t portid, uint32_t ip, uint8_t depth, int socketid)
@@ -44,6 +57,20 @@ void dp_set_ip4(uint16_t portid, uint32_t ip, uint8_t depth, int socketid)
 	mac_ip_table[portid].own_ip = ip;
 	mac_ip_table[portid].depth = depth;
 } 
+
+void dp_set_ip6(uint16_t portid, uint8_t* ipv6, uint8_t depth, int socketid)
+{
+	RTE_VERIFY(portid < DP_MAX_PORTS);
+	RTE_VERIFY(socketid < DP_NB_SOCKETS);
+	rte_memcpy(&mac_ip_table[portid].own_ipv6, ipv6, 16);
+	mac_ip_table[portid].depth = depth;
+}
+
+void dp_set_neigh_ip6(uint16_t portid, uint8_t* ipv6)
+{
+	RTE_VERIFY(portid < DP_MAX_PORTS);
+	rte_memcpy(&mac_ip_table[portid].neigh_ipv6, ipv6, 16);
+}
 
 void dp_set_mac(uint16_t portid)
 {
@@ -99,4 +126,4 @@ int lpm_get_ip4_dst_port(const struct rte_ipv4_hdr *ipv4_hdr, int socketid)
 		return next_hop;
 	else
 		return DP_PF_PORT;
-} 
+}

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -26,10 +26,17 @@ struct rte_eth_conf port_conf = {
 };
 
 #define DP_IP_MASK 24
+#define DP_IPV6_MASK 64
 static uint32_t port_ip4s[DP_MAX_PORTS] = {
 	RTE_IPV4(192, 168, 120, 1), /* Port 0 */
 	RTE_IPV4(192, 168, 123, 1), /* Port 1 */
 	RTE_IPV4(192, 168, 124, 1), /* Port 2 */
+};
+
+static uint8_t port_ip6s[DP_MAX_PORTS][16] = {
+	{0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0xb8,0x66,0xc7,0xff,0xfe,0xd5,0xce,0x25},
+	{0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0xb8,0x66,0xc7,0xff,0xfe,0xd5,0xce,0x25},
+	{0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0xb8,0x66,0xc7,0xff,0xfe,0xd5,0xce,0x25}
 };
 
 struct dp_port* dp_port_create(struct dp_dpdk_layer *dp_layer, dp_port_type type)
@@ -123,6 +130,7 @@ int dp_port_init(struct dp_port* port, int p_port_id, int port_id, struct dp_por
 
 	dp_set_mac(port_id);
 	dp_set_ip4(port_id, port_ip4s[port_id], DP_IP_MASK, rte_eth_dev_socket_id(port_id));
+	dp_set_ip6(port_id, port_ip6s[port_id], DP_IPV6_MASK, rte_eth_dev_socket_id(port_id));
 	dp_add_route(port_id, port_ip4s[port_id], DP_IP_MASK, rte_eth_dev_socket_id(port_id));
 	/* Starting the port. 8< */
 	ret = rte_eth_dev_start(port_id);

--- a/src/dp_service.c
+++ b/src/dp_service.c
@@ -8,9 +8,13 @@
 
 /* Dummy function to configure the data plane hard-coded
  * TODO: This should be done via some kind of RPC mechanism*/
-#define DP_PF_NAME		"enp59s0f0"
-#define DP_PF2_NAME		"enp59s0f1np1"
+#define DP_PF_NAME	"enp59s0f0"
+#define DP_PF2_NAME	"enp59s0f1np1"
 #define DP_PF_MAC	0x43f72e8dead
+#define DP_PF_NAME_1	"enp59s0f0np0"
+#define DP_VF_NAME	"enp59s0f0"
+#define DP_PF_MAC_1	0x43f72e8cfca
+
 void dp_hard_configure()
 {
 	struct dp_port_ext pf_port;

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 dp_sources = ['dp_service.c', 'dp_port.c', 'dpdk_layer.c', 'nodes/arp_node.c',
 			  'nodes/drop_node.c', 'nodes/rx_node.c', 'nodes/cls_node.c','nodes/dhcp_node.c',
-			  'nodes/arp_node.c', 'nodes/tx_node.c', 'nodes/ipv4_lookup_node.c', 'nodes/l2_decap_node.c',
+			  'nodes/arp_node.c','nodes/ipv6_nd_node.c', 'nodes/tx_node.c', 'nodes/ipv4_lookup_node.c', 'nodes/l2_decap_node.c',
 			  'dp_mbuf_dyn.c', 'dp_lpm.c', 'nodes/ipv6_encap_node.c', 'nodes/geneve_encap_node.c',
 			  'nodes/ipv6_lookup_node.c', 'nodes/ipv6_decap_node.c', 'nodes/geneve_decap_node.c']
 

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -1,0 +1,122 @@
+#include <rte_common.h>
+#include <rte_ethdev.h>
+#include <rte_graph.h>
+#include <rte_graph_worker.h>
+#include <rte_mbuf.h>
+#include <rte_ether.h>
+#include "node_api.h"
+#include "nodes/ipv6_nd_node.h"
+#include "dp_lpm.h"
+#include "dp_mbuf_dyn.h"
+#include "dp_debug.h"
+
+
+struct ipv6_nd_node_main ipv6_nd_node;
+
+static int ipv6_nd_node_init(const struct rte_graph *graph, struct rte_node *node)
+{
+	struct ipv6_nd_node_ctx *ctx = (struct ipv6_nd_node_ctx *)node->ctx;
+
+	ctx->next = IPV6_ND_NEXT_DROP;
+	RTE_SET_USED(graph);
+
+	return 0;
+}
+
+static __rte_always_inline int handle_nd(struct rte_mbuf *m) 
+{
+	struct rte_ether_hdr *req_eth_hdr;
+	struct rte_ipv6_hdr *req_ipv6_hdr;
+	struct nd_msg *nd_msg;
+	struct icmp6hdr *req_icmp6_hdr;
+	uint8_t* own_ip6 = dp_get_ip6(m->port);
+
+	req_eth_hdr = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+	req_ipv6_hdr = (struct rte_ipv6_hdr*) (req_eth_hdr + 1);
+	nd_msg = (struct nd_msg*) (req_ipv6_hdr + 1);
+
+	if((memcmp(&nd_msg->target, own_ip6,16)) != 0) {
+		return 0;
+	}
+	rte_ether_addr_copy(&req_eth_hdr->s_addr, &req_eth_hdr->d_addr);
+	rte_memcpy(req_eth_hdr->s_addr.addr_bytes, dp_get_mac(m->port), 6);
+
+	rte_memcpy(req_ipv6_hdr->dst_addr, req_ipv6_hdr->src_addr,16);
+	rte_memcpy(req_ipv6_hdr->src_addr, own_ip6,16);
+
+	dp_set_neigh_mac(m->port, &req_eth_hdr->d_addr);
+	dp_set_neigh_ip6(m->port, req_ipv6_hdr->dst_addr);
+	
+	req_icmp6_hdr = &(nd_msg->icmph);
+	uint8_t type = req_icmp6_hdr->icmp6_type ;
+
+	if( type != NDISC_NEIGHBOUR_SOLICITATION) {
+		return 0;
+
+	}
+	req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
+	req_icmp6_hdr->icmp6_solicited	= 1;
+	req_icmp6_hdr->icmp6_override	= 1;
+
+	// set target lladdr option and MAC
+	nd_msg->opt[0] = ND_OPT_TARGET_LL_ADDR;
+	nd_msg->opt[1] = ND_OPT_LEN_OCTET_1;
+	rte_memcpy(&nd_msg->opt[2],req_eth_hdr->s_addr.addr_bytes,6);
+
+	//L4 cksum calculation 
+	req_icmp6_hdr->icmp6_cksum	= 0;
+	req_icmp6_hdr->icmp6_cksum = rte_ipv6_udptcp_cksum(req_ipv6_hdr,req_icmp6_hdr);
+
+	printf("NA msg: type: %d\n",req_icmp6_hdr->icmp6_type);
+
+	return 1;
+
+} 
+
+
+static __rte_always_inline uint16_t ipv6_nd_node_process(struct rte_graph *graph				, struct rte_node *node, void **objs,uint16_t cnt)
+{
+	struct rte_mbuf *mbuf0, **pkts;
+	int i;
+
+	pkts = (struct rte_mbuf **)objs;
+
+
+	for (i = 0; i < cnt; i++) {
+		mbuf0 = pkts[i];
+		init_dp_mbuf_priv1(mbuf0);
+		if (handle_nd(mbuf0))
+			rte_node_enqueue_x1(graph, node, ipv6_nd_node.next_index[mbuf0->port] , *objs);
+		else
+			rte_node_enqueue_x1(graph, node, IPV6_ND_NEXT_DROP, *objs);
+	}	
+
+	return cnt;
+}
+
+int ipv6_nd_set_next(uint16_t port_id, uint16_t next_index)
+{
+
+	ipv6_nd_node.next_index[port_id] = next_index;
+	return 0;
+}
+
+
+static struct rte_node_register ipv6_nd_node_base = {
+	.name = "ipv6_nd",
+	.init = ipv6_nd_node_init,
+	.process = ipv6_nd_node_process,
+
+	.nb_edges = IPV6_ND_NEXT_MAX,
+	.next_nodes =
+		{
+			[IPV6_ND_NEXT_DROP] = "drop",
+		},
+};
+
+struct rte_node_register *ipv6_nd_node_get(void)
+{
+	return &ipv6_nd_node_base;
+}
+
+RTE_NODE_REGISTER(ipv6_nd_node_base);


### PR DESCRIPTION
In this, basic neighbour discovery support added to handle Neighbour solicitation msg
and reply with Neighbour advertisement msg. Also, a lpm code changed to include ipv6 ip
addresses in the table and supporting getters/setters added. 