### PR TITLE
Added freeup calls for hash tables

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -121,6 +121,7 @@ bool dp_flow_exists(struct flow_key *key);
 int8_t dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(struct flow_key *key /* in / out */);
 int dp_flow_init(int socket_id);
+void dp_flow_free();
 void dp_process_aged_flows(int port_id);
 void dp_process_aged_flows_non_offload(void);
 void dp_free_flow(struct dp_ref *ref);

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -30,6 +30,7 @@ struct lb_value {
 };
 
 int dp_lb_init(int socket_id);
+void dp_lb_free();
 bool dp_is_ip_lb(uint32_t vm_ip, uint32_t vni);
 uint32_t dp_get_lb_ip(uint32_t vm_ip, uint32_t vni);
 uint8_t *dp_lb_get_backend_ip(uint32_t v_ip, uint32_t vni, uint16_t port, uint16_t proto);

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -77,6 +77,7 @@ int lpm_get_ip6_dst_port(int port_id, int t_vni, const struct rte_ipv6_hdr *ipv6
 						 struct vm_route *r, int socketid);
 
 int dp_lpm_init(int socket_id);
+void dp_lpm_free();
 int dp_map_vm_handle(void *key, uint16_t portid);
 int dp_get_portid_with_vm_handle(void *key);
 void dp_del_portid_with_vm_handle(void *key);

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -71,6 +71,7 @@ struct nat_check_result {
 };
 
 int dp_nat_init(int socket_id);
+void dp_nat_free();
 void dp_del_vm_snat_ip(uint32_t vm_ip, uint32_t vni);
 uint32_t dp_get_vm_snat_ip(uint32_t vm_ip, uint32_t vni);
 int dp_set_vm_snat_ip(uint32_t vm_ip, uint32_t s_ip, uint32_t vni, uint8_t *ul_ipv6);

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -36,6 +36,7 @@ struct dp_vnf_value {
 };
 
 int dp_vnf_init(int socket_id);
+void dp_vnf_free();
 int dp_set_vnf_value(void *key, struct dp_vnf_value *val);
 struct dp_vnf_value *dp_get_vnf_value_with_key(void *key);
 int dp_get_portid_with_vnf_key(void *key, enum vnf_type v_type);

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -24,6 +24,11 @@ int dp_flow_init(int socket_id)
 	return DP_OK;
 }
 
+void dp_flow_free()
+{
+	dp_free_jhash_table(ipv4_flow_tbl);
+}
+
 static int8_t dp_build_icmp_flow_key(struct dp_flow *df_ptr, struct flow_key *key /* out */, struct rte_mbuf *m /* in */)
 {
 	struct dp_icmp_err_ip_info icmp_err_ip_info = {0};

--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -29,6 +29,12 @@ int dp_lb_init(int socket_id)
 	return DP_OK;
 }
 
+void dp_lb_free()
+{
+	dp_free_jhash_table(id_map_lb_tbl);
+	dp_free_jhash_table(ipv4_lb_tbl);
+}
+
 static int dp_map_lb_handle(void *id_key, struct lb_key *l_key, struct lb_value *l_val)
 {
 	struct lb_key *lb_k;

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -33,6 +33,11 @@ int dp_lpm_init(int socket_id)
 	return DP_OK;
 }
 
+void dp_lpm_free()
+{
+	dp_free_jhash_table(vm_handle_tbl);
+}
+
 int dp_map_vm_handle(void *key, uint16_t portid)
 {
 	uint16_t *p_port_id;

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -50,6 +50,14 @@ int dp_nat_init(int socket_id)
 	return DP_OK;
 }
 
+void dp_nat_free()
+{
+	dp_free_jhash_table(ipv4_netnat_portoverload_tbl);
+	dp_free_jhash_table(ipv4_netnat_portmap_tbl);
+	dp_free_jhash_table(ipv4_dnat_tbl);
+	dp_free_jhash_table(ipv4_snat_tbl);
+}
+
 int dp_check_if_ip_natted(uint32_t vm_ip, uint32_t vni, struct nat_check_result *result)
 {
 	struct nat_key nkey;

--- a/src/dp_service.c
+++ b/src/dp_service.c
@@ -142,31 +142,36 @@ static int init_interfaces()
 
 static void free_interfaces()
 {
+	dp_vnf_free();
+	dp_lpm_free();
+	dp_lb_free();
+	dp_nat_free();
+	dp_flow_free();
+	// ports seem to be stopped by DPDK at the end
 	dp_telemetry_free();
 	dp_graph_free();
 #ifdef ENABLE_VIRTSVC
 	dp_virtsvc_free();
 #endif
 	dp_ports_free();
+	// dp_multipath has no free
 }
 
 static inline int run_dpdk_service()
 {
-	int result;
+	int result = DP_ERROR;
 
-	if (DP_FAILED(init_interfaces()))
-		return DP_ERROR;
-
-	if (DP_FAILED(dp_grpc_thread_start()))
-		return DP_ERROR;
+	if (DP_FAILED(init_interfaces())
+		|| DP_FAILED(dp_grpc_thread_start()))
+		goto end;
 
 	result = dp_dpdk_main_loop();
 
 	if (DP_FAILED(dp_grpc_thread_join()))
 		result = DP_ERROR;
 
+end:
 	free_interfaces();
-
 	return result;
 }
 

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -137,7 +137,6 @@ static uint32_t dp_jhash_nwords(const void *key, uint32_t length, uint32_t initv
 	return rte_jhash_32b(key, length / 4, initval);
 }
 
-// TODO(plague): free() is rarely used
 struct rte_hash *dp_create_jhash_table(int entries, size_t key_len, const char *name, int socket_id)
 {
 	struct rte_hash *result;

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -15,6 +15,11 @@ int dp_vnf_init(int socket_id)
 	return DP_OK;
 }
 
+void dp_vnf_free()
+{
+	dp_free_jhash_table(vnf_handle_tbl);
+}
+
 int dp_set_vnf_value(void *key, struct dp_vnf_value *val)
 {
 	struct dp_vnf_value *temp_val;

--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -165,6 +165,8 @@ int dp_dpdk_main_loop(void)
 	ret = rte_eal_mp_remote_launch(graph_main_loop, NULL, SKIP_MAIN);
 	if (DP_FAILED(ret)) {
 		DPS_LOG_ERR("Cannot launch lcores %s", dp_strerror(ret));
+		// custom threads are already running, stop them
+		dp_force_quit();
 		return ret;
 	}
 

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -30,7 +30,6 @@ static int create_flow(int port_id,
 }
 
 // TODO(plague): retval checking is not finished here, just bare minimum done
-// TODO(plague): these two look too similar, maybe it can be refactored
 int dp_install_isolated_mode_ipip(int port_id, uint8_t proto_id)
 {
 


### PR DESCRIPTION
I added free() calls for hash tables in multiple places (I had a TODO in the jhash creation code that this is actually never done).

Of course this is not *really* needed as the OS (and in this case even DPDK in hugepages) frees up memory after the process ends, but for any future changes or validation, I think it should be better this way.
(If that was the intention, I think it would need to be done consistently as some things are being freed and some are not).

There was also an edge-case where not starting graph loop would not end gRPC, thus hang the process.