### PR TITLE
fix invalid memory problem that leads to crashing

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -78,6 +78,8 @@ struct flow_value {
 	rte_atomic32_t	flow_cnt;
 	struct flow_nat_info	nat_info;
 	uint8_t			action[DP_FLOW_DIR_MAX];
+	uint8_t			owner;
+	uint16_t		drop_pkt;
 };
 
 struct flow_age_ctx {
@@ -90,7 +92,7 @@ bool dp_are_flows_identical(struct flow_key *key1, struct flow_key *key2);
 void dp_get_flow_data(struct flow_key *key, void **data);
 void dp_add_flow_data(struct flow_key *key, void *data);
 void dp_add_flow(struct flow_key *key);
-void dp_delete_flow(struct flow_key *key);
+int dp_delete_flow(struct flow_key *key);
 bool dp_flow_exists(struct flow_key *key);
 int8_t dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(struct flow_key *key /* in / out */);

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -53,6 +53,7 @@ int dp_is_stats_enabled();
 int dp_is_offload_enabled();
 int dp_is_conntrack_enabled();
 int dp_is_ip6_overlay_enabled();
+int dp_is_hw_protection_enabled();
 
 uint16_t dp_get_pf1_port_id();
 uint16_t dp_get_pf0_port_id();

--- a/include/meson.build
+++ b/include/meson.build
@@ -9,4 +9,4 @@ install_headers('dp_service.h', 'node_api.h', 'dp_port.h', 'dpdk_layer.h', 'dp_n
 				'nodes/snat_node.h', 'nodes/geneve_tunnel_node.h', 'nodes/packet_relay_node.h','dp_util.h', 'dp_error.h',
 				'grpc/dp_grpc_service.h', 'dp_flow.h', 'grpc/dp_async_grpc.h',
 				'grpc/dp_grpc_impl.h', 'dp_netlink.h','rte_flow/dp_rte_flow.h','rte_flow/dp_rte_flow_init.h','rte_flow/dp_rte_flow_traffic_forward.h',
-				'monitoring/dp_monitoring.h','monitoring/dp_event.h')
+				'monitoring/dp_monitoring.h','monitoring/dp_event.h','rte_flow/dp_rte_flow_util.h')

--- a/include/rte_flow/dp_rte_flow.h
+++ b/include/rte_flow/dp_rte_flow.h
@@ -177,6 +177,8 @@ int create_set_meta_action(struct rte_flow_action *action, int action_cnt,
 							struct rte_flow_action_set_meta *meta_action,
 							uint32_t meta_value);
 
