### PR TITLE
Initial/simple implementation of WCMP on hypervisor.

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -75,6 +75,8 @@ void dp_process_aged_flows(int port_id);
 void dp_process_aged_flows_non_offload();
 void dp_free_flow(struct flow_value *cntrack);
 
+hash_sig_t dp_get_flow_hash_value(struct flow_key *key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dp_multi_path.h
+++ b/include/dp_multi_path.h
@@ -1,0 +1,26 @@
+#ifndef __INCLUDE_DP_MULTI_PATH_H
+#define __INCLUDE_DP_MULTI_PATH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "dp_port.h"
+
+#define port_select_table_size 10
+
+typedef enum{
+	OWNER_PORT,
+	PEER_PORT,
+} egress_pf_port;
+
+void fill_port_select_table(double frac);
+egress_pf_port calculate_port_by_hash(uint32_t hash);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __INCLUDE_DP_MULTI_PATH_H */

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -29,6 +29,11 @@ int dp_get_num_of_vfs();
 int get_overlay_type();
 int get_op_env();
 
+int dp_is_wcmp_enabled();
+
+double dp_get_wcmp_frac();
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,4 +1,4 @@
-install_headers('dp_service.h', 'node_api.h', 'dp_port.h', 'dpdk_layer.h', 'dp_nat.h', 'dp_lb.h',
+install_headers('dp_service.h', 'node_api.h', 'dp_port.h', 'dpdk_layer.h', 'dp_nat.h', 'dp_lb.h','dp_multi_path.h',
                 'nodes/arp_node_priv.h', 'nodes/ipv4_lookup_priv.h', 'nodes/dhcp_node.h', 
 				'nodes/tx_node_priv.h', 'nodes/l2_decap_node.h', 'dp_mbuf_dyn.h', 'dp_lpm.h',
 				'nodes/ipv6_encap_node.h', 'nodes/ipv6_lookup_node.h', 

--- a/include/node_api.h
+++ b/include/node_api.h
@@ -26,10 +26,14 @@ struct dp_flow {
 		uint8_t		src_addr6[16];
 	} src;
 	uint32_t	nat_addr;
-	uint8_t		l4_type;
-	uint16_t	dst_port;
-	uint16_t	src_port;
-	uint8_t		icmp_type;
+	
+	uint8_t					l4_type;
+	uint16_t				dst_port;
+	uint16_t				src_port;
+	
+	uint8_t					icmp_type;
+	uint32_t                dp_flow_hash;
+
 	struct {
 		uint8_t		ul_src_addr6[16];
 		uint8_t		ul_dst_addr6[16];

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -187,5 +187,12 @@ void dp_process_aged_flows_non_offload()
 		if (unlikely((cur - flow_val->timestamp) > timeout))
 			dp_free_flow(flow_val);
 	}
+}
+
+hash_sig_t dp_get_flow_hash_value(struct flow_key *key){
+
+	//It is not necessary to first test if this key exists, since for now, this function
+	// is always called after either a flow is checked or added in the firewall node.
+	return rte_hash_hash(ipv4_flow_tbl,key);
 
 }

--- a/src/dp_multi_path.c
+++ b/src/dp_multi_path.c
@@ -1,0 +1,25 @@
+#include "dp_multi_path.h"
+#include <math.h>
+
+static egress_pf_port pf0_egress_select_table[port_select_table_size];
+
+void fill_port_select_table(double frac)
+{
+
+	uint8_t round_frac = (uint8_t)round(frac * 10);
+
+	for (uint8_t i = 0; i < round_frac; i++) {
+		pf0_egress_select_table[i] = OWNER_PORT;
+	}
+
+	for (uint8_t i = round_frac; i < port_select_table_size; i++) {
+		pf0_egress_select_table[i] = PEER_PORT;
+	}
+}
+
+egress_pf_port calculate_port_by_hash(uint32_t hash)
+{
+	uint8_t modulo = hash % port_select_table_size;
+
+	return pf0_egress_select_table[modulo];
+}

--- a/src/dp_service.cpp
+++ b/src/dp_service.cpp
@@ -13,6 +13,7 @@
 #include "dp_nat.h"
 #include "dp_lb.h"
 #include "grpc/dp_grpc_service.h"
+#include "dp_multi_path.h"
 
 static void *dp_handle_grpc(__rte_unused void *arg)
 {
@@ -24,7 +25,6 @@ static void *dp_handle_grpc(__rte_unused void *arg)
 
 	return NULL;
 }
-
 
 static void dp_init_interfaces()
 {
@@ -59,6 +59,8 @@ static void dp_init_interfaces()
 	dp_init_nat_tables(rte_eth_dev_socket_id(dp_get_pf0_port_id()));
 	dp_init_lb_tables(rte_eth_dev_socket_id(dp_get_pf0_port_id()));
 	dp_init_vm_handle_tbl(rte_eth_dev_socket_id(dp_get_pf0_port_id()));
+	if (dp_is_wcmp_enabled())
+		fill_port_select_table(dp_get_wcmp_frac());
 }
 
 int main(int argc, char **argv)
@@ -82,8 +84,8 @@ int main(int argc, char **argv)
 	ret = rte_ctrl_thread_create(dp_get_ctrl_thread_id(), "grpc-thread", NULL,
 							dp_handle_grpc, NULL);
 	if (ret < 0)
-			rte_exit(EXIT_FAILURE,
-					"Cannot create grpc thread\n");
+		rte_exit(EXIT_FAILURE,
+				"Cannot create grpc thread\n");
 
 	dp_dpdk_main_loop();
 

--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -322,6 +322,7 @@ int dp_init_interface(struct dp_port_ext *port, dp_port_type type)
 			cnt++;
 		}	
 	}
