### PR TITLE
handling of outgoing icmp for scalable nat

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -60,8 +60,6 @@ struct flow_key {
 
 struct flow_nat_info {
 	uint8_t nat_type;
-	// uint8_t nat_addr4;
-	// uint8_t nat_port;
 	uint32_t vni;
 	uint8_t underlay_dst[16];
 	uint8_t l4_type;

--- a/include/node_api.h
+++ b/include/node_api.h
@@ -34,6 +34,7 @@ struct dp_flow {
 	uint16_t				src_port;
 	
 	uint8_t					icmp_type;
+	uint16_t				icmp_identifier;
 	uint32_t                dp_flow_hash;
 
 	struct {

--- a/include/rte_flow/dp_rte_flow.h
+++ b/include/rte_flow/dp_rte_flow.h
@@ -46,6 +46,7 @@ struct rte_tcp_hdr *dp_get_tcp_hdr(struct rte_mbuf *m, uint16_t offset);
 struct rte_udp_hdr *dp_get_udp_hdr(struct rte_mbuf *m, uint16_t offset);
 
 uint16_t dp_change_l4_hdr_port(struct rte_mbuf *m, uint8_t port_type, uint16_t new_val);
+uint16_t dp_change_icmp_identifier(struct rte_mbuf *m, uint16_t new_identifier);
 
 // functions to craft actions/patterns are added later
 void create_rte_flow_rule_attr(struct rte_flow_attr *attr, uint32_t group, uint32_t priority, uint32_t ingress, uint32_t egress, uint32_t transfer);

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -50,7 +50,7 @@ void dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in 
 		key->src.port_src = rte_be_to_cpu_16(df_ptr->src_port);
 		break;
 	case IPPROTO_ICMP:
-		key->port_dst = 0;
+		key->port_dst = rte_be_to_cpu_16(df_ptr->icmp_identifier);
 		key->src.type_src = df_ptr->icmp_type;
 		break;
 	default:

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -31,6 +31,7 @@ static __rte_always_inline int handle_dnat(struct rte_mbuf *m)
 	struct flow_value *cntrack = NULL;
 	uint32_t dst_ip, vni;
 	uint8_t underlay_dst[16];
+	uint16_t old_icmp_ident = 65535;
 
 	memset(&key, 0, sizeof(struct flow_key));
 	df_ptr = get_dp_flow_ptr(m);
@@ -51,12 +52,12 @@ static __rte_always_inline int handle_dnat(struct rte_mbuf *m)
 		if (dp_is_ip_dnatted(dst_ip, vni)
 		    && (cntrack->flow_status == DP_FLOW_STATUS_NONE)) {
 			uint32_t dnat_ip = dp_get_vm_dnat_ip(dst_ip, vni);
-			// it is a network-dnat pkt and it is a icmp pkt, send it to relay node for auto-reply
+
 			if (dnat_ip == 0 && df_ptr->l4_type == DP_IP_PROTO_ICMP) {
-				cntrack->nat_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_NEIGH;
 				dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]); // no reverse traffic for relaying pkts
-				return DP_ROUTE_PKT_RELAY;
+				df_ptr->dst_port = df_ptr->icmp_identifier;
 			}
+
 			// only perform this lookup on unknown dnat (VIP dnat. Distributed NAted) traffic flows
 			if (dp_lookup_network_nat_underlay_ip(m, underlay_dst)) {
 				cntrack->nat_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_NEIGH;
@@ -103,10 +104,22 @@ static __rte_always_inline int handle_dnat(struct rte_mbuf *m)
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].ip_src);
 		if (cntrack->nat_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
-			if (dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_DST, htons(cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src)) == 0) {
-				DPS_LOG(ERR, DPSERVICE, "Error to replace l4 hdr's dst port with value %d \n", htons(cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src));
-				return 0;
+			if (df_ptr->l4_type == DP_IP_PROTO_ICMP) {
+				old_icmp_ident = dp_change_icmp_identifier(m, cntrack->flow_key[DP_FLOW_DIR_ORG].port_dst);
+				if (old_icmp_ident == 65535) {
+					DPS_LOG(ERR, DPSERVICE, "Error to replace icmp hdr's identifier with value %d \n", 
+							htons(cntrack->flow_key[DP_FLOW_DIR_ORG].port_dst));
+					return 0;
+				}
+				
+			} else {
+				if (dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_DST, htons(cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src)) == 0) {
+					DPS_LOG(ERR, DPSERVICE, "Error to replace l4 hdr's dst port with value %d \n", 
+							htons(cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src));
+					return 0;
+				}
 			}
+
 		}
 		df_ptr->flags.nat = DP_NAT_CHG_DST_IP;
 		df_ptr->nat_addr = df_ptr->dst.dst_addr;

--- a/src/nodes/packet_relay_node.c
+++ b/src/nodes/packet_relay_node.c
@@ -38,10 +38,6 @@ static __rte_always_inline int handle_packet_relay(struct rte_mbuf *m)
 	if (!cntrack)
 		return ret;
 
-	if (df_ptr->l4_type == DP_IP_PROTO_ICMP) {
-		DPS_LOG(INFO, DPSERVICE, "received a icmp pkt in relay node \n");
-		return ret;
-	}
 
 	if (cntrack->nat_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_NEIGH) {
 		df_ptr->flags.flow_type = DP_FLOW_TYPE_OUTGOING;
@@ -50,6 +46,11 @@ static __rte_always_inline int handle_packet_relay(struct rte_mbuf *m)
 		df_ptr->nxt_hop = m->port;
 		memcpy(df_ptr->tun_info.ul_dst_addr6, cntrack->nat_info.underlay_dst, sizeof(df_ptr->tun_info.ul_dst_addr6));
 		return PACKET_RELAY_NEXT_OVERLAY_SWITCH;
+	}
+
+	if (df_ptr->l4_type == DP_IP_PROTO_ICMP) {
+		DPS_LOG(INFO, DPSERVICE, "received a icmp pkt in relay node \n");
+		return ret;
 	}
 
 	return ret;


### PR DESCRIPTION
This PR provides the implementation that handles outgoing icmp from VMs. It uses the identifier field of icmp request-reply to store selected port information, and perform flow matching. Corresponding automation test is also provided.