+int create_drop_action(struct rte_flow_action *action, int action_cnt);
+
 int create_end_action(struct rte_flow_action *action, int action_cnt);
 
 struct rte_flow *validate_and_install_rte_flow(uint16_t port_id,

--- a/include/rte_flow/dp_rte_flow_util.h
+++ b/include/rte_flow/dp_rte_flow_util.h
@@ -1,0 +1,21 @@
+#ifndef __INCLUDE_DP_RTE_FLOW_UTIL_H
+#define __INCLUDE_DP_RTE_FLOW_UTIL_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <unistd.h>
+#include "rte_malloc.h"
+#include "dp_rte_flow.h"
+
+
+int dp_install_protection_drop(struct rte_mbuf *m, struct dp_flow *df);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_DP_RTE_FLOW_UTIL_H */

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -28,6 +28,7 @@ static int no_offload = 0;
 static int ipv6_overlay = 0;
 static int no_conntrack = 0;
 static int no_stats = 0;
+static int no_hw_protection = 0;
 static int tunnel_opt = DP_FLOW_OVERLAY_TYPE_IPIP;
 static int op_env = DP_OP_ENV_HARDWARE;
 static double wcmp_frac = 1.0;
@@ -75,6 +76,7 @@ static const char op_env_opt_scapytest[] = "scapytest";
 #ifdef ENABLE_GRAPHTRACE
 #	define CMD_LINE_OPT_GRAPHTRACE "graphtrace"
 #endif
+#define CMD_LINE_OPT_NO_HW_PROTECT "no-hw-protect"
 
 enum
 {
@@ -95,6 +97,8 @@ enum
 #ifdef ENABLE_GRAPHTRACE
 	CMD_LINE_OPT_GRAPHTRACE_NUM,
 #endif
+	CMD_LINE_OPT_IPV6_OVERLAY_NUM,
+	CMD_LINE_OPT_NO_HW_PROTECT_NUM,
 };
 
 static const struct option lgopts[] = {
@@ -114,6 +118,7 @@ static const struct option lgopts[] = {
 #ifdef ENABLE_GRAPHTRACE
 	{CMD_LINE_OPT_GRAPHTRACE, 1, 0, CMD_LINE_OPT_GRAPHTRACE_NUM},
 #endif
+	{CMD_LINE_OPT_NO_HW_PROTECT, 0, 0, CMD_LINE_OPT_NO_HW_PROTECT_NUM},
 	{NULL, 0, 0, 0},
 };
 
@@ -136,6 +141,7 @@ static void dp_print_usage(const char *prgname)
 			"  --"CMD_LINE_OPT_NO_CONNTRACK"         disable connection tracking\n"
 			"  --"CMD_LINE_OPT_ENABLE_IPV6_OVERLAY"  enable IPv6 overlay addresses\n"
 			"  --"CMD_LINE_OPT_NO_OFFLOAD"           disable traffic offloading\n"
+			"  --"CMD_LINE_OPT_NO_HW_PROTECT"        disable hw protection for unknown incoming traffic\n"
 #ifdef ENABLE_GRAPHTRACE
 			"  --"CMD_LINE_OPT_GRAPHTRACE"=LEVEL     verbosity level of packet traversing the graph framework (default: 0)\n"
 #endif
@@ -297,7 +303,9 @@ int dp_parse_args(int argc, char **argv)
 		case CMD_LINE_OPT_NO_CONNTRACK_NUM:
 			no_conntrack = 1;
 			break;
-
+		case CMD_LINE_OPT_NO_HW_PROTECT_NUM:
+			no_hw_protection = 1;
+			break;
 		case CMD_LINE_OPT_NO_STATS_NUM:
 			no_stats = 1;
 			break;
@@ -331,6 +339,14 @@ uint dp_get_graphtrace_level()
 int dp_is_offload_enabled()
 {
 	if (no_offload)
+		return 0;
+	else
+		return 1;
+}
+
+int dp_is_hw_protection_enabled()
+{
+	if (no_hw_protection)
 		return 0;
 	else
 		return 1;

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,7 @@ dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.
 			  'nodes/conntrack_node.c', 'nodes/dnat_node.c', 'nodes/packet_relay_node.c','nodes/lb_node.c',
 			  'nodes/snat_node.c', 'grpc/dp_grpc_service.cpp', 'grpc/dp_async_grpc.cpp', 'grpc/dp_grpc_impl.c', 'dp_flow.c',
 			  'dp_netlink.c','rte_flow/dp_rte_flow.c','rte_flow/dp_rte_flow_init.c','rte_flow/dp_rte_flow_traffic_forward.c',
-			  'monitoring/dp_monitoring.c','monitoring/dp_event.c']
+			  'monitoring/dp_monitoring.c','monitoring/dp_event.c','rte_flow/dp_rte_flow_util.c' ]
 
 exe = executable('dp_service', [dp_sources, grpc_generated], include_directories : [inc],
 			dependencies : [dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep, libuuid_dep] )

--- a/src/monitoring/dp_event.c
+++ b/src/monitoring/dp_event.c
@@ -102,10 +102,11 @@ int dp_send_event_timer_msg()
 
 void dp_process_event_timer_msg(struct rte_mbuf *m)
 {
-	if (dp_is_offload_enabled()) {
+	if (dp_is_offload_enabled() || dp_is_hw_protection_enabled()) {
 		dp_process_aged_flows(dp_get_pf0_port_id());
 		dp_process_aged_flows(dp_get_pf1_port_id());
 	} else {
 		dp_process_aged_flows_non_offload();
 	}
+
 }

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -42,6 +42,8 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	flow_val->flow_status = DP_FLOW_STATUS_NONE;
 	flow_val->dir = DP_FLOW_DIR_ORG;
 	flow_val->nat_info.nat_type = DP_FLOW_NAT_TYPE_NONE;
+	flow_val->owner = 1;
+	flow_val->drop_pkt = 0;
 	dp_add_flow_data(key, flow_val);
 
 	// Only the original flow (outgoing)'s hash value is recorded
@@ -50,6 +52,7 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	dp_invert_flow_key(key);
 	flow_val->flow_key[DP_FLOW_DIR_REPLY] = *key;
 	dp_add_flow(key);
+	flow_val->owner += 1;
 	dp_add_flow_data(key, flow_val);
 	return flow_val;
 }

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -64,6 +64,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_mbuf *m)
 					memcpy(cntrack->nat_info.underlay_dst, underlay_dst, sizeof(cntrack->nat_info.underlay_dst));
 
 					dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]); // no reverse traffic for relaying pkts
+					cntrack->owner -= 1;
 					return DNAT_NEXT_PACKET_RELAY;
 				}
 				

--- a/src/nodes/tx_node.c
+++ b/src/nodes/tx_node.c
@@ -77,8 +77,11 @@ static uint16_t tx_node_process(struct rte_graph *graph,
 			new_eth_type = dp_is_pf_port_id(port) ? RTE_ETHER_TYPE_IPV6 : df->l3_type;
 			rewrite_eth_hdr(pkt, port, new_eth_type);
 		}
