### PR TITLE
Delete route function should only operate on its corresponding routes

### DIFF
--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -261,6 +261,7 @@ int dp_del_route(uint16_t portid, uint32_t vni, uint32_t t_vni,
 {
 	struct rte_rib_node *node;
 	struct rte_rib *root;
+	uint64_t next_hop;
 
 	RTE_VERIFY(socketid < DP_NB_SOCKETS);
 	RTE_VERIFY(portid < DP_MAX_PORTS);
@@ -270,10 +271,15 @@ int dp_del_route(uint16_t portid, uint32_t vni, uint32_t t_vni,
 		return EXIT_FAILURE;
 
 	node = rte_rib_lookup_exact(root, ip, depth);
-	if (node)
+	if (node) {
+		if (!DP_FAILED(rte_rib_get_nh(node, &next_hop))) {
+			if (next_hop != portid)
+				return EXIT_FAILURE;
+		}
 		rte_rib_remove(root, ip, depth);
-	else
+	} else {
 		return EXIT_FAILURE;
+	}
 
 	return EXIT_SUCCESS;
 }

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -464,7 +464,7 @@ static int dp_process_delprefix(dp_request *req, dp_reply *rep)
 	}
 
 	if (req->add_pfx.pfx_ip_type == RTE_ETHER_TYPE_IPV4) {
-		if (dp_del_route(dp_port_get_pf0_id(), dp_get_vm_vni(port_id), 0,
+		if (dp_del_route(port_id, dp_get_vm_vni(port_id), 0,
 					 ntohl(req->add_pfx.pfx_ip.pfx_addr), 0,
 					 req->add_pfx.pfx_length, rte_eth_dev_socket_id(dp_port_get_pf0_id()))) {
 			ret = DP_ERROR_VM_DEL_PFX;


### PR DESCRIPTION
If a route is installed for a specific port then should be only deletable if it is also requested to be deleted for that port.
