### PR TITLE
Feature/virtsvc update

### DIFF
--- a/include/dp_virtsvc.h
+++ b/include/dp_virtsvc.h
@@ -9,6 +9,9 @@ extern "C" {
 #include <rte_hash.h>
 #include <rte_telemetry.h>
 
+// limit number of services to one byte due to various implementation reasons
+#define DP_VIRTSVC_MAX 256
+
 #define DP_NB_SYSTEM_PORTS 1024
 #define DP_VIRTSVC_PORTCOUNT (UINT16_MAX+1 - DP_NB_SYSTEM_PORTS)
 

--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -176,6 +176,11 @@ static int add_virtsvc(uint16_t proto, const char *str)
 	char *tok;
 	char *endptr;
 
+	if (virtual_services.nb_entries >= DP_VIRTSVC_MAX) {
+		DP_EARLY_ERR("Number of virtual services is limited to %u", DP_VIRTSVC_MAX);
+		return DP_ERROR;
+	}
+
 	// strtok() is destructive, make a copy
 	snprintf(parse_str, sizeof(parse_str), "%s", str);
 

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -41,6 +41,7 @@ static uint8_t classless_route[sizeof(classless_route_prefix) + sizeof(server_ip
 //   169.254.1.0/24 -> server_ip
 static const uint8_t virtsvc_route_prefix[] = { 24, 169, 254, 1 };
 static uint8_t classless_route[sizeof(classless_route_prefix) + sizeof(server_ip) + sizeof(virtsvc_route_prefix) + sizeof(server_ip)];
+_Static_assert(DP_VIRTSVC_MAX <= UINT8_MAX+1, "Number of virtual services can be higher than supported link-local subnet size");
 #endif
 
 


### PR DESCRIPTION
As virtual services are mapped to link-local addresses in OSC, I added a route for them at 169.254.1.0/24 so they actually reach dp_service.

I also limited number of possible virtual service to 256. This reduces implementation complexity in telemetry (as it can only provide 256 dictionary entries per level) and enables the above route to be limited to one specific /24 subnet.