### PR TITLE
Added packet details into graphtrace logging

### DIFF
--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -8,6 +8,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include <net/if.h>
+#include <rte_byteorder.h>
 #include <rte_ethdev.h>
 #include <rte_hash.h>
 #include <rte_log.h>
@@ -43,6 +44,25 @@ void dp_fill_ipv4_print_buff(unsigned int ip, char *buf);
 
 
 struct rte_hash *dp_create_jhash_table(int entries, size_t key_len, const char *name, int socket_id);
+
+
+// inspired by DPDK's RTE_ETHER_ADDR_PRT_FMT and RTE_ETHER_ADDR_BYTES
+// TODO(plague): apply this to dp_fill_ipv4_print_buff()
+#define DP_IPV4_PRINT_FMT       "%u.%u.%u.%u"
+#define DP_IPV4_PRINT_BYTES(ip) (ip) & 0xFF, \
+								((ip) >> 8) & 0xFF, \
+								((ip) >> 16) & 0xFF, \
+								((ip) >> 24) & 0xFF
+
+#define DP_IPV6_PRINT_FMT       "%x:%x:%x:%x:%x:%x:%x:%x"
+#define DP_IPV6_PRINT_BYTES(ip) rte_cpu_to_be_16(((uint16_t *)(ip))[0]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[1]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[2]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[3]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[4]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[5]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[6]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[7])
 
 #ifdef __cplusplus
 }

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -94,6 +94,7 @@ void rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type)
 	struct rte_ether_hdr *eth_hdr;
 
 	eth_hdr = (struct rte_ether_hdr *)rte_pktmbuf_prepend(m, sizeof(struct rte_ether_hdr));
+	m->packet_type |= RTE_PTYPE_L2_ETHER;
 	rte_ether_addr_copy(dp_get_neigh_mac(port_id), &eth_hdr->dst_addr);
 	eth_hdr->ether_type = htons(eth_type);
 	rte_ether_addr_copy(dp_get_mac(port_id), &eth_hdr->src_addr);

--- a/src/nodes/cls_node.c
+++ b/src/nodes/cls_node.c
@@ -127,6 +127,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			df->flags.flow_type = DP_FLOW_TYPE_INCOMING;
 			extract_outter_ethernet_header(m);
 			rte_pktmbuf_adj(m, (uint16_t)sizeof(struct rte_ether_hdr));
+			m->packet_type &= ~RTE_PTYPE_L2_MASK;
 			return CLS_NEXT_OVERLAY_SWITCH;
 		} else {
 			extract_inner_ethernet_header(m);

--- a/src/nodes/ipip_tunnel_node.c
+++ b/src/nodes/ipip_tunnel_node.c
@@ -59,8 +59,10 @@ static __rte_always_inline rte_edge_t handle_ipip_tunnel_decap(struct rte_mbuf *
 		next_index = IPIP_TUNNEL_NEXT_FIREWALL;
 	}
 
-	if (next_index != IPIP_TUNNEL_NEXT_DROP)
+	if (next_index != IPIP_TUNNEL_NEXT_DROP) {
 		rte_pktmbuf_adj(m, (uint16_t)sizeof(struct rte_ipv6_hdr));
+		m->packet_type &= ~RTE_PTYPE_L3_MASK;
+	}
 
 	return next_index;
 }

--- a/src/nodes/l2_decap_node.c
+++ b/src/nodes/l2_decap_node.c
@@ -30,8 +30,10 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	struct dp_flow *df = get_dp_flow_ptr(m);
 
 	/* Pop the ethernet header */
-	if (df->flags.flow_type != DP_FLOW_TYPE_INCOMING)
+	if (df->flags.flow_type != DP_FLOW_TYPE_INCOMING) {
 		rte_pktmbuf_adj(m, (uint16_t)sizeof(struct rte_ether_hdr));
+		m->packet_type &= ~RTE_PTYPE_L2_ETHER;
+	}
 
 	if (dp_port_is_pf(df->nxt_hop))
 		return L2_DECAP_OVERLAY_SWITCH;


### PR DESCRIPTION
I added a logging for each layer of the packet, e.g.:
```
GRAPHTRACE: tx-0        #0: 0x17bc9fb80 >> PORT 0        : 90:3C:B3:33:72:FB -> 38:C9:31:7F:00:00 / 2a10:afc0:e01f:f403:0:0:0:1 -> 2a10:afc0:e01f:f408:0:64:0:0 / 172.32.10.5 -> 192.168.129.5 / ICMP 8-0
```

To be able to actually know the layer that is in the packet (as dp_service is removing and adding layers as the packet travels through the graph), I had to add code to change `rte_mbuf::pkt_type` as it currently was untouched after the packet gets received.

Since dp_service actually gets all subsequent packet info from its own `dp_flow`, this should not break anything (could potentially be better as mbuf now reflects reality?).

And as for performance, seeing as it is only a few bit operations (and a condition when tunelling), this should not be a problem.

If you find it to be a problem, I can add these changes under `#ifdefs` for graph tracing only (although that would mean that tracing on/off actually behave differently).