### PR TITLE
Fixed wrong graphtrace output is some situations

### DIFF
--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -74,7 +74,7 @@ void trigger_garp()
 
 	pkt->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
 	pkt->pkt_len = pkt->data_len;
-	pkt->packet_type = RTE_PTYPE_L2_ETHER;
+	pkt->packet_type = RTE_PTYPE_L2_ETHER_ARP;
 
 	send_to_all_vfs(pkt, DP_PER_TYPE_DIRECT_TX, RTE_ETHER_TYPE_ARP);
 	rte_pktmbuf_free(pkt);
@@ -97,6 +97,7 @@ void trigger_nd_unsol_adv()
 	if(pkt == NULL)
 		printf("rte_mbuf allocation failed\n");
 
+	pkt->packet_type = RTE_PTYPE_L2_ETHER | RTE_PTYPE_L3_IPV6 | RTE_PTYPE_L4_ICMP;
 	eth_hdr = rte_pktmbuf_mtod(pkt, struct rte_ether_hdr *);
 	ipv6_hdr = (struct rte_ipv6_hdr*)(eth_hdr+1);
 	ns_msg = (struct nd_msg*) (ipv6_hdr + 1);
@@ -149,6 +150,7 @@ void trigger_nd_ra()
 	if (!pkt_buf)
 		printf("rte_mbuf allocation failed\n");
 
+	pkt_buf->packet_type = RTE_PTYPE_L2_ETHER | RTE_PTYPE_L3_IPV6 | RTE_PTYPE_L4_ICMP;
 	eth_hdr = rte_pktmbuf_mtod(pkt_buf, struct rte_ether_hdr *);
 	ipv6_hdr = (struct rte_ipv6_hdr*)(eth_hdr+1);
 	ra_msg = (struct ra_msg*) (ipv6_hdr + 1);

--- a/src/nodes/common_node.c
+++ b/src/nodes/common_node.c
@@ -57,7 +57,7 @@ static void dp_graphtrace_print_udp(void **p_pkt_data, size_t *p_pos, char *buf,
 	struct rte_udp_hdr *udp_hdr = (struct rte_udp_hdr *)*p_pkt_data;
 
 	PRINT_LAYER(p_pos, buf, bufsize,
-		"UDP %d -> %d len %d",
+		"UDP %u -> %u len %u",
 		ntohs(udp_hdr->src_port), ntohs(udp_hdr->dst_port), ntohs(udp_hdr->dgram_len));
 
 	*p_pkt_data = udp_hdr + 1;
@@ -68,7 +68,7 @@ static void dp_graphtrace_print_tcp(void **p_pkt_data, size_t *p_pos, char *buf,
 	struct rte_tcp_hdr *tcp_hdr = (struct rte_tcp_hdr *)*p_pkt_data;
 
 	PRINT_LAYER(p_pos, buf, bufsize,
-		"TCP %d -> %d seq %d ack %d",
+		"TCP %u -> %u seq %u ack %u",
 		ntohs(tcp_hdr->src_port), ntohs(tcp_hdr->dst_port), ntohl(tcp_hdr->sent_seq), ntohl(tcp_hdr->recv_ack));
 
 	*p_pkt_data = tcp_hdr + 1;
@@ -79,7 +79,7 @@ static void dp_graphtrace_print_icmp(void **p_pkt_data, size_t *p_pos, char *buf
 	struct rte_icmp_hdr *icmp_hdr = (struct rte_icmp_hdr *)*p_pkt_data;
 
 	PRINT_LAYER(p_pos, buf, bufsize,
-		"ICMP %d-%d id %d seq %d",
+		"ICMP %u-%u id %u seq %u",
 		icmp_hdr->icmp_type, icmp_hdr->icmp_code, ntohs(icmp_hdr->icmp_ident), ntohs(icmp_hdr->icmp_seq_nb));
 
 	*p_pkt_data = icmp_hdr + 1;


### PR DESCRIPTION
There was bad formatting for packet details in graphtrace and wrong packet type for `rx_periodic` which made the output hard to match to tcpdump/sniffer output.