### PR TITLE
Add script to run dp_service under scapytest configuration

### DIFF
--- a/test/config.py
+++ b/test/config.py
@@ -52,6 +52,4 @@ pfx_ip = "174.23.4.0"
 mylb = "my_lb"
 lb_tcp_dst_port = 80
 
-config_file_path = "/tmp/dp_service.conf"
-
 MAX_LINES_ROUTE_REPLY = 36

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,13 +1,9 @@
-import os
 import pytest
-import shlex
-import subprocess
-import time
 
 from config import *
-from helpers import request_ip
-from helpers import interface_up
+from dp_service import DpService
 from grpc_client import GrpcClient
+from helpers import request_ip
 
 
 def pytest_addoption(parser):
@@ -40,80 +36,49 @@ def port_redundancy(request):
 def grpc_client(build_path):
 	return GrpcClient(build_path)
 
+
 # All tests require dp_service to be running
 @pytest.fixture(scope="package")
-def prepare_env(request, build_path, tun_opt, port_redundancy):
+def dp_service(request, build_path, tun_opt, port_redundancy):
+
+	dp_service = DpService(build_path, tun_opt, port_redundancy)
 
 	if request.config.getoption("--attach"):
 		print("Attaching to an already running service")
 		GrpcClient.wait_for_port()
-		return
-
-	# TODO this should be done via some option in dp_service, reading a hardcoded path is not the way
-	if os.path.exists(config_file_path):
-		os.rename(config_file_path, config_file_path + ".backup")
-
-	dp_service_cmd = (f'{build_path}/src/dp_service -l 0,1'
-						f' --vdev=net_tap0,iface={pf0_tap},mac="{pf0_mac}"'
-						f' --vdev=net_tap1,iface={pf1_tap},mac="{pf1_mac}"'
-						f' --vdev=net_tap2,iface={vf0_tap},mac="{vf0_mac}"'
-						f' --vdev=net_tap3,iface={vf1_tap},mac="{vf1_mac}"'
-						f' --vdev=net_tap4,iface={vf2_tap},mac="{vf2_mac}"'
-						' --'
-						f' --pf0={pf0_tap} --pf1={pf1_tap} --vf-pattern={vf_patt}'
-						f' --ipv6={ul_ipv6} --enable-ipv6-overlay'
-						 ' --no-offload --no-stats'
-						 ' --op_env=scapytest'
-						f' --tun_opt={tun_opt}')
-	if port_redundancy:
-		dp_service_cmd += ' --wcmp-frac=0.5'
+		return dp_service
 
 	if GrpcClient.port_open():
 		raise AssertionError("Another service already running")
 
 	print("------ Service init ------")
-	print(dp_service_cmd)
-	process = subprocess.Popen(shlex.split(dp_service_cmd))
+	print(dp_service.get_cmd())
+	dp_service.start()
 	GrpcClient.wait_for_port()
 	print("--------------------------")
 
 	def tear_down():
-		process.terminate()
-		try:
-			process.wait(5)
-		except subprocess.TimeoutExpired:
-			process.kill()
-			process.wait()
-		# TODO see above
-		if os.path.exists(config_file_path + ".backup") :
-			os.rename(config_file_path + ".backup", config_file_path)
+		dp_service.stop()
 	request.addfinalizer(tear_down)
+
+	return dp_service
+
 
 # Most tests require interfaces to be up and routing established
 @pytest.fixture(scope="package")
-def prepare_ifaces(prepare_env, tun_opt, port_redundancy, grpc_client):
+def prepare_ifaces(request, dp_service, tun_opt, port_redundancy, grpc_client):
 	# TODO look into this when doing Geneve, is this the right way?
 	global t_vni
 	if tun_opt == tun_type_geneve:
 		t_vni = vni
 
+	if request.config.getoption("--attach"):
+		return
+
 	print("---- Interfaces init -----")
