### PR TITLE
Added command-line option to set gRPC port

### DIFF
--- a/docs/deployment/commandline.md
+++ b/docs/deployment/commandline.md
@@ -26,6 +26,7 @@ For more information on EAL options, please see [the official docs](https://doc.
 | --no-offload | None | disable traffic offloading |  |
 | --graphtrace | LEVEL | verbosity level of packet traversing the graph framework |  |
 | --color | MODE | output colorization mode | 'never' (default), 'always' or 'auto' |
+| --grpc-port | PORT | listen for gRPC clients on this port |  |
 
 ## Configuration file
 Unless an environment variable `DP_CONF` is set to override the path, `dp_service` uses `/tmp/dp_service.conf` to read configuration before processing any arguments.

--- a/hack/dp_conf.json
+++ b/hack/dp_conf.json
@@ -122,5 +122,13 @@
     "type": "enum",
     "choices": [ "never", "always", "auto" ],
     "default": "never"
+  },
+  {
+    "lgopt": "grpc-port",
+    "arg": "PORT",
+    "help": "listen for gRPC clients on this port",
+    "var": "grpc_port",
+    "type": "int",
+    "default": 1337
   }
 ]

--- a/include/dp_conf_opts.h
+++ b/include/dp_conf_opts.h
@@ -36,3 +36,4 @@ const bool dp_conf_is_offload_enabled();
 const int dp_conf_get_graphtrace_level();
 #endif
 const enum dp_conf_color dp_conf_get_color();
+const int dp_conf_get_grpc_port();

--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -197,6 +197,8 @@ static int parse_opt(int opt, const char *arg)
 #endif
 	case OPT_COLOR:
 		return opt_str_to_enum((int *)&color, arg, color_choices, RTE_DIM(color_choices));
+	case OPT_GRPC_PORT:
+		return opt_str_to_int(&grpc_port, arg, 1024, 65535);
 	default:
 		DP_EARLY_ERR("Unimplemented option %d", opt);
 		return DP_ERROR;

--- a/src/dp_conf_opts.c
+++ b/src/dp_conf_opts.c
@@ -26,6 +26,7 @@ _OPT_SHOPT_MAX = 255,
 	OPT_GRAPHTRACE,
 #endif
 	OPT_COLOR,
+	OPT_GRPC_PORT,
 };
 
 #define OPTSTRING \
@@ -52,6 +53,7 @@ static const struct option longopts[] = {
 	{ "graphtrace", 1, 0, OPT_GRAPHTRACE },
 #endif
 	{ "color", 1, 0, OPT_COLOR },
+	{ "grpc-port", 1, 0, OPT_GRPC_PORT },
 	{ NULL, }
 };
 
@@ -93,6 +95,7 @@ static void print_help_args(FILE *outfile)
 		"     --graphtrace=LEVEL        verbosity level of packet traversing the graph framework\n"
 #endif
 		"     --color=MODE              output colorization mode: 'never' (default), 'always' or 'auto'\n"
+		"     --grpc-port=PORT          listen for gRPC clients on this port\n"
 	);
 }
 
@@ -111,6 +114,7 @@ static bool offload_enabled = true;
 static int graphtrace_level = 0;
 #endif
 static enum dp_conf_color color = DP_CONF_COLOR_NEVER;
+static int grpc_port = 1337;
 
 const char *dp_conf_get_pf0_name()
 {
@@ -177,5 +181,10 @@ const int dp_conf_get_graphtrace_level()
 const enum dp_conf_color dp_conf_get_color()
 {
 	return color;
+}
+
+const int dp_conf_get_grpc_port()
+{
+	return grpc_port;
 }
 

--- a/src/dp_service.cpp
+++ b/src/dp_service.cpp
@@ -153,13 +153,17 @@ static int init_interfaces()
 
 static void *dp_handle_grpc(__rte_unused void *arg)
 {
+	GRPCService *grpc_svc;
+	char addr[12];  // '[::]:65535\0'
+
 	dp_log_set_thread_name("grpc");
 
-	GRPCService *grpc_svc = new GRPCService();
+	grpc_svc = new GRPCService();
 
-	// TODO(plague) address/port in config
+	snprintf(addr, sizeof(addr), "[::]:%d", dp_conf_get_grpc_port());
+
 	// we are in a thread, proper teardown would be complicated here, so exit instead
-	if (!grpc_svc->run("[::]:1337"))
+	if (!grpc_svc->run(addr))
 		rte_exit(EXIT_FAILURE, "Cannot run without working GRPC server\n");
 
 	delete grpc_svc;


### PR DESCRIPTION
It's not actually useful at the moment, but having the port hardcoded was not future-proof.

The default is the old value, so nothing should change for any consumer.