### PR TITLE
Introduce UUID handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ ninja-build \
 meson \
 python3-pyelftools \
 iproute2 \
+libuuid1 \
+uuid-dev \
 net-tools \
 xz-utils \
 build-essential \
@@ -75,6 +77,7 @@ numactl \
 libnuma1 \
 pciutils \
 procps \
+libuuid1 \
 libgrpc++1 \
 iproute2 \
 && rm -rf /var/lib/apt/lists/*

--- a/include/grpc/dp_async_grpc.h
+++ b/include/grpc/dp_async_grpc.h
@@ -263,4 +263,19 @@ public:
 	}
 	int Proceed() override;
 };
+
+class InitializedCall final : BaseCall {
+	ServerContext ctx_;
+	Empty request_;
+	UUIDMsg reply_;
+	ServerAsyncResponseWriter<UUIDMsg> responder_;
+
+public:
+	InitializedCall(DPDKonmetal::AsyncService* service, ServerCompletionQueue* cq)
+	:BaseCall(service, cq, DP_REQ_TYPE_INIT), responder_(&ctx_) {
+		service_->Requestinitialized(&ctx_, &request_, &responder_, cq_, cq_,
+										 this);
+	}
+	int Proceed() override;
+};
 #endif //__INCLUDE_DP_ASYNC_GRPC_SERVICE_H

--- a/include/grpc/dp_grpc_impl.h
+++ b/include/grpc/dp_grpc_impl.h
@@ -27,6 +27,7 @@ typedef enum {
 	DP_REQ_TYPE_ADDPREFIX,
 	DP_REQ_TYPE_DELPREFIX,
 	DP_REQ_TYPE_LISTPREFIX,
+	DP_REQ_TYPE_INIT,
 } dp_req_type;
 
 typedef struct dp_com_head {

--- a/include/grpc/dp_grpc_service.h
+++ b/include/grpc/dp_grpc_service.h
@@ -10,18 +10,23 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 #include "dp_async_grpc.h"
+#include <uuid/uuid.h>
 
+#define DP_UUID_SIZE 37
 
 class GRPCService final : public DPDKonmetal::AsyncService {
 private:
 	std::unique_ptr<ServerCompletionQueue> cq_;
 	std::unique_ptr<Server> server_;
+	uuid_t binuuid;
+	void *uuid;
 	
 public:
 	GRPCService();
 	~GRPCService();
 	void run(std::string listen_address);
 	void HandleRpcs();
+	char* GetUUID();
 };
 
 #endif //__INCLUDE_DP_GRPC_SERVICE_H

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ proto_dep = dependency('protobuf')
 grpc_dep = dependency('grpc')
 grpccpp_dep = dependency('grpc++')
 thread_dep = dependency('threads')
+libuuid_dep = dependency('uuid')
 
 protoc = find_program('protoc')
 grpc_cpp = find_program('grpc_cpp_plugin')

--- a/proto/dpdk.proto
+++ b/proto/dpdk.proto
@@ -215,8 +215,8 @@ message FirewallRulesMsg {
 	repeated FirewallRule rules = 1;
 }
 
-message BoolMsg {
-	bool bool_val = 1;
+message UUIDMsg {
+	string uuid = 1;
 }
 
 message VirtualFunction {
@@ -243,8 +243,9 @@ message Route {
 
 service DPDKonmetal {
 	//// INITIALIZATION
-	// initialized indicates if the DPDK app has been initialized already.
-	rpc initialized(Empty) returns (BoolMsg) {}
+	// initialized indicates if the DPDK app has been initialized already, if so an UUID is returned.
+	// this UUID gets changed in case the dp-service gets restarted.
+	rpc initialized(Empty) returns (UUIDMsg) {}
 
 	// init will be called once for initial set up of the DPDK app.
 	// init returns an error if the DPDK app has been initialized already. So check if it got initialized before calling init.

--- a/src/grpc/dp_grpc_service.cpp
+++ b/src/grpc/dp_grpc_service.cpp
@@ -8,10 +8,14 @@
 
 GRPCService::GRPCService()
 {
+	uuid = malloc(DP_UUID_SIZE);
+	uuid_generate_random(binuuid);
+	uuid_unparse_upper(binuuid, (char*)uuid);
 }
 
 GRPCService::~GRPCService()
 {
+	free(uuid);
 }
 
 void GRPCService::run(std::string listen_address) 
@@ -25,10 +29,16 @@ void GRPCService::run(std::string listen_address)
 	HandleRpcs();
 }
 
+char* GRPCService::GetUUID()
+{
+	return (char*)uuid;
+}
+
 void GRPCService::HandleRpcs()
 {
 	void* tag;
 	bool ok;
+	new InitializedCall(this, cq_.get());
 	new DelPfxCall(this, cq_.get());
 	new ListPfxCall(this, cq_.get());
 	new AddPfxCall(this, cq_.get());

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,4 +9,4 @@ dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.
 			  'dp_netlink.c','rte_flow/dp_rte_flow.c','rte_flow/dp_rte_flow_init.c','rte_flow/dp_rte_flow_traffic_forward.c']
 
 executable('dp_service', [dp_sources, grpc_generated], include_directories : [inc],
-			dependencies : [dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep] )
+			dependencies : [dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep, libuuid_dep] )

--- a/test/dp_grpc_client.cpp
+++ b/test/dp_grpc_client.cpp
@@ -35,6 +35,7 @@ typedef enum {
 	DP_CMD_ADD_PFX,
 	DP_CMD_LIST_PFX,
 	DP_CMD_DEL_PFX,
+	DP_CMD_INIT,
 } cmd_type;
 
 static char ip6_str[40] = {0};
@@ -55,6 +56,7 @@ static int vni;
 static int t_vni;
 static int length;
 
+#define CMD_LINE_OPT_INIT			"is_init"
 #define CMD_LINE_OPT_ADD_PFX		"addpfx"
 #define CMD_LINE_OPT_LIST_PFX		"listpfx"
 #define CMD_LINE_OPT_DEL_PFX		"delpfx"
@@ -106,6 +108,7 @@ enum {
 	CMD_LINE_OPT_ADD_PFX_NUM,
 	CMD_LINE_OPT_LIST_PFX_NUM,
 	CMD_LINE_OPT_DEL_PFX_NUM,
+	CMD_LINE_OPT_INIT_NUM,
 };
 
 static const struct option lgopts[] = {
@@ -133,6 +136,7 @@ static const struct option lgopts[] = {
 	{CMD_LINE_OPT_ADD_PFX, 1, 0, CMD_LINE_OPT_ADD_PFX_NUM},
 	{CMD_LINE_OPT_LIST_PFX, 1, 0, CMD_LINE_OPT_LIST_PFX_NUM},
 	{CMD_LINE_OPT_DEL_PFX, 1, 0, CMD_LINE_OPT_DEL_PFX_NUM},
+	{CMD_LINE_OPT_INIT, 0, 0, CMD_LINE_OPT_INIT_NUM},
 	{NULL, 0, 0, 0},
 };
 
@@ -252,6 +256,9 @@ int parse_args(int argc, char **argv)
 			break;
 		case CMD_LINE_OPT_LIST_LB_VIP_NUM:
 			command = DP_CMD_LIST_LB_VIP;
+			break;
+		case CMD_LINE_OPT_INIT_NUM:
+			command = DP_CMD_INIT;
 			break;
 		default:
 			dp_print_usage(prgname);
@@ -482,6 +489,15 @@ public:
 			}
 	}
 
+	void Initialized() {
+			Empty request;
+			UUIDMsg reply;
+			ClientContext context;
+
+			stub_->initialized(&context, request, &reply);
+			printf("Received UUID %s \n", reply.uuid().c_str());
+	}
+
 	void DelPfx() {
 			MachinePrefixMsg request;
 			Status reply;
@@ -644,6 +660,10 @@ int main(int argc, char** argv)
 	case DP_CMD_LIST_PFX:
 		std::cout << "Listprefix called " << std::endl;
 		dpdk_client.ListPfx();
+		break;
+	case DP_CMD_INIT:
+		std::cout << "Initialized called " << std::endl;
+		dpdk_client.Initialized();
 		break;
 	default:
 		break;


### PR DESCRIPTION
GRPC call "initialized" returns now an UUID which changes
after restart of dp-service.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>

# Proposed Changes

-
-
-

Fixes #