### PR TITLE
Prepare script checks for misconfigured udev naming for VFs

### DIFF
--- a/hack/prepare.sh
+++ b/hack/prepare.sh
@@ -76,6 +76,8 @@ function get_pattern() {
 	pattern=$(devlink port | grep pci/$dev/ | grep "virtual\|pcivf" | awk '{print $5}' | sed -rn 's/(.*[a-z_])[0-9]{1,3}$/\1/p' | uniq)
 	if [ -z "$pattern" ]; then
 		err "can't determine the pattern for $dev"
+	elif [ $(wc -l <<< "$pattern") -ne 1 ]; then
+		err "multiple patterns found for $dev"
 	fi
 	echo "$pattern"
 }


### PR DESCRIPTION
As we encountered a machine that did not name all VFs properly, the prepare.sh script failed in a silent way.

I added a check to at least report an error in this case.