### PR TITLE
impl of icmp asymmetric traffic for nat

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -63,6 +63,7 @@ struct flow_nat_info {
 	uint32_t vni;
 	uint8_t underlay_dst[16];
 	uint8_t l4_type;
+	uint16_t icmp_err_ip_cksum;
 };
 
 
@@ -91,7 +92,7 @@ void dp_add_flow_data(struct flow_key *key, void *data);
 void dp_add_flow(struct flow_key *key);
 void dp_delete_flow(struct flow_key *key);
 bool dp_flow_exists(struct flow_key *key);
-void dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
+int8_t dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(struct flow_key *key /* in / out */);
 void dp_init_flowtable(int socket_id);
 void dp_process_aged_flows(int port_id);

--- a/include/node_api.h
+++ b/include/node_api.h
@@ -34,6 +34,7 @@ struct dp_flow {
 	uint16_t				src_port;
 	
 	uint8_t					icmp_type;
+	uint8_t					icmp_code;
 	uint16_t				icmp_identifier;
 	uint32_t                dp_flow_hash;
 

--- a/include/rte_flow/dp_rte_flow.h
+++ b/include/rte_flow/dp_rte_flow.h
@@ -32,6 +32,17 @@ extern "C"
 #define DP_L4_PORT_DIR_SRC 1
 #define DP_L4_PORT_DIR_DST 2
 
+#define DP_IP_ICMP_TYPE_ERROR 3
+
+#define DP_IP_ICMP_CODE_DST_PROTO_UNREACHABLE 2
+#define DP_IP_ICMP_CODE_DST_PORT_UNREACHABLE 3
+#define DP_IP_ICMP_CODE_FRAGMENT_NEEDED 4
+
+typedef struct dp_icmp_err_ip_info {
+	struct rte_ipv4_hdr *err_ipv4_hdr;
+	uint16_t	l4_src_port;
+	uint16_t	l4_dst_port;
+} dp_icmp_err_ip_info;
 
 // #define DP_RTE_FLOW_DEFAULT_GROUP	0
 // #define DP_RTE_FLOW_VNET_GROUP		1
@@ -44,6 +55,8 @@ int extract_outer_ipv6_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset);
 struct rte_ipv4_hdr *dp_get_ipv4_hdr(struct rte_mbuf *m);
 struct rte_tcp_hdr *dp_get_tcp_hdr(struct rte_mbuf *m, uint16_t offset);
 struct rte_udp_hdr *dp_get_udp_hdr(struct rte_mbuf *m, uint16_t offset);
+void dp_get_icmp_err_ip_hdr(struct rte_mbuf *m, struct dp_icmp_err_ip_info *err_ip_info);
+void dp_change_icmp_err_l4_src_port(struct rte_mbuf *m, struct dp_icmp_err_ip_info *err_ip_info, uint16_t src_port_v);
 
 uint16_t dp_change_l4_hdr_port(struct rte_mbuf *m, uint8_t port_type, uint16_t new_val);
 uint16_t dp_change_icmp_identifier(struct rte_mbuf *m, uint16_t new_identifier);

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ subdir('proto')
 subdir('include')
 subdir('src')
 subdir('test')
-test('test-ipip', files('test/run_test'), args : [meson.current_build_dir(), 'ipip'], is_parallel : false, timeout : 35)
+test('test-ipip', files('test/run_test'), args : [meson.current_build_dir(), 'ipip'], is_parallel : false, timeout : 60)
 test('test-geneve', files('test/run_test'), args : [meson.current_build_dir(), 'geneve'],  is_parallel : false)
 
 run_target('cppcheck', command : ['cppcheck', '--project=' + 

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -105,7 +105,10 @@ static __rte_always_inline int handle_conntrack(struct rte_mbuf *m)
 	if ((df_ptr->l4_type == IPPROTO_TCP) || (df_ptr->l4_type == IPPROTO_UDP)
 		|| (df_ptr->l4_type == IPPROTO_ICMP)) {
 			memset(&key, 0, sizeof(struct flow_key));
-			dp_build_flow_key(&key, m);
+			if (dp_build_flow_key(&key, m) < 0) {
+				DPS_LOG(WARNING, DPSERVICE, "failed to build a flow key \n");
+				return DP_ROUTE_DROP;
+			}
 			if (dp_flow_exists(&key)) {
 				dp_get_flow_data(&key, (void **)&flow_val);
 				change_flow_state_dir(&key, flow_val, df_ptr);

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -75,6 +75,7 @@ static __rte_always_inline int handle_snat(struct rte_mbuf *m)
 				cntrack->nat_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_LOCAL;
 				cntrack->nat_info.vni = vni;
 				cntrack->nat_info.l4_type = df_ptr->l4_type;
+				cntrack->nat_info.icmp_err_ip_cksum = ipv4_hdr->hdr_checksum;
 			}
 			df_ptr->flags.nat = DP_NAT_CHG_SRC_IP;
 			df_ptr->nat_addr = df_ptr->src.src_addr;

--- a/test/config.py
+++ b/test/config.py
@@ -22,7 +22,7 @@ ul_actual_src="2a10:afc0:e01f:f403:0:64::"
 ul_short_src="2a10:afc0:e01f:f403::"
 start_str = "DPDK main loop started"
 tun_type_geneve="geneve"
-port_redundancy=True
+port_redundancy=False
 
 bcast_mac = "ff:ff:ff:ff:ff:ff"
 null_ip = "0.0.0.0"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,6 +91,7 @@ def add_machine(build_path, tun_opt):
 	subprocess.run(shlex.split("ip link set dev "+vf1_tap+" up"))
 	subprocess.run(shlex.split("ip link set dev "+vf2_tap+" up"))
 	subprocess.run(shlex.split("ip link set dev "+pf0_tap+" up"))
+	# subprocess.run(shlex.split("ip link set dev "+pf1_tap+" up"))
 	subprocess.run(shlex.split(init_cmd))
 	subprocess.run(shlex.split(add_machine_cmd))
 	subprocess.run(shlex.split(add_machine_cmd2))


### PR DESCRIPTION
This PR intends to address the issue mentioned in #106. It carries out two things: 

1) perform conntrack matching for outgoing tcp/udp flow and its corresponding incoming icmp error msg (asymmetric matching)
2) perform ip addr and checksum replacement for the attached IP header in returning icmp error msg. 

currently, three basic icmp error codes are supported, namely, Protocol Unreachable(2), Port Unreachable (3), Fragmentation Needed and Don't Fragment was Set (4).