### PR TITLE
Added missing checks for packet prepend

### DIFF
--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -38,7 +38,7 @@ int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char if
 
 int dp_get_num_of_vfs();
 
-void rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type);
+int rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type);
 
 void dp_fill_ipv4_print_buff(unsigned int ip, char *buf);
 

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -89,15 +89,19 @@ int dp_get_num_of_vfs()
 	return vfs;
 }
 
-void rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type)
+int rewrite_eth_hdr(struct rte_mbuf *m, uint16_t port_id, uint16_t eth_type)
 {
 	struct rte_ether_hdr *eth_hdr;
 
 	eth_hdr = (struct rte_ether_hdr *)rte_pktmbuf_prepend(m, sizeof(struct rte_ether_hdr));
+	if (unlikely(!eth_hdr))
+		return DP_ERROR;
+
 	m->packet_type |= RTE_PTYPE_L2_ETHER;
 	rte_ether_addr_copy(dp_get_neigh_mac(port_id), &eth_hdr->dst_addr);
 	eth_hdr->ether_type = htons(eth_type);
 	rte_ether_addr_copy(dp_get_mac(port_id), &eth_hdr->src_addr);
+	return DP_OK;
 }
 
 


### PR DESCRIPTION
I was using the `rewrite_eth_hdr()` function and noticed it was not checked, so I added a return value. This should be rare, but I wouldn't optimize this out.

I also added logs, I think this should not happen often enough for it to be a problem.

What I am unsure about is the solution in tx_node, I chose the simpler, faster solution of just logging and sending out the wrong packet (i.e. no change from main). The proper solution would require breaking the burst in two, or something similar. Maybe I chose poorly, though?