### PR TITLE
Do not re-create the config file, if it already exists

### DIFF
--- a/hack/prepare.sh
+++ b/hack/prepare.sh
@@ -108,6 +108,11 @@ function make_config() {
 }
 
 # main
+if [ -e $CONFIG ]; then
+    echo "File $CONFIG already exists"
+    exit
+fi
+
 validate
 get_pf
 validate_pf


### PR DESCRIPTION
Make a manual change to the config file possible. Otherwise init container will run this script and recreate the file even it already exists.
