### PR TITLE
Added test-case for LB and VIP/NAT in different VNIs on one dp-service

### DIFF
--- a/test/config.py
+++ b/test/config.py
@@ -53,8 +53,8 @@ nat_neigh_min_port = 500
 nat_neigh_max_port = 520
 nat_neigh_ul_dst="2a10:afc0:e01f:f406:0:64::"
 pfx_ip = "174.23.4.0"
-mylb = "my_lb"
-lb_tcp_dst_port = 80
+lb_name = "my_lb"
+lb_ip = "174.12.3.4"
 
 MAX_LINES_ROUTE_REPLY = 36
 

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -22,7 +22,7 @@ class DpService:
 			script_path = os.path.dirname(os.path.abspath(__file__))
 			self.cmd = f"gdb -x {script_path}/gdbinit --args "
 
-		self.cmd += (f'{self.build_path}/src/dp_service -l 0,1 --no-pci'
+		self.cmd += (f'{self.build_path}/src/dp_service -l 0,1 --no-pci --log-level=user*:8'
 					f' --vdev=net_tap0,iface={pf0_tap},mac="{pf0_mac}"'
 					f' --vdev=net_tap1,iface={pf1_tap},mac="{pf1_mac}"'
 					f' --vdev=net_tap2,iface={vf0_tap},mac="{vf0_mac}"'

--- a/test/test_lb.py
+++ b/test/test_lb.py
@@ -1,17 +1,102 @@
+import pytest
+
 from helpers import *
 
 
 def test_network_lb_external_icmp_echo(prepare_ipv4, grpc_client):
 
-	ipv6_lb = grpc_client.createlb(mylb, vni, virtual_ip, 80, "tcp")
+	ipv6_lb = grpc_client.createlb(lb_name, vni, lb_ip, 80, "tcp")
 
 	icmp_pkt = (Ether(dst=mc_mac, src=pf0_mac, type=0x86DD) /
 				IPv6(dst=ipv6_lb, src=ul_actual_src, nh=4) /
-				IP(dst=virtual_ip, src=public_ip) /
+				IP(dst=lb_ip, src=public_ip) /
 				ICMP(type=8, id=0x0040))
 	answer = srp1(icmp_pkt, iface=pf0_tap, timeout=sniff_timeout)
 	validate_checksums(answer)
 	assert answer and is_icmp_pkt(answer), \
 		"No ECHO reply"
 
-	grpc_client.dellb(mylb)
+	grpc_client.dellb(lb_name)
+
+
+def router_loopback(dst_ipv6, check_ipv4_src, check_ipv4_dst):
+	pkt = sniff_packet(pf0_tap, is_tcp_pkt)
+	assert pkt[IP].dst == check_ipv4_dst, \
+		f"Invalid LB->VM destination IP {pkt[IP].dst}"
+	assert pkt[IP].src == check_ipv4_src, \
+		f"Bad request (src ip: {pkt[IP].src})"
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
+				 IPv6(dst=dst_ipv6, src=pkt[IPv6].dst, nh=4) /
+				 IP(src=pkt[IP].src, dst=pkt[IP].dst) /
+				 TCP(dport=pkt[TCP].dport, sport=pkt[TCP].sport))
+	delayed_sendp(reply_pkt, pf0_tap)
+
+def communicate_vip_lb(lb_ipv6, src_ipv6, src_ipv4, vf_tap, sport):
+	threading.Thread(target=router_loopback, args=(lb_ipv6, src_ipv4, lb_ip)).start()
+	# VM3(VIP) HTTP request to LB(VM1,VM2) server
+	vm_pkt = (Ether(dst=pf0_mac, src=vf2_mac, type=0x0800) /
+			   IP(dst=lb_ip, src=vf2_ip) /
+			   TCP(sport=sport, dport=80))
+	delayed_sendp(vm_pkt, vf2_tap)
+	# LB(VM1,VM2) server request from the router
+	srv_pkt = sniff_packet(vf_tap, is_tcp_pkt)
+	assert srv_pkt[IP].dst == lb_ip, \
+		f"Invalid LB->VM destination IP {srv_pkt[IP].dst}"
+	assert srv_pkt[TCP].dport == 80, \
+		"Invalid server port"
+
+	threading.Thread(target=router_loopback, args=(src_ipv6, lb_ip, src_ipv4)).start()
+	# HTTP response back to VIP(VM3)
+	srv_reply = (Ether(dst=srv_pkt[Ether].src, src=srv_pkt[Ether].dst, type=0x0800) /
+				 IP(dst=srv_pkt[IP].src, src=srv_pkt[IP].dst) /
+				 TCP(sport=srv_pkt[TCP].dport, dport=srv_pkt[TCP].sport))
+	delayed_sendp(srv_reply, vf_tap)
+	# HTTP response from the router on VM3(VIP)
+	vm_reply = sniff_packet(vf2_tap, is_tcp_pkt)
+	assert vm_reply[IP].dst == vf2_ip, \
+		f"Invalid VIPped destination IP {vm_reply[IP].dst}"
+	assert vm_reply[TCP].sport == 80, \
+		f"Invalid server reply port {vm_reply[TCP].sport}"
+
+def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy):
+
+	if port_redundancy:
+		pytest.skip("Port redundancy is not supported for LB(vni1) <-> VIP/NAT(vni2) test")
+
+	# establish a VM in another VNI on the same host
+	vm3_ipv6 = grpc_client.addmachine(vm3_name, "net_tap4", vni2, vf2_ip, vf2_ipv6)
+	grpc_client.addroute_ipv4(vni2, "0.0.0.0", 0, vni2, ul_actual_dst)
+	request_ip(vf2_tap, vf2_mac, vf2_ip)
+
+	lb_ipv6 = grpc_client.createlb(lb_name, vni, lb_ip, 80, "tcp")
+	lb_vm1_ipv6 = grpc_client.addlbpfx(vm1_name, lb_ip)
+	grpc_client.addlbvip(lb_name, lb_vm1_ipv6)
+	lb_vm2_ipv6 = grpc_client.addlbpfx(vm2_name, lb_ip)
+	grpc_client.addlbvip(lb_name, lb_vm2_ipv6)
+
+	vip_ipv6 = grpc_client.addvip(vm3_name, virtual_ip)
+	# Also test round-robin
+	communicate_vip_lb(lb_ipv6, vip_ipv6, virtual_ip, vf1_tap, 1234)
+	communicate_vip_lb(lb_ipv6, vip_ipv6, virtual_ip, vf1_tap, 1234)
+	communicate_vip_lb(lb_ipv6, vip_ipv6, virtual_ip, vf0_tap, 1235)
+	communicate_vip_lb(lb_ipv6, vip_ipv6, virtual_ip, vf1_tap, 1236)
+	communicate_vip_lb(lb_ipv6, vip_ipv6, virtual_ip, vf0_tap, 1237)
+	communicate_vip_lb(lb_ipv6, vip_ipv6, virtual_ip, vf0_tap, 1237)
+	grpc_client.delvip(vm3_name)
+
+	# NAT should behave the same, just test once (watch out for round-robin from before)
+	nat_ipv6 = grpc_client.addnat(vm3_name, nat_vip, nat_local_min_port, nat_local_max_port)
+	communicate_vip_lb(lb_ipv6, nat_ipv6, nat_vip, vf1_tap, 1240)
+	grpc_client.delnat(vm3_name)
+
+	grpc_client.dellbvip(vm2_name, lb_vm2_ipv6)
+	grpc_client.dellbpfx(vm2_name, lb_ip)
+	grpc_client.dellbvip(vm1_name, lb_vm1_ipv6)
+	grpc_client.dellbpfx(vm1_name, lb_ip)
+	grpc_client.dellb(lb_name)
+
+	grpc_client.delroute_ipv4(vni2, "0.0.0.0", 0)
+	grpc_client.delmachine(vm3_name)
+
+	# NOTE: this test, just like in test_pf_to_vf.py
+	# cannot be run twice in a row, since the flows need to age-out

