### PR TITLE
Fix " netlink: 16 bytes leftover " messages in the logs

### DIFF
--- a/src/dp_netlink.c
+++ b/src/dp_netlink.c
@@ -95,7 +95,7 @@ int dp_get_pf_neigh_mac(int if_idx, struct rte_ether_addr* neigh, struct rte_eth
 		goto cleanup;
 	
 	memset(req, 0, sizeof(struct dp_nlnk_req));
-	req->nl.nlmsg_len = NLMSG_LENGTH(sizeof(struct dp_nlnk_req));
+	req->nl.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
 	req->nl.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
 	req->nl.nlmsg_type = RTM_GETNEIGH;
 	req->rt.ndm_type = RTN_UNSPEC;


### PR DESCRIPTION
Use the correct length for netlink request to avoid the complaint in the logs.

Signed-off-by: Guvenc Gulce <guevenc.guelce@sap.com>