### PR TITLE
Added colored logging.

### DIFF
--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -23,3 +23,4 @@ For more information on EAL options, please see [the official docs](https://doc.
 | --enable-ipv6-overlay | None | enable IPv6 overlay addresses |  |
 | --no-offload | None | disable traffic offloading |  |
 | --graphtrace | LEVEL | verbosity level of packet traversing the graph framework |  |
+| --color | MODE | output colorization mode | 'never' (default), 'always' or 'auto' |

--- a/hack/dp_conf.json
+++ b/hack/dp_conf.json
@@ -100,5 +100,14 @@
     "type": "int",
     "default": "0",
     "ifdef": "ENABLE_GRAPHTRACE"
+  },
+  {
+    "lgopt": "color",
+    "arg": "MODE",
+    "help": "output colorization mode",
+    "var": "color",
+    "type": "enum",
+    "choices": [ "never", "always", "auto" ],
+    "default": "never"
   }
 ]

--- a/include/dp_conf_opts.h
+++ b/include/dp_conf_opts.h
@@ -15,6 +15,12 @@ enum dp_conf_nic_type {
 	DP_CONF_NIC_TYPE_TAP,
 };
 
+enum dp_conf_color {
+	DP_CONF_COLOR_NEVER,
+	DP_CONF_COLOR_ALWAYS,
+	DP_CONF_COLOR_AUTO,
+};
+
 const char *dp_conf_get_pf0_name();
 const char *dp_conf_get_pf1_name();
 const char *dp_conf_get_vf_pattern();
@@ -28,3 +34,4 @@ const bool dp_conf_is_offload_enabled();
 #ifdef ENABLE_GRAPHTRACE
 const int dp_conf_get_graphtrace_level();
 #endif
+const enum dp_conf_color dp_conf_get_color();

--- a/include/dp_log.h
+++ b/include/dp_log.h
@@ -70,6 +70,8 @@ void _dp_log(unsigned int level, unsigned int logtype,
 
 void dp_log_set_thread_name(const char *name);
 
+int dp_log_init();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -151,6 +151,8 @@ static int parse_opt(int opt, const char *arg)
 	case OPT_GRAPHTRACE:
 		return opt_str_to_int(&graphtrace_level, arg, 0, DP_GRAPHTRACE_LEVEL_MAX);
 #endif
+	case OPT_COLOR:
+		return opt_str_to_enum((int *)&color, arg, color_choices, RTE_DIM(color_choices));
 	default:
 		fprintf(stderr, "Unimplemented option %d\n", opt);
 		return DP_ERROR;

--- a/src/dp_conf_opts.c
+++ b/src/dp_conf_opts.c
@@ -23,6 +23,7 @@ _OPT_SHOPT_MAX = 255,
 #ifdef ENABLE_GRAPHTRACE
 	OPT_GRAPHTRACE,
 #endif
+	OPT_COLOR,
 };
 
 #define OPTSTRING \
@@ -46,6 +47,7 @@ static const struct option longopts[] = {
 #ifdef ENABLE_GRAPHTRACE
 	{ "graphtrace", 1, 0, OPT_GRAPHTRACE },
 #endif
+	{ "color", 1, 0, OPT_COLOR },
 	{ NULL, }
 };
 
@@ -57,6 +59,12 @@ static const char *overlay_type_choices[] = {
 static const char *nic_type_choices[] = {
 	"hw",
 	"tap",
+};
+
+static const char *color_choices[] = {
+	"never",
+	"always",
+	"auto",
 };
 
 static void print_help_args(FILE *outfile)
@@ -78,6 +86,7 @@ static void print_help_args(FILE *outfile)
 #ifdef ENABLE_GRAPHTRACE
 		"     --graphtrace=LEVEL        verbosity level of packet traversing the graph framework\n"
 #endif
+		"     --color=MODE              output colorization mode: 'never' (default), 'always' or 'auto'\n"
 	);
 }
 
@@ -94,6 +103,7 @@ static bool offload_enabled = true;
 #ifdef ENABLE_GRAPHTRACE
 static int graphtrace_level = 0;
 #endif
+static enum dp_conf_color color = DP_CONF_COLOR_NEVER;
 
 const char *dp_conf_get_pf0_name()
 {
@@ -152,3 +162,8 @@ const int dp_conf_get_graphtrace_level()
 }
 
 #endif
+const enum dp_conf_color dp_conf_get_color()
+{
+	return color;
+}
+

--- a/src/dp_service.cpp
+++ b/src/dp_service.cpp
@@ -17,6 +17,7 @@
 #include "dp_alias.h"
 #include "grpc/dp_grpc_service.h"
 #include "dp_multi_path.h"
+#include "dp_log.h"
 
 static char **dp_argv;
 static int dp_argc;
@@ -165,7 +166,7 @@ static int run_service()
 		return EXIT_FAILURE;
 	}
 
-	rte_openlog_stream(stdout);
+	dp_log_init();
 	dp_log_set_thread_name("control");
 	DPS_LOG_INFO("Starting DP Service version %s", DP_SERVICE_VERSION);
 	// from this point on, only DPS_LOG should be used


### PR DESCRIPTION
Added coloring of log output for dp_service.

This makes warnings more visible in the stream of info messages.

By default, coloring is off. There is a cmdline option like in `grep` or `ls`. I suggest using `--color=auto` so it only colorizes output in an interactive terminal and not in a redirect.

For developers, I'd suggest to edit `/tmp/dp_service.conf` and adding `color auto` line there.