### PR TITLE
Fixed buffer overruns in DHCPv6 node, fixed non-RFC behavior, refactor

### DIFF
--- a/include/nodes/dhcpv6_node.h
+++ b/include/nodes/dhcpv6_node.h
@@ -2,135 +2,15 @@
 #define __INCLUDE_DHCPV6_NODE_H__
 
 #include <stdint.h>
-#include <rte_ether.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define	DHCPV6_CLIENT_PORT 546
-#define	DHCPV6_SERVER_PORT 547
-
-#define DHCPV6_FIXED_LEN	4
-#define DP_UDP_HDR_SZ	8
-#define OPTIONS_INDEX 4
-#define INFINITY 0xffffffff
-#define DP_DUMMY_HW_ID	0xabcd
-/*
- * DHCPv6 message types
- */
-#define DHCPV6_SOLICIT		    1
-#define DHCPV6_ADVERTISE	    2
-#define DHCPV6_REQUEST		    3
-#define DHCPV6_CONFIRM		    4
-#define DHCPV6_RENEW		    5
-#define DHCPV6_REBIND		    6
-#define DHCPV6_REPLY		    7
-#define DHCPV6_RELEASE		    8
-#define DHCPV6_DECLINE		    9
-#define DHCPV6_RECONFIGURE	   10
-
-/*
- * Status Codes
- */
-#define STATUS_Success	0
-#define STATUS_UnspecFail	1
-#define STATUS_NoAddrsAvail	2
-#define STATUS_NoBinding	3
-#define STATUS_NotOnLink	4
-
-/* DUID types
- */
-#define DP_DUID_LLT	1
-#define DP_DUID_EN	2
-#define DP_DUID_LL	3
-#define DP_DUID_UUID	4
-
-/* DHCPv6 Option codes: */
-#define DP_CLIENTID	1
-#define DP_SERVERID	2
-#define DP_IA_NA	3
-#define DP_IA_TA	4
-#define DP_IAADDR	5
-#define DP_STATUS_CODE	13
-#define DP_RAPID_COMMIT	14
-#define DP_IA_PD	25
-#define DP_IAPREFIX	26
-
-/*
- * Normal packet format
- */
-struct dhcpv6_packet {
-	uint8_t msg_type;
-	uint8_t transaction_id[3];
-	uint8_t options[];
-};
-
-struct duid_t {
-	uint16_t type;
-	uint16_t hw_type;
-	struct rte_ether_addr mac;
-};
-
-struct server_id {
-	uint16_t op;
-	uint16_t len;
-	struct duid_t id;
-};
-
-struct client_id {
-	uint16_t op;
-	uint16_t len;
-	uint8_t id[128];
-};
-
-struct rapid_commit {
-	uint16_t op;
-	uint16_t len;
-};
-
-struct status_code {
-	uint16_t op;
-	uint16_t len;
-	uint16_t status;
-};
-
-struct ia_addr {
-	uint8_t in6_addr[16];
-	int32_t time_1;
-	int32_t time_2;
-	struct status_code code;
-};
-
-struct ia_addr_option {
-	uint16_t op;
-	uint16_t len;
-	struct ia_addr addr;
-
-};
-
-struct ia {
-	uint16_t ia_id;
-	int32_t time_1;
-	int32_t time_2;
-	struct ia_addr_option addrv6;
-};
-
-struct ia_option {
-	uint16_t op;
-	uint16_t len;
-	struct ia val;
-};
-
-struct dhcpv6_option {
-	uint16_t op_code;
-	uint16_t op_len;
-	uint8_t data[];
-};
 
 int dhcpv6_node_append_vf_tx(uint16_t port_id, const char *tx_node_name);
 
 #ifdef __cplusplus
 }
 #endif
+
 #endif

