### PR TITLE
Add a build option to run dp_service as non-root

### DIFF
--- a/hack/set_cap.sh
+++ b/hack/set_cap.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# NET_ADMIN for setting MAC, etc.
+# NET_RAW to access NIC ports
+# SYS_ADMIN for /proc/self/pagemap access
+
+# NOTICE: binaries with file capabilities have their effective IDs changed to 'root:root' in /proc/self
+# therefore also DAC_OVERRIDE is needed to ignore /proc/self/pagemap (now root) permissions
+# which is of course not ideal, so maybe another way is needed (run as root and drop down after init?)
+
+if [ $# -ne 2 ]; then
+	echo "Usage: $0 <root-binary> <user-binary-name>" 2>&1
+	exit 1
+fi
+
+if [ ! -f "$1" ]; then
+	echo "Specified binary does not exist: '$1'" 2>&1
+	exit 1
+fi
+
+cp $1 $2 && sudo setcap cap_net_raw,cap_net_admin,cap_sys_admin,cap_dac_override=eip $2

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,10 @@ protoc = find_program('protoc')
 grpc_cpp = find_program('grpc_cpp_plugin')
 pytest = find_program('pytest', required : false)
 scapy = find_program('scapy', required : false)
+if get_option('enable_usermode')
+  sudo = find_program('sudo')
+  setcap = find_program('setcap')
+endif
 
 if not pytest.found()
   message('Without pytest, the tests can not be run')
@@ -34,4 +38,3 @@ test('test-geneve', files('test/run_test'), args : [meson.current_build_dir(), '
 
 run_target('cppcheck', command : ['cppcheck', '--project=' + 
   join_paths(meson.build_root(), 'compile_commands.json')])
-

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('enable_usermode', type: 'boolean', value: false, description:
+       'Make the resulting binary runnable without root (requires sudo during build)')
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,5 +9,13 @@ dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.
 			  'dp_netlink.c','rte_flow/dp_rte_flow.c','rte_flow/dp_rte_flow_init.c','rte_flow/dp_rte_flow_traffic_forward.c',
 			  'monitoring/dp_monitoring.c','monitoring/dp_event.c']
 
-executable('dp_service', [dp_sources, grpc_generated], include_directories : [inc],
+exe = executable('dp_service', [dp_sources, grpc_generated], include_directories : [inc],
 			dependencies : [dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep, libuuid_dep] )
+
+if get_option('enable_usermode')
+custom_target('dp_service_user', depends: exe, input: exe, output: 'dp_service_user',
+  command: [ '../hack/set_cap.sh', '@INPUT@', '@OUTPUT@' ],
+  build_by_default: true,
+  console: true
+)
+endif


### PR DESCRIPTION
### Rationale ###
I wanted to debug in an IDE and that is very hard with root+gdb (gdb itself is not the problem, being root is).

And in general it would be nice to have the option to run the service as a user anyway.

### Limitations ###
Due to Linux handling VA to PA address translation (via '/proc/self/pagemaps') and filesystem capability-enabled binaries. I had to disable DAC for the binary (i.e. filesystems permissions have no effect), so that is too close to being root for me.

### Description ###

Once enabled in meson via `meson -Denable_usermode=true build` (add `--reconfigure` for already existing build dirs), ninja will try to create a `dp_service_user` binary with filesystem capabilities that are needed to run it without root.

You need sudo and setcap (both checked by meson) and you will be asked for a password in the post-build phase.

I suggest adding
```
username ALL=(root) NOPASSWD: /sbin/setcap
```
for ease of use.

If you want to then debug the binary, your debugger (I am using `gdb`) needs to have those capabilities too. Check `hack/set_cap.sh` for the right ones.

I **will** be documenting debugging as a whole and I'll add a section about it there, once it is made.