+
 	return -1;
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.c', 'nodes/arp_node.c',
+dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.c', 'dp_multi_path.c','nodes/arp_node.c',
 			  'nodes/drop_node.c', 'nodes/rx_node.c','nodes/rx_periodic_node.c', 'nodes/cls_node.c','nodes/dhcp_node.c','nodes/dhcpv6_node.c',
 			  'nodes/arp_node.c','nodes/ipv6_nd_node.c', 'nodes/tx_node.c', 'nodes/ipv4_lookup_node.c', 'nodes/l2_decap_node.c',
 			  'dp_mbuf_dyn.c', 'dp_lpm.c', 'nodes/ipv6_encap_node.c', 'nodes/firewall_node.c',

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -63,6 +63,9 @@ static __rte_always_inline int handle_conntrack(struct rte_mbuf *m)
 			flow_val->dir = DP_FLOW_DIR_ORG;
 			dp_add_flow_data(&key, flow_val);
 
+			// Only the original flow (outgoing)'s hash value is recorded
+			df_ptr->dp_flow_hash=(uint32_t)dp_get_flow_hash_value(&key);
+
 			/* Add reply direction to the conntrack table */
 			dp_invert_flow_key(&key);
 			flow_val->flow_key[DP_FLOW_DIR_REPLY] = key;
@@ -80,6 +83,7 @@ static __rte_always_inline int handle_conntrack(struct rte_mbuf *m)
 					flow_val->flow_state = DP_FLOW_STATE_ESTAB;
 				flow_val->dir = DP_FLOW_DIR_ORG;
 			}
+			df_ptr->dp_flow_hash=(uint32_t)dp_get_flow_hash_value(&key);
 		}
 		flow_val->timestamp = rte_rdtsc();
 		df_ptr->conntrack = flow_val;

--- a/src/nodes/ipip_tunnel_node.c
+++ b/src/nodes/ipip_tunnel_node.c
@@ -30,7 +30,6 @@ static __rte_always_inline int handle_ipip_tunnel_encap(struct rte_mbuf *m, stru
 
 	uint32_t vni_ns = htonl(df->tun_info.dst_vni);
 
-	// memcpy(srv6_hdr->last_segment.locator,df->tun_info.ul_dst_addr6,8);
 	memcpy(df->tun_info.ul_dst_addr6 + 8, &vni_ns, 4);
 	memset(df->tun_info.ul_dst_addr6 + 12, 0, 4);
 

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -34,8 +34,6 @@ void dp_install_isolated_mode_ipip(int port_id, uint8_t proto_id)
 	// create flow match patterns -- end
 	pattern_cnt = insert_end_match_pattern(pattern, pattern_cnt);
 
-	printf("pattern_cnt is %d \n", pattern_cnt);
-
 	// create flow action -- queue
 	struct rte_flow_action_queue queue_action;
 	action_cnt = create_redirect_queue_action(action, action_cnt,


### PR DESCRIPTION
This commit is initial/simple implementation of WCMP on hypervisor.

The idea of WCMP on hypervisor is that traffic flows coming out of a VM will be forwarded to different pf ports, depending on the hashing value of this flow.

It is achieved by using an additional parameter, --wcmp-frac=[0.0-1.0], when starting dp_service. This value indicates the percentage of the traffic that need to be forwarded through this VF's owner PF.
When this value is set as 0.5, we have ECMP, in which, traffic workload is meant to be equally shared between PFs (in theory).

Due to the constraint of Mellanox nic/driver, in the offloading mode, the traffic flows that are determined to forwarded to the peer pf port, go through the software path. With 2 core configuration for dp_service, there is a degredation of max throughput for this scenario.