### PR TITLE
Updated documentation after testing on Debian 12

### DIFF
--- a/docs/deployment/tcpdump.md
+++ b/docs/deployment/tcpdump.md
@@ -1,0 +1,28 @@
+# Dataplane service packet analysis using tcpdump
+Due to the fact, that dp-service uses DPDK and thus a poll-mode driver (PMD) instead of kernel network stack, traditional tools are unable to see traffic passing through dp-service-bound network cards.
+
+## Offloaded mode
+Unfortunately, there is no way to see traffic going directly through the card itself as it never enters the host's I/O layer.
+
+## Non-offloaded mode
+Normally, all traffic goes though the PMD and is accessed by the host's CPU via RDMA (Remote Direct Memory Access). `libpcap` (the library tcpdump uses) has support for RDMA devices and can use hardware-specific bindings to provide a virtual network interface for tcpdump (and other libpcap-based tools) to listen on.
+
+For Mellanox cards, such interfaces are usually `mlx5_0` and `mlx5_1` (given that the kernel driver used is `mlx5`). `mlx5_0` then shows traffic for the first physical port and **all** virtual ports (VMs) in one stream. `mlx5_1` only shows traffic for the secondary physical port.
+
+This support is not enabled by default though.
+
+### Enabling RDMA support in libpcap
+If `libibverbs` library is installed during configuration and compilation of `libpcap`, RDMA support gets compiled-in. As this is not the case for packages provided by the standard distributions' package trees, `libpcap` needs to be recompiled manually.
+
+#### Debian
+A good place to start with is the [building tutorial](https://wiki.debian.org/BuildingTutorial). There is no need to actually do any changes whatsoever, just make sure `libibverbs-dev` is installed first and then build `libpcap0.8` from source and install it using `dpkg -i`.
+
+To prevent the system from re-installing the original package, you need to provide a repository do download the manually-compiled package from. The simplest way is to use [a local repository](https://wiki.debian.org/DebianRepository/Setup#Quick_instructions_to_create_a_trivial_local_archive_with_apt-ftparchive).
+
+### AppArmor
+Because of the changed behavior of custom-built tcpdump package, changes to AppArmor rules are needed. On Debian this is done easily by adding rules to `/etc/apparmor.d/local/usr.bin.tcpdump`:
+```
+  /etc/libibverbs.d/ r,
+  /etc/libibverbs.d/* r,
+  /dev/infiniband/* rw,
+```

--- a/docs/testing/performance.md
+++ b/docs/testing/performance.md
@@ -1,27 +1,47 @@
-# Test environment
-The performace test for dp-service can be carried out in several ways, including normal iperf tests and stress tests again relying on DPDK. Iperf tests usually cannot generate traffic at line rate to fully discover the capacity of dpdk applications. Thus, this page is mostly dedicated to stress tests relying on DPDK.
+# Testing performance
+Performace testing of dp-service can be carried out in several ways, including more traditional methods (iperf) and stress-tests relying on DPDK (pktgen).
 
-To perform such stress tests, the current solution is to use [pktgen](https://pktgen-dpdk.readthedocs.io/en/latest/) inside virtual machines. One is for generating traffic and the other one is for observing incoming flow rates.
-
-## How to use pktgen
-To install pktgen inside VM, DPDK related libraries and Mellanox related drivers needs to be firstly installed or activated. The details regarding this can be found [here](kernel.md#mellanox-drivers). And a library named 'libibverbs-dev' also needs to be installed. After DPDK is in place, pktgen can be compiled and installed as following:
-
+## iPerf
+On one VM (server):
 ```
-PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig meson build
-ninja -C build
-sudo ninja -C build install
+iperf -s
 ```
 
-Now, we can use pktgen to generate and receive traffic. In each VM, firstly configure hugepage using `echo 1024 > /proc/sys/vm/nr_hugepages`
-
-Then start pktgen as following and for the meaning of the configuration parameters, please find [here](https://pktgen-dpdk.readthedocs.io/en/latest/usage_pktgen.html).
-
+On the other VM (client):
 ```
-LD_LIBRARY_PATH=/usr/local/lib64 /usr/local/bin/pktgen -l 1-4 -n 2  -- -P -m '[2-5].0' -T
+iperf -c <server IP> -i1
 ```
 
-An example piece of code is provided here to generate UDP traffic in one direction, the details of commands can be found [here](https://pktgen-dpdk.readthedocs.io/en/latest/commands.html#runtime-options-and-commands):
+> Iperf tests usually cannot generate traffic at line rate to fully discover the capacity of DPDK applications.
 
+## Pktgen
+To perform stress tests, the current solution is to use [pktgen](https://pktgen-dpdk.readthedocs.io/en/latest/) inside virtual machines. One is for generating traffic and the other one is for observing incoming flow rates.
+
+### Installing pktgen
+To install pktgen inside a VM, DPDK and related libraries and NIC-related drivers need to be installed and working. To achieve this, please follow the instructions for [building](../development/building.md) and [running](../development/running.md) of dp-service, stopping at the point of actually using dp-service (since pktgen is 'just' another DPDK application, like dp-service).
+
+Additionaly, DPDK for pktgen needs to be installed with `libpcap-dev` and `libnuma-dev` (and `libibverbs-dev` for Mellanox cards). After DPDK is installed, pktgen can be compiled and installed as follows:
+
+```
+wget https://github.com/pktgen/Pktgen-DPDK/archive/refs/tags/pktgen-21.11.0.zip
+unzip pktgen-21.11.0.zip
+cd Pktgen-DPDK-tags-pktgen-21.11.0
+make
+cp usr/local/bin/pktgen /usr/local/bin/
+```
+
+This guide is using the same DPDK for Pktgen as for dp-service. If you want to use newer DPDK and pktgen, build and install using `meson build && ninja -C build && sudo ninja -C build install` instead.
+
+### Using pktgen
+To run, pktgen (as any DPDK application) requires [hugepages](../development/running.md#huge-pages). Also make sure the VM's CPU supports SSSE3.
+
+To generate traffic, start pktgen like this (see [pktgen docs](https://pktgen-dpdk.readthedocs.io/en/latest/usage_pktgen.html) for explanation).
+
+```
+pktgen -l 1-4 -n 2  -- -P -m '[2-5].0' -T -f test.conf
+```
+
+The `test.conf` file is an example provided here to generate UDP traffic in one direction, for details see [pktgen docs](https://pktgen-dpdk.readthedocs.io/en/latest/commands.html#runtime-options-and-commands):
 ```
 stop 0
 set 0 rate 40
@@ -29,19 +49,22 @@ set 0 ttl 3
 set 0 proto udp
 set 0 src mac be:41:c3:aa:10:54 
 set 0 dst mac ab:cd:00:00:00:01
-set 0 dst ip dst_ip
-set 0 src ip src_ip/32
+set 0 dst ip <dst_vm_ip>
+set 0 src ip <src_vm_ip>/32
 set 0 size 128
+start 0
 ```
+To run pktgen on the receiving side, you can use this file and simply switch `src` and `dst`.
 
-## How to use Intel's Profiler
+## VTune by Intel
 In addition to the above described stress test, it is also possible to [profile](https://www.intel.com/content/www/us/en/developer/articles/technical/profile-dpdk-with-intel-vtune-amplifier.html) DPDK applications' code. 
 
 An official docker [image](https://hub.docker.com/r/intel/oneapi-vtune) is provided. Thus start this docker image with `sudo docker run -it --rm --net host -v /home/tli/.ssh:/etc/ssh -d intel/oneapi-vtune vtune-backend --allow-remote-access`, and its URL to log in can be found in the container's log. The steps to run a profiling test can be found [here](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-vtune/top/linux-os.html).
 
 One limitation for such code profiler for the DPDK application is that the identified function that consumes many CPU cycles may not be a complex function, but due to too many repetitions of it during the CPU polling without actual incoming packets. Thus, this code profiling is used as a first impression on code complexity. In the end, the actual stress tests using packet injection matters.
 
-# Guidelines to optimize non-offloading performance
+
+# Performance optimization (non-offloading)
 Several aspects can be explored to perform such host optimization. Intel provides an official [documentation](http://doc.dpdk.org/guides/prog_guide/writing_efficient_code.html) and a [blog](https://www.intel.com/content/www/us/en/developer/articles/guide/dpdk-performance-optimization-guidelines-white-paper.html) dedicated for this topic. 
 We highlight several points that were tested and summarize their impacts. 
 
@@ -49,44 +72,31 @@ We highlight several points that were tested and summarize their impacts.
 A proper running environment is important to achieve good performance. Two important host optimization directions are:
 
 ### Numa
-Enforce to use CPU cores that share the socket with NIC. This optimization can enable observable performance enhancement.  
+Enforce to use CPU cores that share the socket with NIC. This optimization can enable observable performance enhancement.
 
-Use the following command to find out NIC's numa node 
-`
-cat /sys/bus/pci/devices/0000\:06\:00.0/numa_node
-`
+Use the following command to find out NIC's numa node: `cat /sys/bus/pci/devices/0000\:06\:00.0/numa_node`
 
-And check the numa node attachment of CPU cores:
-
-`
-/dpdk/usertools/cpu_layout.py
-`
+And check the numa node attachment of CPU cores: `/dpdk/usertools/cpu_layout.py`
 
 ### CPU isolation
-Isolating CPU core that is used by DPDK application and removing it from Linux scheduler is mentioned in the above optimization document. The experiment was carried out on a lenovo machine as following:
-
-```
-1. add 'isolcpus=2' to GRUB_CMDLINE_LINUX_DEFAULT from the file /etc/default/grub
-2. run update-grub to make it take effect
-3. reboot
-```
+Isolating CPU core that is used by DPDK application and removing it from Linux scheduler is mentioned in the above optimization document. The experiment was carried out on a lenovo machine as follows:
+1. Add `isolcpus=2` to `GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub`,
+2. run `update-grub` to make it take effect,
+3. reboot.
 
 This approach does not bring observable performance enhancement. It is possibly due to it is experimented on a machine with few tasks.
 
 ## Compilation optimization
-By default, DPDK library is configured to compile as the release mode. dp-service needs to be configured in the release mode as well using `
-meson build --buildtype=release
-`.
+By default, DPDK library is configured to compile as the release mode. dp-service needs to be configured in the release mode as well using `meson build --buildtype=release`.
 
 This brings observable performance enhancement.
 
 Additional flags (-march=native -mcpu=native -mtune=native) to compile source code for the native platform can be also added into meson build file. 
-
-`
+```
 project('dp_service', 'c', 'cpp',
   default_options: ['c_args=-Wno-deprecated-declarations -march=native -mcpu=native -mtune=native -Werror -Wno-format-truncation', 'cpp_args=-fpermissive'],
   ...
-`
+```
 
 This does not bring observable performance enhancement.
 
@@ -104,5 +114,3 @@ Using the graph node framework also brings non-negligible performance penalty, d
 
 ### Move pkts more efficiently
 Avoiding to move packets one by one from one node to another can bring observable peformance enhancement. One of the ways is to use functions like `rte_node_next_stream_move`. But due to the fact that you have to give hints on the most highly possible next node, it is applicable for some nodes with few next node options.
-
-


### PR DESCRIPTION
I reworked the documentation for first-time build/use of dp_service as there was misinformation about mellanox firmware tools.

I added more information to the performance testing docs that I lacked during my preparation of the tests.

I also documented the tcpdump compilation for RDMA devices.