-	interface_up(vf0_tap)
-	interface_up(vf1_tap)
-	interface_up(vf2_tap)
-	interface_up(pf0_tap)
-	if port_redundancy:
-		interface_up(pf1_tap)
-	grpc_client.assert_output("--init", "Init called")
-	grpc_client.assert_output(f"--addmachine {vm1_name} --vni {vni} --ipv4 {vf0_ip} --ipv6 {vf0_ipv6}", "Allocated VF for you")
-	grpc_client.assert_output(f"--addmachine {vm2_name} --vni {vni} --ipv4 {vf1_ip} --ipv6 {vf1_ipv6}", "Allocated VF for you")
-	grpc_client.assert_output(f"--addroute --vni {vni} --ipv4 {ov_target_pfx} --length 24 --t_vni {t_vni} --t_ipv6 {ul_actual_dst}", f"Route ip {ov_target_pfx}")
-	grpc_client.assert_output(f"--addroute --vni {vni} --ipv6 2002::123 --length 128 --t_vni {t_vni} --t_ipv6 {ul_actual_dst}", "target ipv6 2002::123")
-	grpc_client.assert_output(f"--addroute --vni {vni} --ipv4 0.0.0.0 --length 0 --t_vni {vni} --t_ipv6 {ul_actual_dst}", "Route ip 0.0.0.0")
-	# TODO(plague): this is required as service obviously is still doing some initialization
-	# Discuss a logline to wait for (would need to rework service outptu handling) or waiting with GRPC thread for this to finish
-	time.sleep(3)
+	dp_service.init_ifaces(grpc_client)
 	print("--------------------------")