--- a/test/test_pf_to_vf.py
+++ b/test/test_pf_to_vf.py
@@ -6,24 +6,28 @@ from helpers import *
 def send_lb_pkt_to_pf(lb_ipv6):
 	lb_pkt = (Ether(dst=mc_mac, src=pf0_mac, type=0x86DD) /
 			  IPv6(dst=lb_ipv6, src=ul_actual_src, nh=4) /
-			  IP(dst=virtual_ip, src=public_ip) /
+			  IP(dst=lb_ip, src=public_ip) /
 			  TCP(sport=1234, dport=80))
 	delayed_sendp(lb_pkt, pf0_tap)
 
 def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 
-	lb_ipv6 = grpc_client.createlb(mylb, vni, virtual_ip, 80, "tcp")
-	lbpfx_ipv6 = grpc_client.addlbpfx(vm1_name, virtual_ip)
-	grpc_client.addlbvip(mylb, lbpfx_ipv6)
+	lb_ipv6 = grpc_client.createlb(lb_name, vni, lb_ip, 80, "tcp")
+	lbpfx_ipv6 = grpc_client.addlbpfx(vm1_name, lb_ip)
+	grpc_client.addlbvip(lb_name, lbpfx_ipv6)
 
 	threading.Thread(target=send_lb_pkt_to_pf, args=(lb_ipv6,)).start()
 
 	pkt = sniff_packet(vf0_tap, is_tcp_pkt)
 	dst_ip = pkt[IP].dst
 	dport = pkt[TCP].dport