-		if (df->flags.valid && df->conntrack)
+		if (df->flags.valid && df->conntrack) {
+			df->conntrack->owner += 1;
 			dp_handle_traffic_forward_offloading(pkt, df);
+		}
+
 	}
 
 	sent_count = rte_eth_tx_burst(port, queue, (struct rte_mbuf **)objs, nb_objs);

--- a/src/rte_flow/dp_rte_flow.c
+++ b/src/rte_flow/dp_rte_flow.c
@@ -774,6 +774,13 @@ int create_set_meta_action(struct rte_flow_action *action, int action_cnt,
 	return ++action_cnt;
 }
 
+int create_drop_action(struct rte_flow_action *action, int action_cnt)
+{
+
+	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_DROP;
+	return ++action_cnt;
+}
+
 int create_end_action(struct rte_flow_action *action, int action_cnt)
 {
 
@@ -798,6 +805,7 @@ void config_allocated_agectx(struct flow_age_ctx *agectx, uint16_t port_id,
 	agectx->rte_flow = flow;
 	// agectx->cntrack->port = port_id; // it is not actually used, considering to remove this field
 	rte_atomic32_inc(&agectx->cntrack->flow_cnt);
+	agectx->cntrack->owner += 1;
 }
 
 struct rte_flow *validate_and_install_rte_flow(uint16_t port_id,
@@ -815,7 +823,7 @@ struct rte_flow *validate_and_install_rte_flow(uint16_t port_id,
 	res = rte_flow_validate(port_id, attr, pattern, action, &error);
 
 	if (res) {
-		printf("Flow can't be validated message: %s\n", error.message ? error.message : "(no stated reason)");
+		printf("Flow can't be validated message: %s on port %d \n", error.message ? error.message : "(no stated reason)", port_id);
 		return NULL;
 	} else {
 		// printf("Flow validated on port %d\n", port_id);

--- a/src/rte_flow/dp_rte_flow_util.c
+++ b/src/rte_flow/dp_rte_flow_util.c
@@ -1,0 +1,147 @@
+#include "rte_flow/dp_rte_flow_util.h"
+#include "rte_flow/dp_rte_flow_traffic_forward.h"
+
+__rte_always_inline int dp_install_protection_drop(struct rte_mbuf *m, struct dp_flow *df)
+{
+	struct underlay_conf *u_conf = get_underlay_conf();
+
+	struct rte_flow_attr attr;
+
+	struct rte_flow_item pattern[DP_TUNN_OPS_OFFLOAD_MAX_PATTERN];
+	int pattern_cnt = 0;
+	struct rte_flow_action action[2];
+	int action_cnt = 0;
+
+	memset(pattern, 0, sizeof(pattern));
+	memset(action, 0, sizeof(action));
+
+	// create flow match patterns -- eth
+	struct rte_flow_item_eth eth_spec;
+	struct rte_flow_item_eth eth_mask;
+
+	pattern_cnt = insert_ethernet_match_pattern(pattern, pattern_cnt,
+												&eth_spec, &eth_mask,
+												NULL, 0, NULL, 0,
+												htons(df->tun_info.l3_type));
+
+	// create flow match patterns -- ipv6
+	struct rte_flow_item_ipv6 ipv6_spec;
+	struct rte_flow_item_ipv6 ipv6_mask;
+
+	pattern_cnt = insert_ipv6_match_pattern(pattern, pattern_cnt,
+											&ipv6_spec, &ipv6_mask,
+											NULL, 0,
+											df->tun_info.ul_dst_addr6, sizeof(df->tun_info.ul_dst_addr6),
+											df->tun_info.proto_id);
+
+	if (get_overlay_type() == DP_FLOW_OVERLAY_TYPE_GENEVE) {
+
+		// create flow match patterns -- udp
+		struct rte_flow_item_udp udp_spec;
+		struct rte_flow_item_udp udp_mask;
+
+		pattern_cnt = insert_udp_match_pattern(pattern, pattern_cnt,
+											   &udp_spec, &udp_mask,
+											   0, htons(u_conf->dst_port));
+
+		// create flow match patterns -- geneve
+		struct rte_flow_item_geneve gen_spec;
+		struct rte_flow_item_geneve gen_mask;
+
+		pattern_cnt = insert_geneve_match_pattern(pattern, pattern_cnt,
+												  &gen_spec, &gen_mask,
+												  df->l3_type, &df->tun_info.dst_vni);
+	}
+
+	// create flow match patterns -- inner packet, ipv6 or ipv4
+	struct rte_flow_item_ipv6 ol_ipv6_spec;
+	struct rte_flow_item_ipv6 ol_ipv6_mask;
+
+	struct rte_flow_item_ipv4 ol_ipv4_spec;
+	struct rte_flow_item_ipv4 ol_ipv4_mask;
+
+	if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
+		pattern_cnt = insert_ipv6_match_pattern(pattern, pattern_cnt,
+												&ol_ipv6_spec, &ol_ipv6_mask,
+												NULL, 0,
+												df->dst.dst_addr6, sizeof(ol_ipv6_spec.hdr.dst_addr),
+												df->l4_type);
+
+	} else {
+		pattern_cnt = insert_ipv4_match_pattern(pattern, pattern_cnt,
+												&ol_ipv4_spec, &ol_ipv4_mask,
+												df, DP_IS_DST);
+
+	}
+
+	// create flow match patterns -- inner packet, tcp, udp or icmp/icmpv6
+	struct rte_flow_item_tcp tcp_spec;
+	struct rte_flow_item_tcp tcp_mask;
+
+	if (df->l4_type == DP_IP_PROTO_TCP) {
+		pattern_cnt = insert_tcp_match_pattern(pattern, pattern_cnt,
+											   &tcp_spec, &tcp_mask,
+											   df->src_port, df->dst_port);
+
+	}
+
+	struct rte_flow_item_udp udp_spec;
+	struct rte_flow_item_udp udp_mask;
+
+	if (df->l4_type == DP_IP_PROTO_UDP) {
+		pattern_cnt = insert_udp_match_pattern(pattern, pattern_cnt,
+											   &udp_spec, &udp_mask,
+											   df->src_port, df->dst_port);
+	}
+
+	struct rte_flow_item_icmp icmp_spec;
+	struct rte_flow_item_icmp icmp_mask;
+
+	if (df->l4_type == DP_IP_PROTO_ICMP) {
+		pattern_cnt = insert_icmp_match_pattern(pattern, pattern_cnt,
+												&icmp_spec, &icmp_mask,
+												df->icmp_type);
+	}
+
+	struct rte_flow_item_icmp6 icmp6_spec;
+	struct rte_flow_item_icmp6 icmp6_mask;
+
+	if (df->l4_type == DP_IP_PROTO_ICMPV6) {
+		pattern_cnt = insert_icmpv6_match_pattern(pattern, pattern_cnt,
+												  &icmp6_spec, &icmp6_mask,
+												  df->icmp_type);
+	}
+
+	// create flow match patterns -- end
+	pattern_cnt = insert_end_match_pattern(pattern, pattern_cnt);
+
+
+	// create action -- drop
+	action_cnt = create_drop_action(action, action_cnt);
+
+	// create flow action -- age
+	struct flow_age_ctx *agectx = rte_zmalloc("age_ctx", sizeof(struct flow_age_ctx), RTE_CACHE_LINE_SIZE);
+	struct rte_flow_action_age flow_age;
+
+	if (!agectx)
+		return 0;
+
+	action_cnt = create_flow_age_action(action, action_cnt,
+											&flow_age, 3, agectx);
+
+	// create flow action -- end
+	action_cnt = create_end_action(action, action_cnt);
+
+	// validate and install rte flow
+	create_rte_flow_rule_attr(&attr, 0, 0, 1, 0, 1);
+	struct rte_flow *flow = NULL;
+
+	flow = validate_and_install_rte_flow(m->port, &attr, pattern, action, df);
+	if (!flow) {
+		free_allocated_agectx(agectx);
+		return 0;
+	}
+	// config the content of agectx
+	config_allocated_agectx(agectx, m->port, df, flow);
+	return 1;
+}


### PR DESCRIPTION
Fix #102 (EAL: Error: Invalid memory)

Invalid memory problem that leads to crashing appears when heavy load of traffic pkts that dp-service does not know where to forward (e.g., heavy traffic to a VM before its info is added). It could be due to reused mbuf (incoming speed is faster than the consuming speed)) are currently been deleting in drop_node.

It also has a potential bug that freeing cntrack (dp_free_flow()) for multiple times when 1) flow rule expires in both hardware and software; 2) a large trunck of pkts of the same original direction shall be dropped

To fix the problem, several aspects have been addressed:
	1) cntrack's owners are recorded, including ori/reply flow entries in software table and hardware flow rules. Its memory is deleted/freed when no owner is recorded;
        2) free software flow rule only when dropped pakets of this flow saturate the graph ring queue buffer (assuming they occupy all the received pkts in one iteration);
	3) in addition to 2), use hardware offloading to block traffic that needs to be massively dropped. diable this feature for e.g., connectX-4, using --no-hw-protect. Without this improvement, invalid memory error shouldn't be triggered as well.

    