+
 
 # Some tests require IPv4 addresses assigned
 @pytest.fixture(scope="package")

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import os
+import shlex
+import subprocess
+
+from config import *
+from grpc_client import GrpcClient
+from helpers import interface_up
+
+# TODO this should be done a better way
+config_file_path = "/tmp/dp_service.conf"
+
+class DpService:
+
+	def __init__(self, build_path, tun_opt, port_redundancy, gdb=False):
+		self.build_path = build_path
+		self.port_redundancy = port_redundancy
+
+		self.cmd = ""
+		if gdb:
+			script_path = os.path.dirname(os.path.abspath(__file__))
+			self.cmd = f"gdb -x {script_path}/gdbinit --args "
+
+		self.cmd += (f'{self.build_path}/src/dp_service -l 0,1'
+					f' --vdev=net_tap0,iface={pf0_tap},mac="{pf0_mac}"'
+					f' --vdev=net_tap1,iface={pf1_tap},mac="{pf1_mac}"'
+					f' --vdev=net_tap2,iface={vf0_tap},mac="{vf0_mac}"'
+					f' --vdev=net_tap3,iface={vf1_tap},mac="{vf1_mac}"'
+					f' --vdev=net_tap4,iface={vf2_tap},mac="{vf2_mac}"'
+					 ' --'
+					f' --pf0={pf0_tap} --pf1={pf1_tap} --vf-pattern={vf_patt}'
+					f' --ipv6={ul_ipv6} --enable-ipv6-overlay'
+					 ' --no-offload --no-stats'
+					 ' --op_env=scapytest'
+					f' --tun_opt={tun_opt}')
+		if self.port_redundancy:
+			self.cmd += ' --wcmp-frac=0.5'
+
+	def get_cmd(self):
+		return self.cmd
+
+	def start(self):
+		# TODO see above
+		if os.path.exists(config_file_path):
+			os.rename(config_file_path, config_file_path + ".backup")
+		self.process = subprocess.Popen(shlex.split(self.cmd))
+
+	def stop(self):
+		# TODO see above
+		if os.path.exists(config_file_path + ".backup") :
+			os.rename(config_file_path + ".backup", config_file_path)
+		self.process.terminate()
+		try:
+			self.process.wait(5)
+		except subprocess.TimeoutExpired:
+			self.process.kill()
+			self.process.wait()
+
+	def init_ifaces(self, grpc_client):
+		interface_up(vf0_tap)
+		interface_up(vf1_tap)
+		interface_up(vf2_tap)
+		interface_up(pf0_tap)
+		if self.port_redundancy:
+			interface_up(pf1_tap)
+		grpc_client.assert_output("--init", "Init called")
+		grpc_client.assert_output(f"--addmachine {vm1_name} --vni {vni} --ipv4 {vf0_ip} --ipv6 {vf0_ipv6}", "Allocated VF for you")
+		grpc_client.assert_output(f"--addmachine {vm2_name} --vni {vni} --ipv4 {vf1_ip} --ipv6 {vf1_ipv6}", "Allocated VF for you")
+		grpc_client.assert_output(f"--addroute --vni {vni} --ipv4 {ov_target_pfx} --length 24 --t_vni {t_vni} --t_ipv6 {ul_actual_dst}", f"Route ip {ov_target_pfx}")
+		grpc_client.assert_output(f"--addroute --vni {vni} --ipv6 2002::123 --length 128 --t_vni {t_vni} --t_ipv6 {ul_actual_dst}", "target ipv6 2002::123")
+		grpc_client.assert_output(f"--addroute --vni {vni} --ipv4 0.0.0.0 --length 0 --t_vni {vni} --t_ipv6 {ul_actual_dst}", "Route ip 0.0.0.0")
+
+
+# If run manually:
+import argparse
+import signal
+
+def silent_sigint(sig, frame):
+	pass
+
+if __name__ == '__main__':
+	script_path = os.path.dirname(os.path.abspath(__file__))
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--build-path", action="store", default=f"{script_path}/../build", help="Path to the root build directory")
+	parser.add_argument("--tun-opt", action="store", choices=["ipip", "geneve"], default="ipip", help="Underlay tunnel type")
+	parser.add_argument("--port-redundancy", action="store_true", help="Set up two physical ports")
+	parser.add_argument("--no-init", action="store_true", help="Do not set interfaces up automatically")
+	parser.add_argument("--init-only", action="store_true", help="Only init interfaces of a running service")
+	parser.add_argument("--gdb", action="store_true", help="Run service under gdb")
+	args = parser.parse_args()
+
+	dp_service = DpService(args.build_path, args.tun_opt, args.port_redundancy, args.gdb)
+
+	if args.init_only:
+		dp_service.init_ifaces(GrpcClient(args.build_path))
+		exit(0)
+
+	# service handles Ctrl-C directly
+	signal.signal(signal.SIGINT, silent_sigint)
+
+	print(dp_service.get_cmd())
+	dp_service.start()
+	GrpcClient.wait_for_port()
+	if not args.no_init:
+		dp_service.init_ifaces(GrpcClient(args.build_path))
+
+	ret = dp_service.process.wait()
+	if ret < 0:
+		print(f"Killed with signal {-ret}")
+	elif ret > 0:
+		print(f"Failed with code {ret}")
+
+	# TODO see above
+	if os.path.exists(config_file_path + ".backup") :
+		os.rename(config_file_path + ".backup", config_file_path)

--- a/test/gdbinit
+++ b/test/gdbinit
@@ -1,0 +1,4 @@
+# TUN/TAP use signals in their implementation
+handle SIG35 nostop noprint pass
+
+run


### PR DESCRIPTION
So we do not have to scrape the output of pytest for the actual arguments being used when running tests, I made a script that calls dp_service with all arguments from config.py.

You can now run `tests/dp_service.py` and it automatically uses all data from config.py.

You an also add `--gdb` and it is automatically run under GDB (autostart, but that can be removed if wanted), with a `gdbinit` script that prepares signal handling due to TUN/TAP.

Pytest code of course reuses this, so there is no duplication of cmdline generation.

---
If you need to start service without interface initialization (and subsequent GRPC), use `--no-init`. You can do that later by a separate call `dp_service.py --init-only`.