### PR TITLE
Fix dp_service_user for ConnectX-6

### DIFF
--- a/hack/set_cap.sh
+++ b/hack/set_cap.sh
@@ -3,6 +3,8 @@
 # NET_ADMIN for setting MAC, etc.
 # NET_RAW to access NIC ports
 # SYS_ADMIN for /proc/self/pagemap access
+# SYS_RAWIO to be able to apply rte_flow rules in transfer mode
+# TODO: docs mention this sometimes: IPC_LOCK for DMA memory pinning
 
 # NOTICE: binaries with file capabilities have their effective IDs changed to 'root:root' in /proc/self
 # therefore also DAC_OVERRIDE is needed to ignore /proc/self/pagemap (now root) permissions
@@ -18,4 +20,4 @@ if [ ! -f "$1" ]; then
 	exit 1
 fi
 
-cp $1 $2 && sudo setcap cap_net_raw,cap_net_admin,cap_sys_admin,cap_dac_override=eip $2
+cp $1 $2 && sudo setcap cap_sys_rawio,cap_net_raw,cap_net_admin,cap_sys_admin,cap_dac_override=eip $2


### PR DESCRIPTION
This is just a small patch to enable running dp-service without root on ConnectX-6, as opposed to ConnectX-4 where UCTX_EN is not used, additional capability is needed.