### PR TITLE
Add DPS_LOG() macro for debug outputs with timestamp

### DIFF
--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -5,6 +5,20 @@
 extern "C" {
 #endif
 #include <stdbool.h>
+#include <rte_log.h>
+
+#define DP_TIMESTAMP_BUF_SIZE 26
+
+#define RTE_LOGTYPE_DPSERVICE RTE_LOGTYPE_USER1
+#define DPS_LOG(l, t, ...)						\
+	do {										\
+	char buf[DP_TIMESTAMP_BUF_SIZE] = {0};		\
+	time_t now = time(NULL);					\
+	strftime(buf, DP_TIMESTAMP_BUF_SIZE - 1, "%Y-%m-%d %H:%M:%S", gmtime(&now));\
+	fprintf(rte_log_get_stream(), "%s ", buf);	\
+	rte_log(RTE_LOG_ ## l,						\
+		 RTE_LOGTYPE_ ## t, # t ": " __VA_ARGS__);\
+	} while (0)
 
 #define VM_MACHINE_ID_STR_LEN	64
 #define VM_MACHINE_PXE_STR_LEN	32

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -62,7 +62,7 @@ int dp_port_init(struct dp_port *port, int port_id, struct dp_port_ext *port_det
 				port_id, strerror(-ret));
 
 	if_indextoname(dev_info.if_index, ifname);
-	printf(":: initializing port: %d (%s)\n", port_id, ifname);
+	DPS_LOG(INFO, DPSERVICE, "INIT initializing port: %d (%s)\n", port_id, ifname);
 
 	port_conf.txmode.offloads &= dev_info.tx_offload_capa;
 
@@ -118,7 +118,7 @@ int dp_port_init(struct dp_port *port, int port_id, struct dp_port_ext *port_det
 
 	if (port->dp_p_type == DP_PORT_VF) {
 		ret = rte_eth_promiscuous_enable(port_id);
-		printf("Setting interface number %d in promiscuous mode\n", port_id);
+		DPS_LOG(INFO, DPSERVICE, "INIT setting interface number %d in promiscuous mode\n", port_id);
 		if (ret != 0)
 			rte_exit(EXIT_FAILURE,
 					":: promiscuous mode enable failed: err=%s, port=%u\n",

--- a/src/dp_service.cpp
+++ b/src/dp_service.cpp
@@ -108,7 +108,6 @@ int main(int argc, char **argv)
 {
 	int ret;
 
-	printf("Starting DP Service version %s\n", DP_SERVICE_VERSION);
 	dp_handle_conf_file();
 	if (dp_is_mellanox_opt_set()) {
 		if (dp_add_args(argc, argv) < 0)
@@ -120,6 +119,8 @@ int main(int argc, char **argv)
 	argc -= ret;
 	argv += ret;
 
+	rte_openlog_stream(stdout);
+	DPS_LOG(INFO, DPSERVICE, "Starting DP Service version %s\n", DP_SERVICE_VERSION);
 	ret = dp_parse_args(argc, argv);
 	if (ret < 0)
 		rte_exit(EXIT_FAILURE, "Invalid dp_service parameters\n");

--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -212,8 +212,7 @@ static int main_core_loop(void)
 
 int dp_dpdk_main_loop(void)
 {
-
-	printf("DPDK main loop started\n ");
+	DPS_LOG(INFO, DPSERVICE, "DPDK main loop started\n");
 
 	/* Launch per-lcore init on every worker lcore */
 	rte_eal_mp_remote_launch(graph_main_loop, NULL, SKIP_MAIN);
@@ -268,8 +267,8 @@ static int dp_port_flow_isolate(int port_id)
 	/* Poisoning to make sure PMDs update it in case of error. */
 	memset(&error, 0x66, sizeof(error));
 	if (rte_flow_isolate(port_id, set, &error))
-		printf("Flow can't be validated message: %s\n", error.message ? error.message : "(no stated reason)");
-	printf("Ingress traffic on port %u is %s to the defined flow rules\n",
+		DPS_LOG(ERR, DPSERVICE, "Flow can't be validated message: %s\n", error.message ? error.message : "(no stated reason)");
+	DPS_LOG(INFO, DPSERVICE, "Ingress traffic on port %u is %s to the defined flow rules\n",
 			port_id,
 			set ? "now restricted" : "not restricted anymore");
 	return 0;
@@ -291,13 +290,13 @@ static void dp_install_isolated_mode(int port_id)
 {
 
 	if (get_overlay_type() == DP_FLOW_OVERLAY_TYPE_IPIP) {
-		printf("Init isolation flow rule for IPinIP tunnels\n");
+		DPS_LOG(INFO, DPSERVICE, "Init isolation flow rule for IPinIP tunnels\n");
 		dp_install_isolated_mode_ipip(port_id, DP_IP_PROTO_IPv4_ENCAP);
 		dp_install_isolated_mode_ipip(port_id, DP_IP_PROTO_IPv6_ENCAP);
 	}
 
 	if (get_overlay_type() == DP_FLOW_OVERLAY_TYPE_GENEVE) {
-		printf("Init isolation flow rule for GENEVE tunnels\n");
+		DPS_LOG(INFO, DPSERVICE, "Init isolation flow rule for GENEVE tunnels\n");
 		dp_install_isolated_mode_geneve(port_id);
 	}
 
@@ -337,10 +336,9 @@ int dp_init_interface(struct dp_port_ext *port, dp_port_type type)
 
 	nr_ports = rte_eth_dev_count_avail();
 	if (nr_ports == 0)
-		rte_exit(EXIT_FAILURE, ":: no Ethernet ports found\n");
+		rte_exit(EXIT_FAILURE, "no Ethernet ports found\n");
 
 	dp_port_ext = *port;
-	printf("Looking for VFs of PF %s\n", dp_port_ext.port_name);
 
 	RTE_ETH_FOREACH_DEV(port_id) {
 		struct rte_eth_dev_info dev_info;

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <rte_mbuf.h>
 #include <dp_error.h>
+#include <dp_util.h>
 #include <dp_lpm.h>
 #include <rte_ether.h>
 
@@ -47,6 +48,7 @@ int InitCall::Proceed()
 	if (status_ == REQUEST) {
 		new InitCall(service_, cq_);
 		status_ = AWAIT_MSG;
+		DPS_LOG(INFO, DPSERVICE, "GRPC init called \n");
 		return -1;
 	} else if (status_ == AWAIT_MSG) {
 		GRPCService* grpc_service = dynamic_cast<GRPCService*>(service_);
@@ -73,6 +75,7 @@ int CreateLBCall::Proceed()
 		new CreateLBCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC create LoadBalancer called for id: %s\n", request_.loadbalancerid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.add_lb.lb_id, DP_LB_ID_SIZE, "%s",
 				 request_.loadbalancerid().c_str());
@@ -127,6 +130,7 @@ int DelLBCall::Proceed()
 		new DelLBCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC delete LoadBalancer called for id: %s\n", request_.loadbalancerid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.del_lb.lb_id, DP_LB_ID_SIZE, "%s",
 				 request_.loadbalancerid().c_str());
@@ -164,6 +168,7 @@ int GetLBCall::Proceed()
 		new GetLBCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC get LoadBalancer called for id: %s\n", request_.loadbalancerid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.add_lb.lb_id, DP_LB_ID_SIZE, "%s",
 				 request_.loadbalancerid().c_str());
@@ -217,6 +222,7 @@ int AddLBVIPCall::Proceed()
 		new AddLBVIPCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC add LoadBalancer target called for id: %s\n", request_.loadbalancerid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.add_lb_vip.lb_id, DP_LB_ID_SIZE, "%s",
 				 request_.loadbalancerid().c_str());
@@ -256,6 +262,7 @@ int DelLBVIPCall::Proceed()
 		new DelLBVIPCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC delete LoadBalancer target called for id: %s\n", request_.loadbalancerid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.del_lb_vip.lb_id, DP_LB_ID_SIZE, "%s",
 				 request_.loadbalancerid().c_str());
@@ -300,6 +307,7 @@ int GetLBVIPBackendsCall::Proceed()
 		new GetLBVIPBackendsCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC list LoadBalancer targets called for id: %s\n", request_.loadbalancerid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.qry_lb_vip.lb_id, DP_LB_ID_SIZE, "%s",
 				 request_.loadbalancerid().c_str());
@@ -343,6 +351,7 @@ int AddPfxCall::Proceed()
 		new AddPfxCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC add AliasPrefix called for id: %s\n", request_.interfaceid().interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.add_pfx.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().interfaceid().c_str());
@@ -389,6 +398,7 @@ int DelPfxCall::Proceed()
 		new DelPfxCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC delete AliasPrefix called for id: %s\n", request_.interfaceid().interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.add_pfx.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().interfaceid().c_str());
@@ -431,6 +441,7 @@ int ListPfxCall::Proceed()
 		new ListPfxCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC list AliasPrefix(es) called for id: %s\n", request_.interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.get_pfx.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().c_str());
@@ -476,6 +487,7 @@ int AddVIPCall::Proceed()
 		new AddVIPCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC add VIP called for id: %s\n", request_.interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.add_vip.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().c_str());
@@ -518,6 +530,7 @@ int DelVIPCall::Proceed()
 		new DelVIPCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC delete VIP called for id: %s\n", request_.interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.del_vip.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().c_str());
@@ -552,6 +565,7 @@ int GetVIPCall::Proceed()
 		new GetVIPCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC get VIP called for id: %s\n", request_.interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.get_vip.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().c_str());
@@ -593,6 +607,9 @@ int AddInterfaceCall::Proceed()
 		new AddInterfaceCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC add Interface called for id: %s IP: %s dpdk pci: %s\n",
+				request_.interfaceid().c_str(), request_.ipv4config().primaryaddress().c_str(),
+				request_.devicename().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		err_status->set_error(EXIT_SUCCESS);
 		request.add_machine.vni = request_.vni();
@@ -655,6 +672,8 @@ int DelInterfaceCall::Proceed()
 		new DelInterfaceCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC delete Interface called for id: %s\n",
+				request_.interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.del_machine.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().c_str());
@@ -693,6 +712,8 @@ int GetInterfaceCall::Proceed()
 		new GetInterfaceCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC get Interface called for id: %s\n",
+				request_.interfaceid().c_str());
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		snprintf(request.get_machine.machine_id, VM_MACHINE_ID_STR_LEN,
 				 "%s", request_.interfaceid().c_str());
@@ -741,6 +762,7 @@ int AddRouteCall::Proceed()
 		new AddRouteCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC add Route called\n");
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		request.route.vni = request_.vni().vni();
 		request.route.trgt_hop_ip_type = RTE_ETHER_TYPE_IPV6;
@@ -786,6 +808,7 @@ int DelRouteCall::Proceed()
 		new DelRouteCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC delete Route called\n");
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		request.route.vni = request_.vni().vni();
 		request.route.trgt_hop_ip_type = RTE_ETHER_TYPE_IPV6;
@@ -839,6 +862,7 @@ int ListRoutesCall::Proceed()
 		new ListRoutesCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC list Routes called\n");
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		request.route.vni = request_.vni();
 		dp_send_to_worker(&request);
@@ -904,6 +928,7 @@ int ListInterfacesCall::Proceed()
 		new ListInterfacesCall(service_, cq_);
 		if (InitCheck() == INITCHECK)
 			return -1;
+		DPS_LOG(INFO, DPSERVICE, "GRPC list Interfaces called\n");
 		dp_fill_head(&request.com_head, call_type_, 0, 1);
 		dp_send_to_worker(&request);
 		status_ = AWAIT_MSG;

--- a/src/grpc/dp_grpc_service.cpp
+++ b/src/grpc/dp_grpc_service.cpp
@@ -26,7 +26,7 @@ void GRPCService::run(std::string listen_address)
 	builder.RegisterService(this);
 	this->cq_ = builder.AddCompletionQueue();
 	this->server_= builder.BuildAndStart();
-	std::cout << "Server initialized and listening on " << listen_address << std::endl;
+	DPS_LOG(INFO, DPSERVICE, "Server initialized and listening on %s\n", listen_address.c_str());
 	HandleRpcs();
 }
 

--- a/src/nodes/rx_node.c
+++ b/src/nodes/rx_node.c
@@ -3,6 +3,7 @@
 #include <rte_graph.h>
 #include <rte_graph_worker.h>
 #include <rte_mbuf.h>
+#include "dp_util.h"
 #include "nodes/rx_node_priv.h"
 #include "node_api.h"
 
@@ -51,7 +52,7 @@ static int rx_node_init(const struct rte_graph *graph, struct rte_node *node)
 	ctx->queue_id = ethdev_rx_main.node_ctx[port_id].queue_id;
 	ctx->next = RX_NEXT_CLS;
 
-	printf("rx_node: init, port_id: %u, queue_id: %u\n", ctx->port_id,
+	DPS_LOG(INFO, DPSERVICE, "rx_node: init, port_id: %u, queue_id: %u\n", ctx->port_id,
 			ctx->queue_id);
 
 	RTE_SET_USED(graph);


### PR DESCRIPTION
DPS_LOG() uses rte_log() and supports log levels with timestamps.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>
