### PR TITLE
Introduce config file for some of the dp_service parameters

### DIFF
--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -17,6 +17,8 @@
 #define DP_MAX_VNI_STR 12
 #define DP_TUNNEL_OPT_SIZE 8
 #define DP_OP_ENV_OPT_SIZE 10
+#define DP_CONF_FILE_SIZE 64
+#define DP_LINE_SIZE 128
 
 static int debug_mode = 0;
 static int no_offload = 0;
@@ -32,14 +34,16 @@ static char vni_str[DP_MAX_IP6_CHAR] = {0};
 static uint16_t pf_ports[DP_MAX_PF_PORT][2] = {0};
 static char tunnel_opt_str[DP_TUNNEL_OPT_SIZE] = {0};
 static char op_env_opt_str[DP_OP_ENV_OPT_SIZE] = {0};
+static char conf_file_str[DP_CONF_FILE_SIZE] = {0};
 
 static const char short_options[] = "d" /* debug */
 									"D" /* promiscuous */;
 static const char tunnel_opt_geneve[] = "geneve";
 static const char op_env_opt_scapytest[] = "scapytest";
 
-#define DP_SYSFS_PREFIX_MLX_VF_COUNT "/sys/class/net/"
-#define DP_SYSFS_SUFFIX_MLX_VF_COUNT "/device/sriov_numvfs"
+#define DP_SYSFS_PREFIX_MLX_VF_COUNT	"/sys/class/net/"
+#define DP_SYSFS_SUFFIX_MLX_VF_COUNT	"/device/sriov_numvfs"
+#define DP_DEFAULT_CONF_FILE			"/tmp/dp_service.conf"
 #define DP_SYSFS_STR_LEN 256
 
 #define CMD_LINE_OPT_PF0 "pf0"
@@ -47,6 +51,7 @@ static const char op_env_opt_scapytest[] = "scapytest";
 #define CMD_LINE_OPT_IPV6 "ipv6"
 #define CMD_LINE_OPT_VF_PATTERN "vf-pattern"
 #define CMD_LINE_OPT_TUNNEL_OPT "tun_opt"
+#define CMD_LINE_OPT_CONF_FILE "conf-file"
 #define CMD_LINE_OPT_OP_ENV "op_env"
 #define CMD_LINE_OPT_VNI "vni"
 #define CMD_LINE_OPT_NO_OFFLOAD "no-offload"
@@ -66,6 +71,7 @@ enum
 	CMD_LINE_OPT_NO_OFFLOAD_NUM,
 	CMD_LINE_OPT_NO_CONNTRACK_NUM,
 	CMD_LINE_OPT_NO_STATS_NUM,
+	CMD_LINE_OPT_CONF_FILE_NUM,
 };
 
 static const struct option lgopts[] = {
@@ -79,6 +85,7 @@ static const struct option lgopts[] = {
 	{CMD_LINE_OPT_NO_OFFLOAD, 0, 0, CMD_LINE_OPT_NO_OFFLOAD_NUM},
 	{CMD_LINE_OPT_NO_CONNTRACK, 0, 0, CMD_LINE_OPT_NO_CONNTRACK_NUM},
 	{CMD_LINE_OPT_NO_STATS, 0, 0, CMD_LINE_OPT_NO_STATS_NUM},
+	{CMD_LINE_OPT_CONF_FILE, 1, 0, CMD_LINE_OPT_CONF_FILE_NUM},
 	{NULL, 0, 0, 0},
 };
 
@@ -95,10 +102,60 @@ static void dp_print_usage(const char *prgname)
 			" --vf-pattern=eth*"
 			" [--tun_opt]=ipip/geneve"
 			" [--op_env]=scapytest/hardware"
+			" [--conf-file]=/file_path"
 			" [--no-stats]"
 			" [--no-conntrack]"
 			" [--no-offload]\n",
 			prgname);
