### PR TITLE
Separate gRPC source 

### DIFF
--- a/include/dpdk_layer.h
+++ b/include/dpdk_layer.h
@@ -6,9 +6,6 @@
 #include <rte_timer.h>
 #include <rte_cycles.h>
 
-#include <signal.h>
-#include <pthread.h>
-
 #include "dp_port.h"
 
 #ifdef __cplusplus
@@ -64,10 +61,11 @@ int dp_graph_init(void);
 int dp_dpdk_main_loop(void);
 void dp_dpdk_exit(void);
 
+void dp_force_quit();
+
 void set_underlay_conf(struct underlay_conf *u_conf);
 struct underlay_conf *get_underlay_conf();
 struct dp_dpdk_layer *get_dpdk_layer();
-pthread_t *dp_get_ctrl_thread_id();
 
 #ifdef __cplusplus
 }

--- a/include/grpc/dp_grpc_thread.h
+++ b/include/grpc/dp_grpc_thread.h
@@ -1,0 +1,15 @@
+#ifndef __INCLUDE_GRPC_THREAD_H__
+#define __INCLUDE_GRPC_THREAD_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int dp_grpc_thread_start();
+int dp_grpc_thread_join();
+int dp_grpc_thread_cancel();
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/grpc/dp_grpc_thread.cpp
+++ b/src/grpc/dp_grpc_thread.cpp
@@ -1,0 +1,58 @@
+#include "grpc/dp_grpc_thread.h"
+#include <rte_thread.h>
+#include "dp_conf.h"
+#include "dp_error.h"
+#include "dp_log.h"
+#include "grpc/dp_grpc_service.h"
+
+static pthread_t grpc_thread_id;
+
+static void *dp_grpc_main_loop(__rte_unused void *arg)
+{
+	GRPCService *grpc_svc;
+	char addr[12];  // '[::]:65535\0'
+
+	dp_log_set_thread_name("grpc");
+
+	grpc_svc = new GRPCService();
+
+	snprintf(addr, sizeof(addr), "[::]:%d", dp_conf_get_grpc_port());
+
+	// we are in a thread, proper teardown would be complicated here, so exit instead
+	if (!grpc_svc->run(addr))
+		rte_exit(EXIT_FAILURE, "Cannot run without working GRPC server\n");
+
+	delete grpc_svc;
+	return NULL;
+}
+
+int dp_grpc_thread_start()
+{
+	int ret = rte_ctrl_thread_create(&grpc_thread_id, "grpc-thread", NULL, dp_grpc_main_loop, NULL);
+
+	if (DP_FAILED(ret))
+		DPS_LOG_ERR("Cannot create grpc thread %s", dp_strerror(ret));
+	return ret;
+}
+
+int dp_grpc_thread_join()
+{
+	int ret = pthread_join(grpc_thread_id, NULL);  // returns errno on failure
+
+	if (ret) {
+		DPS_LOG_ERR("Cannot join grpc thread %s", dp_strerror(ret));
+		return DP_ERROR;
+	}
+	return DP_OK;
+}
+
+int dp_grpc_thread_cancel()
+{
+	int ret = pthread_cancel(grpc_thread_id);  // returns errno on failure
+
+	if (ret) {
+		DPS_LOG_ERR("Cannot cancel grpc thread %s", dp_strerror(ret));
+		return DP_ERROR;
+	}
+	return DP_OK;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.c', 'dp_alias.c', 'dp_multi_path.c','nodes/arp_node.c',
+dp_sources = ['dp_service.c', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.c', 'dp_alias.c', 'dp_multi_path.c','nodes/arp_node.c',
 			  'nodes/drop_node.c', 'nodes/rx_node.c','nodes/rx_periodic_node.c', 'nodes/cls_node.c','nodes/dhcp_node.c','nodes/dhcpv6_node.c',
 			  'nodes/arp_node.c','nodes/ipv6_nd_node.c', 'nodes/tx_node.c', 'nodes/ipv4_lookup_node.c', 'nodes/l2_decap_node.c',
 			  'dp_mbuf_dyn.c', 'dp_lpm.c', 'nodes/ipv6_encap_node.c', 'nodes/firewall_node.c',
@@ -8,7 +8,7 @@ dp_sources = ['dp_service.cpp', 'dp_port.c', 'dpdk_layer.c', 'dp_nat.c', 'dp_lb.
 			  'nodes/snat_node.c', 'grpc/dp_grpc_service.cpp', 'grpc/dp_async_grpc.cpp', 'grpc/dp_grpc_impl.c', 'dp_flow.c',
 			  'dp_netlink.c','rte_flow/dp_rte_flow.c','rte_flow/dp_rte_flow_init.c','rte_flow/dp_rte_flow_traffic_forward.c',
 			  'monitoring/dp_monitoring.c','monitoring/dp_event.c',
-			  'dp_log.c', 'dp_error.c', 'dp_hairpin.c'
+			  'dp_log.c', 'dp_error.c', 'dp_hairpin.c', 'grpc/dp_grpc_thread.cpp'
  			]
 # TODO(plague) look into autogereration of such dependencies (source file list)
 


### PR DESCRIPTION
To encapsulate gRPC thread related code, I moved to a separate file.

This actually enabled dp_service to be in C and not C++ anymore, which is another nice separation of the gRPC code.

I also moved signal handling to dp_service.c as this is more related to the command-line utility code than the dataplane service code.