### PR TITLE
Added --dhcp-mtu to set MTU in DHCP responses

### DIFF
--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -16,6 +16,7 @@ For more information on EAL options, please see [the official docs](https://doc.
 | --ipv6 | ADDR6 | IPv6 underlay address |  |
 | --vf-pattern | PATTERN | virtual interface name pattern (e.g. 'eth1vf') |  |
 | --overlay-type | TYPE | overlay tunnel type to use | 'ipip' (default) or 'geneve' |
+| --dhcp-mtu | SIZE | set the mtu field in DHCP responses (68 - 1500) |  |
 | --wcmp-fraction | FRACTION | weighted-cost-multipath coefficient for pf0 (0.0 - 1.0) |  |
 | --nic-type | NICTYPE | NIC type to use | 'hw' (default) or 'tap' |
 | --no-stats | None | do not print periodic statistics to stdout |  |

--- a/hack/dp_conf.json
+++ b/hack/dp_conf.json
@@ -48,6 +48,14 @@
     "default": "ipip"
   },
   {
+    "lgopt": "dhcp-mtu",
+    "arg": "SIZE",
+    "help": "set the mtu field in DHCP responses (68 - 1500)",
+    "var": "dhcp_mtu",
+    "type": "int",
+    "default": 1500
+  },
+  {
     "lgopt": "wcmp-fraction",
     "arg": "FRACTION",
     "help": "weighted-cost-multipath coefficient for pf0 (0.0 - 1.0)",

--- a/include/dp_conf_opts.h
+++ b/include/dp_conf_opts.h
@@ -25,6 +25,7 @@ const char *dp_conf_get_pf0_name();
 const char *dp_conf_get_pf1_name();
 const char *dp_conf_get_vf_pattern();
 const enum dp_conf_overlay_type dp_conf_get_overlay_type();
+const int dp_conf_get_dhcp_mtu();
 const double dp_conf_get_wcmp_frac();
 const enum dp_conf_nic_type dp_conf_get_nic_type();
 const bool dp_conf_is_stats_enabled();

--- a/include/nodes/dhcp_node.h
+++ b/include/nodes/dhcp_node.h
@@ -34,7 +34,6 @@ extern "C" {
 #define DP_DHCP_ACK			0x05
 #define DP_DHCP_INFINITE	0xffffffff
 #define DP_DHCP_MASK		0xffffffff
-#define DP_DHCP_MTU_VALUE	0x005DC
 
 #define DHCP_MAGIC_COOKIE 0x63825363
 

--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -132,6 +132,8 @@ static int parse_opt(int opt, const char *arg)
 		return opt_str_to_enum((int *)&overlay_type, arg, overlay_type_choices, RTE_DIM(overlay_type_choices));
 	case OPT_NIC_TYPE:
 		return opt_str_to_enum((int *)&nic_type, arg, nic_type_choices, RTE_DIM(nic_type_choices));
+	case OPT_DHCP_MTU:
+		return opt_str_to_int(&dhcp_mtu, arg, 68, 1500);  // RFC 791, RFC 894
 	case OPT_WCMP_FRACTION:
 		wcmp_enabled = true;
 		return opt_str_to_double(&wcmp_frac, arg, 0.0, 1.0);

--- a/src/dp_conf_opts.c
+++ b/src/dp_conf_opts.c
@@ -14,6 +14,7 @@ _OPT_SHOPT_MAX = 255,
 	OPT_IPV6,
 	OPT_VF_PATTERN,
 	OPT_OVERLAY_TYPE,
+	OPT_DHCP_MTU,
 	OPT_WCMP_FRACTION,
 	OPT_NIC_TYPE,
 	OPT_NO_STATS,
@@ -38,6 +39,7 @@ static const struct option longopts[] = {
 	{ "ipv6", 1, 0, OPT_IPV6 },
 	{ "vf-pattern", 1, 0, OPT_VF_PATTERN },
 	{ "overlay-type", 1, 0, OPT_OVERLAY_TYPE },
+	{ "dhcp-mtu", 1, 0, OPT_DHCP_MTU },
 	{ "wcmp-fraction", 1, 0, OPT_WCMP_FRACTION },
 	{ "nic-type", 1, 0, OPT_NIC_TYPE },
 	{ "no-stats", 0, 0, OPT_NO_STATS },
@@ -77,6 +79,7 @@ static void print_help_args(FILE *outfile)
 		"     --ipv6=ADDR6              IPv6 underlay address\n"
 		"     --vf-pattern=PATTERN      virtual interface name pattern (e.g. 'eth1vf')\n"
 		"     --overlay-type=TYPE       overlay tunnel type to use: 'ipip' (default) or 'geneve'\n"
+		"     --dhcp-mtu=SIZE           set the mtu field in DHCP responses (68 - 1500)\n"
 		"     --wcmp-fraction=FRACTION  weighted-cost-multipath coefficient for pf0 (0.0 - 1.0)\n"
 		"     --nic-type=NICTYPE        NIC type to use: 'hw' (default) or 'tap'\n"
 		"     --no-stats                do not print periodic statistics to stdout\n"
@@ -94,6 +97,7 @@ static char pf0_name[IF_NAMESIZE];
 static char pf1_name[IF_NAMESIZE];
 static char vf_pattern[IF_NAMESIZE];
 static enum dp_conf_overlay_type overlay_type = DP_CONF_OVERLAY_TYPE_IPIP;
+static int dhcp_mtu = 1500;
 static double wcmp_frac = 1.0;
 static enum dp_conf_nic_type nic_type = DP_CONF_NIC_TYPE_HW;
 static bool stats_enabled = true;
@@ -123,6 +127,11 @@ const char *dp_conf_get_vf_pattern()
 const enum dp_conf_overlay_type dp_conf_get_overlay_type()
 {
 	return overlay_type;
+}
+
+const int dp_conf_get_dhcp_mtu()
+{
+	return dhcp_mtu;
 }
 
 const double dp_conf_get_wcmp_frac()

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -179,7 +179,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 	dhcp_srv_ident = htonl(dp_get_gw_ip4());
 	net_mask = htonl(DP_DHCP_MASK);
-	mtu = htons(DP_DHCP_MTU_VALUE);
+	mtu = htons(dp_conf_get_dhcp_mtu());
 
 	vend_pos += add_dhcp_option(&dhcp_hdr->options[vend_pos], &dhcp_type, DP_DHCP_MSG_TYPE, 1);
 	vend_pos += add_dhcp_option(&dhcp_hdr->options[vend_pos], &dhcp_lease, DP_DHCP_LEASE_MSG, 4);

--- a/test/config.py
+++ b/test/config.py
@@ -21,6 +21,7 @@ ul_actual_dst="2a10:afc0:e01f:f408:0:64::"
 ul_actual_src="2a10:afc0:e01f:f403:0:64::"
 ul_short_src="2a10:afc0:e01f:f403::"
 tun_type_geneve="geneve"
+dhcp_mtu = 1337
 
 bcast_mac = "ff:ff:ff:ff:ff:ff"
 null_ip = "0.0.0.0"

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -20,7 +20,7 @@ class DpService:
 			script_path = os.path.dirname(os.path.abspath(__file__))
 			self.cmd = f"gdb -x {script_path}/gdbinit --args "
 
-		self.cmd += (f'{self.build_path}/src/dp_service -l 0,1'
+		self.cmd += (f'{self.build_path}/src/dp_service -l 0,1 --no-pci'
 					f' --vdev=net_tap0,iface={pf0_tap},mac="{pf0_mac}"'
 					f' --vdev=net_tap1,iface={pf1_tap},mac="{pf1_mac}"'
 					f' --vdev=net_tap2,iface={vf0_tap},mac="{vf0_mac}"'
@@ -29,6 +29,7 @@ class DpService:
 					 ' --'
 					f' --pf0={pf0_tap} --pf1={pf1_tap} --vf-pattern={vf_patt}'
 					f' --ipv6={ul_ipv6} --enable-ipv6-overlay'
+					f' --dhcp-mtu={dhcp_mtu}'
 					 ' --no-offload --no-stats'
 					f' --nic-type=tap --overlay-type={tun_opt}')
 		if self.port_redundancy:


### PR DESCRIPTION
As per discussion, MTU in DHCP replies is now not a harcoded value, but a command-line option.

It defaults to 1500.

There is a range limit to 64-65535 (magic numbers, no spec used), please request a change if needed.