### PR TITLE
Fixed problems in test (forgotten test and kernel packet noise)

### DIFF
--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -6,7 +6,7 @@ import subprocess
 
 from config import *
 from grpc_client import GrpcClient
-from helpers import interface_up
+from helpers import interface_init
 
 
 class DpService:
@@ -58,12 +58,11 @@ class DpService:
 			self.process.wait()
 
 	def init_ifaces(self, grpc_client):
-		interface_up(VM1.tap)
-		interface_up(VM2.tap)
-		interface_up(VM3.tap)
-		interface_up(PF0.tap)
-		if self.port_redundancy:
-			interface_up(PF1.tap)
+		interface_init(VM1.tap)
+		interface_init(VM2.tap)
+		interface_init(VM3.tap)
+		interface_init(PF0.tap)
+		interface_init(PF1.tap, self.port_redundancy)
 		grpc_client.init()
 		VM1.ul_ipv6 = grpc_client.addmachine(VM1.name, VM1.pci, VM1.vni, VM1.ip, VM1.ipv6)
 		VM2.ul_ipv6 = grpc_client.addmachine(VM2.name, VM2.pci, VM2.vni, VM2.ip, VM2.ipv6)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -63,8 +63,12 @@ def delayed_sendp(packet, interface):
 	sendp(packet, iface=interface)
 
 
-def interface_up(interface):
-	cmd = f"ip link set dev {interface} up"
+def interface_init(interface, enabled=True):
+	if enabled:
+		cmd = f"ip link set dev {interface} up"
+		print(cmd)
+		subprocess.check_output(shlex.split(cmd))
+	cmd = f"ip addr flush dev {interface}"
 	print(cmd)
 	subprocess.check_output(shlex.split(cmd))
 

--- a/test/test_vf_to_pf.py
+++ b/test/test_vf_to_pf.py
@@ -17,7 +17,7 @@ def reply_icmp_pkt_from_vm1(nat_ul_ipv6):
 				 ICMP(type=0, id=pkt[ICMP].id))
 	delayed_sendp(reply_pkt, PF0.tap)
 
-def xtest_vf_to_pf_network_nat_icmp(prepare_ipv4, grpc_client):
+def test_vf_to_pf_network_nat_icmp(prepare_ipv4, grpc_client):
 
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 

--- a/test/test_vf_to_vf.py
+++ b/test/test_vf_to_vf.py
@@ -4,12 +4,12 @@ import pytest
 from helpers import *
 
 
-def vf_to_vf_tcp_responder(vf_name):
-	pkt = sniff_packet(vf_name, is_tcp_pkt)
+def vf_to_vf_tcp_responder(vf_tap):
+	pkt = sniff_packet(vf_tap, is_tcp_pkt)
 	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x0800) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 TCP(sport=pkt[TCP].dport, dport=pkt[TCP].sport))
-	delayed_sendp(reply_pkt, vf_name)
+	delayed_sendp(reply_pkt, vf_tap)
 
 
 def test_vf_to_vf_tcp(prepare_ipv4, grpc_client):


### PR DESCRIPTION
First, I "uncommented" a forgotten test (that's my bad). I just merged that fix with this one.

Then I noticed that randomly, LB test failed (1/10?). It was because the TAP interfaces had IPv6 addresses assigned (done automagically somehow) thus the kernel was sending NS, ND and some other packets to them. This randomly coincided with a running sniffer by scapy, thus providing the test script with a bogus packet instead of the right one.

So the tests now remove addresses from TAP interfaces when putting them up.

(And there is one rename of an argument for consistency on a separate place).