--- a/include/protocols/dp_dhcpv6.h
+++ b/include/protocols/dp_dhcpv6.h
@@ -1,0 +1,145 @@
+#ifndef __INCLUDE_DP_DHCPV6_H__
+#define __INCLUDE_DP_DHCPV6_H__
+
+#include <stdint.h>
+#include <rte_ether.h>
+
+#define	DHCPV6_CLIENT_PORT	546
+#define	DHCPV6_SERVER_PORT	547
+
+#define DHCPV6_INFINITY 0xffffffff
+
+/*
+ * Message types
+ */
+#define DHCPV6_SOLICIT		1
+#define DHCPV6_ADVERTISE	2
+#define DHCPV6_REQUEST		3
+#define DHCPV6_CONFIRM		4
+#define DHCPV6_RENEW		5
+#define DHCPV6_REBIND		6
+#define DHCPV6_REPLY		7
+#define DHCPV6_RELEASE		8
+#define DHCPV6_DECLINE		9
+#define DHCPV6_RECONFIGURE	10
+
+/*
+ * Status Codes
+ */
+#define DHCPV6_STATUS_SUCCESS		0
+#define DHCPV6_STATUS_UNSPECFAIL	1
+#define DHCPV6_STATUS_NOADDRSAVAIL	2
+#define DHCPV6_STATUS_NOBINDING		3
+#define DHCPV6_STATUS_NOTONLINK		4
+
+/*
+ * DUID types
+ */
+#define DHCPV6_DUID_LLT		1
+#define DHCPV6_DUID_EN		2
+#define DHCPV6_DUID_LL		3
+#define DHCPV6_DUID_UUID	4
+
+/*
+ * Option codes
+ */
+#define DHCPV6_OPT_CLIENTID		1
+#define DHCPV6_OPT_SERVERID		2
+#define DHCPV6_OPT_IA_NA		3
+#define DHCPV6_OPT_IA_TA		4
+#define DHCPV6_OPT_IAADDR		5
+#define DHCPV6_OPT_STATUS_CODE	13
+#define DHCPV6_OPT_RAPID_COMMIT	14
+#define DHCPV6_OPT_IA_PD		25
+#define DHCPV6_OPT_IAPREFIX		26
+
+// General definitions as per RFC
+struct dhcpv6_packet {
+	uint8_t msg_type;
+	uint8_t transaction_id[3];
+	uint8_t options[];
+};
+
+struct dhcpv6_option {
+	uint16_t op_code;
+	uint16_t op_len;
+	uint8_t data[];
+};
+
+// client id can be of any type, this is the maximum size allowed
+struct dhcpv6_opt_client_id {
+	uint16_t op_code;
+	uint16_t op_len;
+	uint8_t id[128];
+};
+
+struct dhcpv6_ia_na {
+	uint32_t iaid;
+	uint32_t t1;
+	uint32_t t2;
+	struct dhcpv6_option options[];
+};
+
+struct dhcpv6_opt_ia_na {
+	uint16_t op_code;
+	uint16_t op_len;
+	struct dhcpv6_ia_na ia_na;
+};
+
+struct dhcpv6_ia_addr {
+	uint8_t  ipv6[16];
+	uint32_t preferred_lifetime;
+	uint32_t valid_lifetime;
+	struct dhcpv6_option options[];
+};
+
+struct dhcpv6_opt_ia_addr {
+	uint16_t op_code;
+	uint16_t op_len;
+	struct dhcpv6_ia_addr addr;
+};
+
+struct dhcpv6_opt_status_code {
+	uint16_t op_code;
+	uint16_t op_len;
+	uint16_t status;
+};
+
+struct dhcpv6_duid_ll {
+	uint16_t type;
+	uint16_t hw_type;
+	struct rte_ether_addr mac;
+};
+
+// Specific definitions for easier work with options in dp-service
+
+struct dhcpv6_opt_server_id_ll {
+	uint16_t op_code;
+	uint16_t op_len;
+	struct dhcpv6_duid_ll id;
+};
+
+struct dhcpv6_ia_addr_status {
+	uint8_t  ipv6[16];
+	uint32_t preferred_lifetime;
+	uint32_t valid_lifetime;
+	struct dhcpv6_opt_status_code options[1];
+};
+struct dhcpv6_opt_ia_addr_status {
+	uint16_t op_code;
+	uint16_t op_len;
+	struct dhcpv6_ia_addr_status addr;
+};
+struct dhcpv6_ia_na_single_addr_status {
+	uint32_t iaid;
+	uint32_t t1;
+	uint32_t t2;
+	struct dhcpv6_opt_ia_addr_status options[1];
+};
+struct dhcpv6_opt_ia_na_single_addr_status {
+	uint16_t op_code;
+	uint16_t op_len;
+	struct dhcpv6_ia_na_single_addr_status ia_na;
+};
+
+#endif

--- a/src/dp_graph.c
+++ b/src/dp_graph.c
@@ -1,4 +1,5 @@
 #include "dp_graph.h"
