### PR TITLE
Added a short deployment document for Mellanox first-time use

### DIFF
--- a/docs/deployment/mellanox.md
+++ b/docs/deployment/mellanox.md
@@ -1,0 +1,43 @@
+# Deployment guide for Mellanox ConnectX cards
+Before running dp-service for the first time on Mellanox ConnectX cards, use this guide to check the proper configuration.
+
+
+## Firmware configuration
+SR-IOV needs to be enabled on the card itself and maximum number of virtual functions (thus available NICs for VMs) must be set.
+
+To check the firmware configuration an official tool `mlxconfig` is available. There is also an open-source alternative that is present in Debian package tree called `mstflint`.
+
+To use the configuration tool, the PCI address of the first physical port is needed, use `lspci` to list all devices and use the lowest PCI address of any Mellanox entries:
+```
+# lspci | grep Mellanox
+0000:03:00.0 Ethernet controller: Mellanox Technologies MT2894 Family [ConnectX-6 Lx]
+0000:03:00.1 Ethernet controller: Mellanox Technologies MT2894 Family [ConnectX-6 Lx]
+0000:03:00.2 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:00.3 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:00.4 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:00.5 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:00.6 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:00.7 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:01.0 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+0000:03:01.1 Ethernet controller: Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+```
+
+Then check the current firmware status:
+```
+# apt install mstflint
+# mstconfig -d 0000:03:00.0 q | grep -E 'SRIOV_EN|UCTX_EN|NUM_OF_VFS'
+         NUM_OF_VFS                          8
+         SRIOV_EN                            False(0)
+         UCTX_EN                             True(1)
+```
+
+Set the number of VFs to the needed value (max 126 at the moment) and enable both SR-IOV and UCTX:
+```
+# mstconfig -d 0000:03:00.0 s SRIOV_EN=1 UCTX_EN=1 NUM_OF_VFS=126
+```
+Restart the machine for the changes to take effect.
+> These changes are done in the NIC itself, it does not matter if the host is an ephemeral image or if another host OS will boot later.
+
+
+## Dp-service setup
+Either `prepare.sh` script or `preparedp.service` systemd unit needs to be run before dp-service can work properly. This should already be done automatically if using the Docker image provided. Make sure this does not produce any errors.

--- a/docs/development/mellanox.md
+++ b/docs/development/mellanox.md
@@ -45,9 +45,9 @@ In some hardware however, `pci=realloc` kernel command-line parameter is require
 
 
 ## Firmware configuration
-For reading and writing Mellanox firmware options, `mlxconfig` command-line tool is needed. This is part of the offical [nVidia OFED package](#nvidia-ofed), which can be hard to install and overrides your kernel mainline NIC drivers, which is not the way dp-service is deployed. An open-source tool (should be part of your distro's package tree) `mstflint` can be used to varying degree of success (on most configurations it only successfully lists the firmware version). Some motherbords support setting Mellanox values in BIOS though.
+For reading and writing Mellanox firmware options, `mlxconfig` command-line tool is needed. This is part of the offical [nVidia OFED package](#nvidia-ofed), which can be hard to install and overrides your kernel mainline NIC drivers, which is not the way dp-service is deployed. An open-source package `mstflint` can be used instead (should be part of your distro's package tree). Some motherboards support setting Mellanox values in BIOS too.
 
-To query firmware values use `mlxconfig -d <pci-device-address> q`, to write values use `mlxconfig -d <pci-device-address> set KEY1=value KEY2=value ...`.
+To query firmware values use `mstconfig -d <pci-device-address> q`, to write values use `mstconfig -d <pci-device-address> set KEY1=value KEY2=value ...`.
 
 ### Enabling SR-IOV
 For dp-service to properly function as a virtual router for VMs running on a host, firmware value `SRIOV_EN` needs to be `True` and `NUM_OF_VFS` needs to be non-zero (set to the number of VMs that will be run).


### PR DESCRIPTION
When deploying dp-service to a new region, there were some questions asked by the ops, so I documented the questions for later use.