### PR TITLE
Offload checksum calculation for DNAT and SNAT handling

### DIFF
--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -28,7 +28,8 @@ void dp_del_vm_dnat_ip(uint32_t d_ip, uint32_t vni);
 bool dp_is_ip_dnatted(uint32_t d_ip, uint32_t vni);
 uint32_t dp_get_vm_dnat_ip(uint32_t d_ip, uint32_t vni);
 int dp_set_vm_dnat_ip(uint32_t d_ip, uint32_t vm_ip, uint32_t vni);
-void dp_nat_chg_ip(struct dp_flow *df_ptr, struct rte_ipv4_hdr *ipv4_hdr);
+void dp_nat_chg_ip(struct dp_flow *df_ptr, struct rte_ipv4_hdr *ipv4_hdr,
+				   struct rte_mbuf *m);
 
 #ifdef __cplusplus
 }

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -11,13 +11,10 @@ struct rte_eth_conf port_conf = {
 	},
 	.txmode = {
 			.offloads =
-				DEV_TX_OFFLOAD_GENEVE_TNL_TSO |
 				DEV_TX_OFFLOAD_IPV4_CKSUM  |
 				DEV_TX_OFFLOAD_UDP_CKSUM   |
 				DEV_TX_OFFLOAD_TCP_CKSUM   |
-				DEV_TX_OFFLOAD_SCTP_CKSUM  |
-				DEV_TX_OFFLOAD_OUTER_UDP_CKSUM| 
-				DEV_TX_OFFLOAD_TCP_TSO,
+				DEV_TX_OFFLOAD_IP_TNL_TSO
 	},
 	.rx_adv_conf = {
 			.rss_conf = {

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -55,7 +55,7 @@ static __rte_always_inline int handle_dnat(struct rte_mbuf *m)
 			df_ptr->flags.nat = DP_NAT_CHG_DST_IP;
 			df_ptr->nat_addr = df_ptr->dst.dst_addr;
 			df_ptr->dst.dst_addr = ipv4_hdr->dst_addr;
-			dp_nat_chg_ip(df_ptr, ipv4_hdr);
+			dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_status = DP_FLOW_STATUS_DST_NAT;
@@ -74,7 +74,7 @@ static __rte_always_inline int handle_dnat(struct rte_mbuf *m)
 		df_ptr->flags.nat = DP_NAT_CHG_DST_IP;
 		df_ptr->nat_addr = df_ptr->dst.dst_addr;
 		df_ptr->dst.dst_addr = ipv4_hdr->dst_addr;
-		dp_nat_chg_ip(df_ptr, ipv4_hdr);
+		dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 	}
 
 	/* We already know what to do */
@@ -85,7 +85,7 @@ static __rte_always_inline int handle_dnat(struct rte_mbuf *m)
 		df_ptr->flags.nat = DP_NAT_CHG_DST_IP;
 		df_ptr->nat_addr = df_ptr->dst.dst_addr;
 		df_ptr->dst.dst_addr = ipv4_hdr->dst_addr;
-		dp_nat_chg_ip(df_ptr, ipv4_hdr);
+		dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 	}
 	return 1;
 }

--- a/src/nodes/ipv6_encap_node.c
+++ b/src/nodes/ipv6_encap_node.c
@@ -27,8 +27,9 @@ static __rte_always_inline int handle_ipv6_encap(struct rte_mbuf *m, struct dp_f
 	struct underlay_conf *u_conf = get_underlay_conf();
 	struct rte_ipv6_hdr *ipv6_hdr;
 
-    m->outer_l2_len = sizeof(struct rte_ether_hdr);
-    m->outer_l3_len = sizeof(struct rte_ipv6_hdr);
+	m->outer_l2_len = sizeof(struct rte_ether_hdr);
+	m->outer_l3_len = sizeof(struct rte_ipv6_hdr);
+	m->l2_len = 0; /* We dont have inner l2, when we encapsulate */
 
 	ipv6_hdr = (struct rte_ipv6_hdr *)rte_pktmbuf_prepend(m, sizeof(struct rte_ipv6_hdr));
 
@@ -42,7 +43,8 @@ static __rte_always_inline int handle_ipv6_encap(struct rte_mbuf *m, struct dp_f
 	rte_memcpy(ipv6_hdr->dst_addr, df->tun_info.ul_dst_addr6, sizeof(ipv6_hdr->dst_addr));
 	ipv6_hdr->proto = df->tun_info.proto_id;
 
-	m->ol_flags = RTE_MBUF_F_TX_IPV6;
+	m->ol_flags |= RTE_MBUF_F_TX_OUTER_IPV6;
+	m->ol_flags |= RTE_MBUF_F_TX_TUNNEL_IP;
 
 	return 1;
 } 

--- a/src/nodes/lb_node.c
+++ b/src/nodes/lb_node.c
@@ -59,7 +59,7 @@ static __rte_always_inline int handle_lb(struct rte_mbuf *m)
 			df_ptr->flags.nat = DP_NAT_CHG_DST_IP;
 			df_ptr->nat_addr = df_ptr->dst.dst_addr;
 			df_ptr->dst.dst_addr = ipv4_hdr->dst_addr;
-			dp_nat_chg_ip(df_ptr, ipv4_hdr);
+			dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_status = DP_FLOW_STATUS_DST_LB;
@@ -79,7 +79,7 @@ static __rte_always_inline int handle_lb(struct rte_mbuf *m)
 		df_ptr->flags.nat = DP_NAT_CHG_DST_IP;
 		df_ptr->nat_addr = df_ptr->dst.dst_addr;
 		df_ptr->dst.dst_addr = ipv4_hdr->dst_addr;
-		dp_nat_chg_ip(df_ptr, ipv4_hdr);
+		dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 	}
 
 	return 1;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -48,7 +48,7 @@ static __rte_always_inline int handle_snat(struct rte_mbuf *m)
 			df_ptr->flags.nat = DP_NAT_CHG_SRC_IP;
 			df_ptr->nat_addr = df_ptr->src.src_addr;
 			df_ptr->src.src_addr = ipv4_hdr->src_addr;
-			dp_nat_chg_ip(df_ptr, ipv4_hdr);
+			dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 
 			/* Expect the new destination in this conntrack object */
 			cntrack->flow_status = DP_FLOW_STATUS_SRC_NAT;
@@ -67,7 +67,7 @@ static __rte_always_inline int handle_snat(struct rte_mbuf *m)
 		df_ptr->flags.nat = DP_NAT_CHG_SRC_IP;
 		df_ptr->nat_addr = df_ptr->src.src_addr;
 		df_ptr->src.src_addr = ipv4_hdr->src_addr;
-		dp_nat_chg_ip(df_ptr, ipv4_hdr);
+		dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 	}
 
 	if (((cntrack->flow_status == DP_FLOW_STATUS_DST_NAT) || (cntrack->flow_status == DP_FLOW_STATUS_DST_LB))
@@ -77,7 +77,7 @@ static __rte_always_inline int handle_snat(struct rte_mbuf *m)
 		df_ptr->flags.nat = DP_NAT_CHG_SRC_IP;
 		df_ptr->nat_addr = df_ptr->src.src_addr;
 		df_ptr->src.src_addr = ipv4_hdr->src_addr;
-		dp_nat_chg_ip(df_ptr, ipv4_hdr);
+		dp_nat_chg_ip(df_ptr, ipv4_hdr, m);
 	}
 	return 1;
 }


### PR DESCRIPTION
For SNAT and DNAT handling (aka VIP), offload the cheksum
calculation to the underlying NIC.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>

# Proposed Changes

-
-
-

Fixes #