+#include <rte_memory.h>
 #include "dp_conf.h"
 #include "dp_error.h"
 #include "dp_log.h"

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -115,7 +115,7 @@ static int parse_options(struct dp_dhcp_header *dhcp_pkt,
 			continue;
 		if (op_type == DHCP_OPT_END)
 			break;
-		if (i > options_len) {
+		if (i >= options_len) {
 			DPS_LOG_WARNING("Malformed DHCP option");
 			return DP_ERROR;
 		}

--- a/src/nodes/ipv6_lookup_node.c
+++ b/src/nodes/ipv6_lookup_node.c
@@ -7,7 +7,7 @@
 #include "dp_mbuf_dyn.h"
 #include "dp_util.h"
 #include "nodes/common_node.h"
-#include "nodes/dhcpv6_node.h"
+#include "protocols/dp_dhcpv6.h"
 #include "rte_flow/dp_rte_flow.h"
 
 #define NEXT_NODES(NEXT) \

--- a/test/test_dhcpv6.py
+++ b/test/test_dhcpv6.py
@@ -3,34 +3,46 @@ from helpers import *
 
 def test_dhcpv6(prepare_ifaces):
 
-	DUID = b"00020000ab11b7d4e0eed266171d"
+	DUID = DUID_LL(lladdr=VM1.mac)
+	IAID = 0x18702501
 
 	eth = Ether(dst=ipv6_multicast_mac)
 	ip6 = IPv6(dst=gateway_ipv6)
-	udp = UDP(sport=546, dport=547)
+	udp = UDP()
 
-	rc_op = DHCP6OptRapidCommit(optlen=0)
-	opreq = DHCP6OptOptReq(optlen=4)
+	rc_op = DHCP6OptRapidCommit()
+	opreq = DHCP6OptOptReq()
 	et_op = DHCP6OptElapsedTime()
-	cid_op = DHCP6OptClientId(optlen=28, duid=DUID)
-	iana_op = DHCP6OptIA_NA(optlen=12, iaid=0x18702501, T1=0, T2=0)
+	cid_op = DHCP6OptClientId(duid=DUID)
+	iana_op = DHCP6OptIA_NA(iaid=IAID, T1=0, T2=0)
 
 	sol = DHCP6_Solicit(trid=random.randint(0, 16777215))
 	pkt = eth / ip6 / udp / sol / iana_op / rc_op / et_op / cid_op / opreq
 	answer = srp1(pkt, iface=VM1.tap, type=ETH_P_IPV6, timeout=sniff_timeout)
 	validate_checksums(answer)
-	duid = bytes(answer[DHCP6OptClientId].duid)
+	duid = answer[DHCP6OptClientId].duid
 	assert duid == DUID, \
 		f"Bad duid in DHCPv6 Solicit ({duid})"
+	assert answer[DHCP6OptIA_NA].iaid == IAID, \
+		f"Bad IA id in DHCPv6 Solicit"
 
 	req = DHCP6_Request()
-	iana_op = answer[DHCP6OptIAAddress]
+	iana_op = DHCP6OptIA_NA(iaid=IAID, T1=0, T2=0, ianaopts=[answer[DHCP6OptIAAddress]])
 	pkt = eth / ip6 / udp / req / iana_op / rc_op / et_op / cid_op / opreq
 	answer = srp1(pkt, iface=VM1.tap, type=ETH_P_IPV6, timeout=sniff_timeout)
 	validate_checksums(answer)
-	duid == bytes(answer[DHCP6OptClientId].duid)
+	duid == answer[DHCP6OptClientId].duid
 	assert duid == DUID, \
 		f"Bad duid in DHCPv6 Request ({duid})"
+	assert answer[DHCP6OptIA_NA].iaid == IAID, \
+		f"Bad IA id in DHCPv6 Request"
 	assigned_ipv6 = answer[DHCP6OptIAAddress].addr
 	assert assigned_ipv6 == VM1.ipv6, \
 		f"Wrong address assigned ({assigned_ipv6})"
+
+	req = DHCP6_Confirm()
+	pkt = eth / ip6 / udp / req / et_op
+	answer = srp1(pkt, iface=VM1.tap, type=ETH_P_IPV6, timeout=sniff_timeout)
+	validate_checksums(answer)
+	assert DHCP6_Reply in answer, \
+		f"No proper reply to DHCPv6 confirm packet"


### PR DESCRIPTION
I wanted to address those GCC errors in DHCPv6. This led me to actual buffer overruns in the code. 

This led me to the test suite which was faulty, as according to Wireshark, this is not how the communication actually looks like. 

That also led me to discover that the code could segfault due to not handling communication properly and relying on the exact sequence the tests provided.

So I had to rewrite most of the code. But I am no expert on IPv6 and have no real means to test properly, so please run some checks too.

I also migrated all RFC-related definitions for DHCPv6 into a separate file as it has nothing to do with the actual node. I created a new `protocols/` directory, as I would like to do this later for other such definitions. If that is not something wanted, I'll commit an update.