### PR TITLE
Do not recirculate the lb prefix messages in tx_node

### DIFF
--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 #include <stdbool.h>
 #include <rte_log.h>
+#include <rte_mbuf.h>
 
 #define DP_TIMESTAMP_BUF_SIZE 26
 
@@ -62,7 +63,7 @@ int get_op_env();
 int dp_is_wcmp_enabled();
 
 double dp_get_wcmp_frac();
-
+void rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type);
 void print_ip(unsigned int ip, char *buf);
 
 

--- a/include/nodes/ipv6_encap_node.h
+++ b/include/nodes/ipv6_encap_node.h
@@ -10,6 +10,7 @@ extern "C" {
 enum
 {
 	IPV6_ENCAP_NEXT_DROP,
+	IPV6_ENCAP_NEXT_CLS,
 	IPV6_ENCAP_NEXT_MAX
 };
 

--- a/include/nodes/tx_node_priv.h
+++ b/include/nodes/tx_node_priv.h
@@ -10,7 +10,6 @@ extern "C" {
 enum
 {
 	TX_NEXT_DROP,
-	TX_NEXT_CLS,
 	TX_NEXT_MAX
 };
 

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -449,6 +449,16 @@ __rte_always_inline uint16_t dp_get_pf1_port_id()
 	return pf_ports[1][0];
 }
 
+void rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type)
+{
+	struct rte_ether_hdr *eth_hdr;
+
+	eth_hdr = (struct rte_ether_hdr *)rte_pktmbuf_prepend(m, sizeof(struct rte_ether_hdr));
+	rte_ether_addr_copy(dp_get_neigh_mac(port_id), &eth_hdr->dst_addr);
+	eth_hdr->ether_type = htons(eth_type);
+	rte_ether_addr_copy(dp_get_mac(port_id), &eth_hdr->src_addr);
+}
+
 
 void print_ip(unsigned int ip, char *buf)
 {


### PR DESCRIPTION
tx_node is too late for recirculation so do it before.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>