### PR TITLE
Improved code_check.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __*
 .idea/
 *.pl
 scapy-script/*
+code_check/_checkpatch.pl

--- a/code_check/README.md
+++ b/code_check/README.md
@@ -1,14 +1,21 @@
-A script is provided to simplify the usage of checkpatch.pl to perform code polishing. It is useful, especially when a subset of checking types shall be considered during the checking process. In order to use this script, firstly download checkpatch.pl by following this [link](https://github.com/torvalds/linux/blob/master/scripts/checkpatch.pl), and put it into this directory. This script currently supports three functions:
+A script is provided to simplify the usage of checkpatch.pl to perform code polishing. It is useful, especially when a subset of checking types shall be considered during the checking process.
 
-1) check last n commit:
+In order to use this script, download checkpatch.pl by calling `./check.sh -d`. You can also download one yourself from [this link](https://github.com/torvalds/linux/blob/master/scripts/checkpatch.pl), and put it into this directory as `_checkpatch.pl`.
 
-	`./check.sh -t check  -i n`
+Currently supported functions:
+1) Check all commits since merge-base:
 
-2) check single file PATH_TO_ILE:
+	`./check.sh`
+
+2) Check last n commits:
+
+	`./check.sh -i n`
+
+3) Check a single file:
  	
-	`./check.sh -t check -f PATH_TO_ILE`
+	`./check.sh -f PATH_TO_FILE`
 
-3) auto fix single file PATH_TO_ILE:
+4) Auto-fix a single file:
 	
-	`./check.sh -t fix  -f PATH_TO_ILE`
+	`./check.sh -t fix -f PATH_TO_FILE`
 

--- a/code_check/check.sh
+++ b/code_check/check.sh
@@ -1,58 +1,72 @@
 #!/bin/bash
 
-func(){
-	echo "Usage:"
-	echo "check.sh [-t TYPE] [-i DIFF] [-f FILE]"
-	echo "Description:"
-	echo "TYPE: would you like to \"check\" or \"fix\" "
-	echo "DIFF: the number of diff that needs to be checked"
-	echo "FILE: the file that needs to be checked or fixed"
-	exit -1
+set -e
+
+usage() {
+	echo "Usage: $0 [-t TYPE] [-i DIFF | -f FILE] [-d]"
+	echo ""
+	echo "Options:"
+	echo "  -t TYPE    mode of operation: \"check\" or \"fix\", default: \"check\""
+	echo "  -i DIFF    number of commits to be checked"
+	echo "  -f FILE    file to be checked or fixed"
+	echo "  -d         download checkpatch.pl"
+	echo ""
+	echo "If no option specified, the whole branch will be checked from merge-base"
+	exit 1
 }
 
 TYPE_CHECK_LIST="ALLOC_ARRAY_ARGS,BLOCK_COMMENT_STYLE,ASSIGN_IN_IF,BOOL_COMPARISON,COMPARISON_TO_NULL,CONSTANT_COMPARISON,CODE_INDENT,DEEP_INDENTATION,SWITCH_CASE_INDENT_LEVEL,LONG_LINE,LONG_LINE_STRING,LONG_LINE_COMMENT,MULTILINE_DEREFERENCE,TRAILING_STATEMENTS,ARRAY_SIZE,INLINE_LOCATION,TRAILING_SEMICOLON,CAMELCASE,CONST_CONST,FUNCTION_ARGUMENTS,RETURN_PARENTHESES,ASSIGNMENT_CONTINUATIONS,BRACES,BRACKET_SPACE,CONCATENATED_STRING,ELSE_AFTER_BRACE,LINE_SPACING,OPEN_BRACE,POINTER_LOCATION,SPACING,TRAILING_WHITESPACE,WHILE_AFTER_BRACE"
+CHECKPATCH_OPTS="--no-tree --max-line-length=180 --types \"${TYPE_CHECK_LIST}\""
+SCRIPT_DIR="$(dirname ${BASH_SOURCE})"
+CHECKPATCH="${SCRIPT_DIR}/_checkpatch.pl"
 
-while getopts 't:i:f:' OPT; do
+function check_diff () {
+	git -C "${SCRIPT_DIR}/.." diff "${DIFF}" | "${CHECKPATCH}" ${CHECKPATCH_OPTS}
+}
+
+function check_file() {
+	"${CHECKPATCH}" ${CHECKPATCH_OPTS} -f "${FILE}"
+}
+
+function auto_fix_file() {
+	"${CHECKPATCH}" ${CHECKPATCH_OPTS} --fix-inplace -f "${FILE}"
+}
+
+function download_checkpatch() {
+	if [ -f "${CHECKPATCH}" ]; then
+		echo "checkpatch.pl already present" >&2
+		exit 1
+	fi
+	wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl -O "${CHECKPATCH}"
+	chmod +x "${CHECKPATCH}"
+	exit 1
+}
+
+
+TYPE="check"
+DIFF="$(git -C "${SCRIPT_DIR}/.." merge-base main HEAD)"
+while getopts 't:i:f:d' OPT; do
 	case $OPT in
 		t) TYPE="$OPTARG";;
-		i) 
-			if [[ $OPTARG = -* ]]; then
-			((OPTIND--))
-			continue
-			fi
-			DIFF="$OPTARG";;
-		f) 
-			if [[ $OPTARG = -* ]]; then
-				((OPTIND--))
-				continue
-			fi
-			FILE="$OPTARG";;
-		?) func;;
+		i) DIFF="HEAD~$OPTARG";;
+		f) FILE="$OPTARG";;
+		d) download_checkpatch;;
+		?) usage;;
 	esac
 done
 
+if [ ! -f "${CHECKPATCH}" ]; then
+	echo "checkpatch.pl not present, use '$0 -d'" >&2
+	exit 1
+fi
 
-function check_diff (){
-	(cd .. ; git diff "HEAD~${DIFF}") | ./checkpatch.pl --no-tree --max-line-length=180 --types "${TYPE_CHECK_LIST}"
-}
-
-function check_file(){
-	./checkpatch.pl --no-tree --max-line-length=180 --types "${TYPE_CHECK_LIST}" -f "${FILE}"
-}
-
-function auto_fix_file(){
-	./checkpatch.pl --no-tree --max-line-length=180 --types "${TYPE_CHECK_LIST}" --fix-inplace -f "${FILE}"
-}
-
-if [ $TYPE = "check" ] && [ -n "${DIFF}" ] 
-then
+if [ "${TYPE}" = "check" ] && [ -n "${DIFF}" ]; then
 	check_diff
-elif [ $TYPE = "check" ] && [ -n "${FILE}" ]
-then
+elif [ "${TYPE}" = "check" ] && [ -n "${FILE}" ]; then
 	check_file
-elif [ $TYPE = "fix" ] && [ -n "${FILE}" ]
-then
+elif [ "${TYPE}" = "fix" ] && [ -n "${FILE}" ]; then
 	auto_fix_file
 else
-	func
+	usage
 fi
+


### PR DESCRIPTION
It was my first time using code_check.sh, so I did not even have checkpatch.pl and then wanted to check the whole PR. So I tried to make it easier to use.

- new argument '-d' to download checkpatch
- save checkpatch as '_checkpatch.pl' so tab-completion of 'check.sh' is not stopped mid-way
- enabled fail-on-error
- added default values to '-t' (check) and '-i' (see below)
- by default check.sh now tries to check every commit since branching from main (merge-base)
- you can call 'check.sh' from anywhere, even outside the repository