+}
+
+static void dp_handle_conf_file()
+{
+	char s[DP_LINE_SIZE] = {0};
+	FILE * fp;
+	char * line = NULL;
+	size_t len = 0, count = 0;
+	ssize_t read;
+	char* token;
+
+	fp = fopen(conf_file_str, "r");
+	if (fp == NULL)
+		return;
+
+	while ((read = getline(&line, &len, fp)) != -1) {
+		line[read-1] = '\0';
+		strncpy(s, line, ((read > DP_LINE_SIZE) ? DP_LINE_SIZE : read));
+		token = strtok(s, " ");
+		if (strncmp(token, CMD_LINE_OPT_PF0, strlen(CMD_LINE_OPT_PF0)) == 0) {
+			token = strtok(NULL, " ");
+			strncpy(pf0name, token, IFNAMSIZ);
+			count++;
+		}
+		if (strncmp(token, CMD_LINE_OPT_PF1, strlen(CMD_LINE_OPT_PF1)) == 0) {
+			token = strtok(NULL, " ");
+			strncpy(pf1name, token, IFNAMSIZ);
+			count++;
+		}
+		if (strncmp(token, CMD_LINE_OPT_VF_PATTERN, strlen(CMD_LINE_OPT_VF_PATTERN)) == 0) {
+			token = strtok(NULL, " ");
+			strncpy(vf_pattern, token, IFNAMSIZ);
+			count++;
+		}
+		if (strncmp(token, CMD_LINE_OPT_IPV6, strlen(CMD_LINE_OPT_IPV6)) == 0) {
+			token = strtok(NULL, " ");
+			strncpy(ip6_str, token, DP_MAX_IP6_CHAR - 1);
+			inet_pton(AF_INET6, ip6_str, get_underlay_conf()->src_ip6);
+			count++;
+		}
+		/* Each line has only 2 tokens, otherwise file is corrupt */
+		if (count != 1)
+			return;
+		count = 0;
+	}
+
+	printf("Config file found at %s and will be used ! \n", conf_file_str);
+	fclose(fp);
+	free(line);
 }
 
 int dp_parse_args(int argc, char **argv)
@@ -109,6 +166,8 @@ int dp_parse_args(int argc, char **argv)
 	int opt, ret, temp;
 
 	argvopt = argv;
+
+	strncpy(conf_file_str, DP_DEFAULT_CONF_FILE, DP_CONF_FILE_SIZE);
 
 	/* Error or normal output strings. */
 	while ((opt = getopt_long(argc, argvopt, short_options, lgopts,
@@ -140,7 +199,6 @@ int dp_parse_args(int argc, char **argv)
 		case CMD_LINE_OPT_VF_PATTERN_NUM:
 			strncpy(vf_pattern, optarg, IFNAMSIZ);
 			break;
-
 		case CMD_LINE_OPT_TUNNEL_OPT_NUM:
 			strncpy(tunnel_opt_str, optarg, DP_TUNNEL_OPT_SIZE);
 			if (!strcmp(tunnel_opt_str, tunnel_opt_geneve))
@@ -152,6 +210,9 @@ int dp_parse_args(int argc, char **argv)
 				tunnel_opt = DP_FLOW_OVERLAY_TYPE_IPIP;
 			}
 
+			break;
+		case CMD_LINE_OPT_CONF_FILE_NUM:
+			strncpy(conf_file_str, optarg, DP_CONF_FILE_SIZE);
 			break;
 		
 		case CMD_LINE_OPT_OP_ENV_NUM:
@@ -195,6 +256,9 @@ int dp_parse_args(int argc, char **argv)
 		argv[optind - 1] = prgname;
 	ret = optind - 1;
 	optind = 1; /* Reset getopt lib */
+
+	/* If conf file exists, overwrite some part of the settings from file */
+	dp_handle_conf_file();
 
 	return ret;
 }


### PR DESCRIPTION
pf0, pf1, vf-pattern and ipv6 parameters can be read via
the config file which can be set with --conf-file parameter.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>

# Proposed Changes

-
-
-

Fixes #