-	assert dst_ip == virtual_ip and dport == 80, \
+	assert dst_ip == lb_ip and dport == 80, \
 		f"Wrong packet received (ip: {dst_ip}, dport: {dport})"
 
 	grpc_client.dellbvip(vm1_name, lbpfx_ipv6)
-	grpc_client.dellbpfx(vm1_name, virtual_ip)
-	grpc_client.dellb(mylb)
+	grpc_client.dellbpfx(vm1_name, lb_ip)
+	grpc_client.dellb(lb_name)
+
+	# TODO: Currently, to use this test again with the same port(s)
+	# you need to wait for the used flow to be aged-out (done every 30s)
+	# If TCP RST is implemented down the line, this can be overcome

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -67,23 +67,23 @@ def test_grpc_add_list_delVIP(prepare_ifaces, grpc_client):
 
 def test_grpc_add_list_delLBVIP(prepare_ifaces, grpc_client):
 	# Try to add LB VIP, list, test error cases, delete vip and list again
-	ul_ipv6 = grpc_client.createlb(mylb, vni, virtual_ip, 80, "tcp")
-	grpc_client.addlbvip(mylb, back_ip1)
-	grpc_client.assert_output(f"--listbackips {mylb}",
+	ul_ipv6 = grpc_client.createlb(lb_name, vni, lb_ip, 80, "tcp")
+	grpc_client.addlbvip(lb_name, back_ip1)
+	grpc_client.assert_output(f"--listbackips {lb_name}",
 		back_ip1)
-	grpc_client.addlbvip(mylb, back_ip2)
-	grpc_client.assert_output(f"--listbackips {mylb}",
+	grpc_client.addlbvip(lb_name, back_ip2)
+	grpc_client.assert_output(f"--listbackips {lb_name}",
 		back_ip2)
-	grpc_client.dellbvip(mylb, back_ip1)
-	grpc_client.assert_output(f"--listbackips {mylb}",
+	grpc_client.dellbvip(lb_name, back_ip1)
+	grpc_client.assert_output(f"--listbackips {lb_name}",
 		back_ip1, negate=True)
-	grpc_client.dellbvip(mylb, back_ip2)
-	grpc_client.assert_output(f"--listbackips {mylb}",
+	grpc_client.dellbvip(lb_name, back_ip2)
+	grpc_client.assert_output(f"--listbackips {lb_name}",
 		back_ip2, negate=True)
-	grpc_client.assert_output(f"--getlb {mylb}",
+	grpc_client.assert_output(f"--getlb {lb_name}",
 		ul_ipv6)
-	grpc_client.dellb(mylb)
-	grpc_client.assert_output(f"--getlb {mylb}",
+	grpc_client.dellb(lb_name)
+	grpc_client.assert_output(f"--getlb {lb_name}",
 		ul_ipv6, negate=True)
 
 def test_grpc_add_list_delPfx(prepare_ifaces, grpc_client):


### PR DESCRIPTION
This the equivalent test to the previous NAT-VIP test and fix.

I have also confirmed that the implemented fix covers this situation (i.e. this test was not able to pass before).

(And I left `--log-level=user*:8` in there because I always add it locally, hope that's OK.)