### PR TITLE
Fixed byte-order in DNS DHCP option

### DIFF
--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -130,7 +130,6 @@ static int opt_str_to_enum(int *dst, const char *arg, const char *choices[], uin
 static int add_dhcp_dns(const char *str)
 {
 	uint8_t *tmp;
-	uint32_t ip;
 	struct in_addr addr;
 
 	if (inet_aton(str, &addr) != 1) {
@@ -151,8 +150,7 @@ static int add_dhcp_dns(const char *str)
 	}
 	dhcp_dns.array = tmp;
 
-	ip = htonl(addr.s_addr);
-	rte_memcpy(&dhcp_dns.array[dhcp_dns.len], &ip, sizeof(ip));
+	rte_memcpy(&dhcp_dns.array[dhcp_dns.len], &addr.s_addr, sizeof(addr.s_addr));
 	dhcp_dns.len += 4;
 	return DP_OK;
 }

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -111,7 +111,7 @@ static int parse_options(struct dp_dhcp_header *dhcp_pkt,
 						 enum dp_pxe_mode *pxe_mode)
 {
 	uint8_t op_type;
-	uint8_t op_len;
+	uint8_t op_len = 0;
 	int result = DP_ERROR;  // need at least msg_type
 
 	for (int i = 0; i < options_len; i += op_len) {

--- a/test/config.py
+++ b/test/config.py
@@ -22,7 +22,7 @@ ul_actual_src="2a10:afc0:e01f:f403:0:64::"
 ul_short_src="2a10:afc0:e01f:f403::"
 tun_type_geneve="geneve"
 dhcp_mtu = 1337
-dhcp_dns1 = "4.4.4.4"
+dhcp_dns1 = "8.8.4.4"
 dhcp_dns2 = "8.8.8.8"
 
 bcast_mac = "ff:ff:ff:ff:ff:ff"


### PR DESCRIPTION
There was a bug in string to ip conversion and a potential bug in option parsing.