### PR TITLE
Encapsulated dp_multipath calls

### DIFF
--- a/include/dp_multi_path.h
+++ b/include/dp_multi_path.h
@@ -1,26 +1,18 @@
 #ifndef __INCLUDE_DP_MULTI_PATH_H
 #define __INCLUDE_DP_MULTI_PATH_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "dp_port.h"
+void dp_multipath_init();
 
-#define port_select_table_size 10
-
-typedef enum{
-	OWNER_PORT,
-	PEER_PORT,
-} egress_pf_port;
-
-void fill_port_select_table(double frac);
-egress_pf_port calculate_port_by_hash(uint32_t hash);
-
+uint16_t dp_multipath_get_pf(uint32_t hash);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* __INCLUDE_DP_MULTI_PATH_H */

--- a/src/dp_service.c
+++ b/src/dp_service.c
@@ -128,8 +128,7 @@ static int init_interfaces()
 		|| DP_FAILED(dp_alias_init(pf0_socket)))
 		return DP_ERROR;
 
-	if (dp_conf_is_wcmp_enabled())
-		fill_port_select_table(dp_conf_get_wcmp_frac());
+	dp_multipath_init();
 
 	return DP_OK;
 }

--- a/src/nodes/ipv4_lookup_node.c
+++ b/src/nodes/ipv4_lookup_node.c
@@ -72,20 +72,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			return IPV4_LOOKUP_NEXT_DROP;
 	}
 
-	if (df_ptr->flags.flow_type == DP_FLOW_TYPE_OUTGOING) {
-		// rewrite outgoing port if WCMP algorithm decides to do so
-		if (dp_conf_is_wcmp_enabled()) {
-			egress_pf_port selected_port = calculate_port_by_hash(df_ptr->dp_flow_hash);
-			uint16_t owner_port_id = dp_port_get_pf0_id();
-			uint16_t peer_port_id = dp_port_get_pf1_id();
-			// basic logic of port redundancy if one of ports are down
-			if ((selected_port == PEER_PORT && dp_port_get_link_status(peer_port_id) == RTE_ETH_LINK_UP)
-				|| (selected_port == OWNER_PORT && dp_port_get_link_status(owner_port_id) == RTE_ETH_LINK_DOWN)
-			) {
-				df_ptr->nxt_hop = peer_port_id;
-			}
-		}
-	}
+	if (df_ptr->flags.flow_type == DP_FLOW_TYPE_OUTGOING)
+		df_ptr->nxt_hop = dp_multipath_get_pf(df_ptr->dp_flow_hash);
 
 	return IPV4_LOOKUP_NEXT_NAT;
 }


### PR DESCRIPTION
I needed to re-use the code for selecting the right PF for WCMP, so I moved the code into a function. Since I was rewriting half the file anyway I changed the init function name too.

The new code is written slightly differently, i.e. it always rewrites the PF port_id, as opposed to the old code which only did that when PF0 was not to be used. But given that PF0 was only ever the previous value, it is functionally the same.

I'm also tagging @byteocean so he can check I understood our previous slack conversation properly.