### PR TITLE
Improved graphtrace (bugfixes and better packet type recognition)

### DIFF
--- a/src/nodes/geneve_tunnel_node.c
+++ b/src/nodes/geneve_tunnel_node.c
@@ -81,7 +81,8 @@ static __rte_always_inline rte_edge_t handle_geneve_tunnel_decap(struct rte_mbuf
 	
 	rte_pktmbuf_adj(m, (uint16_t)sizeof(struct rte_udp_hdr));
 
-	m->packet_type &= ~(RTE_PTYPE_L4_MASK | RTE_PTYPE_L3_MASK);
+	// this shift is non-standard as the actual values of PTYPE should be opaque
+	m->packet_type = (m->packet_type & RTE_PTYPE_INNER_L4_MASK) >> 16;
 	
 	geneve_hdr = rte_pktmbuf_mtod(m, struct rte_flow_item_geneve*);
 	rte_memcpy(&df->tun_info.dst_vni, geneve_hdr->vni, sizeof(geneve_hdr->vni));

--- a/src/nodes/ipip_tunnel_node.c
+++ b/src/nodes/ipip_tunnel_node.c
@@ -40,6 +40,7 @@ static __rte_always_inline rte_edge_t handle_ipip_tunnel_decap(struct rte_mbuf *
 {
 	rte_edge_t next_index = IPIP_TUNNEL_NEXT_DROP;
 	struct dp_vnf_value *vnf_val;
+	uint8_t proto = df->tun_info.proto_id;
 
 	vnf_val = dp_get_vnf_value_with_key((void *)df->tun_info.ul_dst_addr6);
 	if (vnf_val) {
@@ -50,15 +51,17 @@ static __rte_always_inline rte_edge_t handle_ipip_tunnel_decap(struct rte_mbuf *
 		return IPIP_TUNNEL_NEXT_DROP;
 	}
 
-	if (df->tun_info.proto_id == DP_IP_PROTO_IPv4_ENCAP)
+	if (proto == DP_IP_PROTO_IPv4_ENCAP)
 		next_index = IPIP_TUNNEL_NEXT_IPV4_CONNTRACK;
 
-	if (df->tun_info.proto_id == DP_IP_PROTO_IPv6_ENCAP)
+	if (proto == DP_IP_PROTO_IPv6_ENCAP)
 		next_index = IPIP_TUNNEL_NEXT_IPV6_LOOKUP;
 
 	if (next_index != IPIP_TUNNEL_NEXT_DROP) {
 		rte_pktmbuf_adj(m, (uint16_t)sizeof(struct rte_ipv6_hdr));
-		m->packet_type &= ~RTE_PTYPE_L3_MASK;
+		// this shift is non-standard as the actual values of PTYPE should be opaque
+		m->packet_type = ((m->packet_type & RTE_PTYPE_INNER_L4_MASK) >> 16)
+						 | (proto == DP_IP_PROTO_IPv4_ENCAP ? RTE_PTYPE_L3_IPV4 : RTE_PTYPE_L3_IPV6);
 	}
 
 	return next_index;

--- a/src/nodes/ipv6_encap_node.c
+++ b/src/nodes/ipv6_encap_node.c
@@ -53,7 +53,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	rte_memcpy(ipv6_hdr->dst_addr, df->tun_info.ul_dst_addr6, sizeof(ipv6_hdr->dst_addr));
 	ipv6_hdr->proto = df->tun_info.proto_id;
 
-	if (RTE_ETH_IS_IPV4_HDR(m->packet_type))
+	if (ipv6_hdr->proto == IPPROTO_IPIP)
 		m->packet_type = RTE_PTYPE_L3_IPV6 | tunnel_type | RTE_PTYPE_INNER_L3_IPV4;
 	else
 		m->packet_type = RTE_PTYPE_L3_IPV6 | tunnel_type | RTE_PTYPE_INNER_L3_IPV6;


### PR DESCRIPTION
There was a problem with some tunneled packets not being marked by DPDK as tunneled, so improved my algorithm. Some of the encap type change was also wrong.

Also a bugfix for printing and a little bit of verbosity for easier match with TCPdump.