### PR TITLE
Fixed nat portmap table sizes

### DIFF
--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -33,13 +33,13 @@ int dp_nat_init(int socket_id)
 	if (!ipv4_dnat_tbl)
 		return DP_ERROR;
 
-	ipv4_netnat_portmap_tbl = dp_create_jhash_table(DP_NAT_TABLE_MAX, sizeof(struct netnat_portmap_key),
+	ipv4_netnat_portmap_tbl = dp_create_jhash_table(FLOW_MAX, sizeof(struct netnat_portmap_key),
 												  "ipv4_netnat_portmap_table", socket_id);
 
 	if (!ipv4_netnat_portmap_tbl)
 		return DP_ERROR;
 
-	ipv4_netnat_portoverload_tbl = dp_create_jhash_table(DP_NAT_TABLE_MAX, sizeof(struct netnat_portoverload_tbl_key),
+	ipv4_netnat_portoverload_tbl = dp_create_jhash_table(FLOW_MAX, sizeof(struct netnat_portoverload_tbl_key),
 												  "ipv4_netnat_portoverload_tbl", socket_id);
 
 	if (!ipv4_netnat_portoverload_tbl)


### PR DESCRIPTION
NAT portmap can run out of space in a hash table with
```
2023-02-17 11:31:04.601 3(worker) E SERVICE: Failed to add ipv4 network nat port overload key (Error 28: No space left on device) [../src/dp_nat.c:631:dp_allocate_network_snat_port()]
2023-02-17 11:31:04.601 3(worker) W GRAPH: snat: Failed to allocate a valid network nat port for 192.168.1.10:39728 [../src/nodes/snat_node.c:62:get_next_index()]
```

After talking to @byteocean this seems to be because of wrong table size specification in init, so we changed the parameter.