### PR TITLE
Refactored monitoring source code

### DIFF
--- a/include/monitoring/dp_event.h
+++ b/include/monitoring/dp_event.h
@@ -1,5 +1,5 @@
-#ifndef __INCLUDE_DP_EVENT_H
-#define __INCLUDE_DP_EVENT_H
+#ifndef __INCLUDE_DP_EVENT_H__
+#define __INCLUDE_DP_EVENT_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -7,21 +7,18 @@ extern "C" {
 
 #include <stdint.h>
 #include <rte_mbuf.h>
-#include "dp_util.h"
-#include "dpdk_layer.h"
-#include "dp_monitoring.h"
-
+#include <rte_ethdev.h>
 
 int dp_link_status_change_event_callback(uint16_t port_id, 
-												enum rte_eth_event_type type, 
-												void *param,
-												void *ret_param);
+										 enum rte_eth_event_type type,
+										 void *param,
+										 void *ret_param);
 void dp_process_event_link_msg(struct rte_mbuf *m);
+
 int dp_send_event_flow_aging_msg();
 void dp_process_event_flow_aging_msg(struct rte_mbuf *m);
-
 
 #ifdef __cplusplus
 }
 #endif
-#endif /* __INCLUDE_DP_EVENT_H */
+#endif /* __INCLUDE_DP_EVENT_H__ */

--- a/include/monitoring/dp_monitoring.h
+++ b/include/monitoring/dp_monitoring.h
@@ -1,5 +1,5 @@
-#ifndef __INCLUDE_DP_MONITORING_H
-#define __INCLUDE_DP_MONITORING_H
+#ifndef __INCLUDE_DP_MONITORING_H__
+#define __INCLUDE_DP_MONITORING_H__
 
 #include <stdint.h>
 #include <rte_mbuf.h>
@@ -8,39 +8,37 @@
 extern "C" {
 #endif
 
-typedef enum {
+enum dp_status_type {
 	DP_STATUS_TYPE_UNKNOWN,
 	DP_STATUS_TYPE_LINK,
 	DP_STATUS_TYPE_FLOW_AGING,
-} dp_status_type;
+};
 
-typedef enum {
+enum dp_status_scope {
 	DP_STATUS_SCOPE_LOCAL,
 	DP_STATUS_SCOPE_REMOTE,
-} dp_status_scope;
+};
 
-typedef struct {
-	dp_status_type type;
-	dp_status_scope scope; 
-} dp_event_msg_head;
+struct dp_event_msg_head {
+	enum dp_status_type type;
+	enum dp_status_scope scope;
+};
 
-typedef struct {
+struct dp_link_status {
 	uint16_t port_id;
 	uint8_t status;
-} dp_link_status;
+};
 
-typedef struct {
-	dp_event_msg_head msg_head;
-	
+struct dp_event_msg {
+	struct dp_event_msg_head msg_head;
 	union {
-		dp_link_status link_status;
+		struct dp_link_status link_status;
 	} event_entry;
-
-} dp_event_msg;
+};
 
 void dp_process_event_msg(struct rte_mbuf *m);
 
 #ifdef __cplusplus
 }
 #endif
-#endif /* __INCLUDE_DP_MONITORING_H */
+#endif /* __INCLUDE_DP_MONITORING_H__ */

--- a/src/dp_timers.c
+++ b/src/dp_timers.c
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include <rte_timer.h>
 #include <rte_cycles.h>
+#include "dp_conf.h"
 #include "dp_error.h"
 #include "dp_log.h"
 #include "dp_periodic_msg.h"

--- a/src/monitoring/dp_event.c
+++ b/src/monitoring/dp_event.c
@@ -1,82 +1,96 @@
 #include "monitoring/dp_event.h"
-#include <rte_common.h>
+#include "dp_conf.h"
+#include "dp_error.h"
 #include "dp_flow.h"
 #include "dp_log.h"
-#include "dp_util.h"
+#include "dp_port.h"
+#include "monitoring/dp_monitoring.h"
+
+
+static int dp_send_event_msg(struct dp_event_msg *msg)
+{
+	struct rte_mbuf *m;
+	struct dp_event_msg *mbuf_msg;
+	int ret;
+
+	m = rte_pktmbuf_alloc(get_dpdk_layer()->rte_mempool);
+	if (!m) {
+		DPS_LOG_ERR("Cannot allocate monitoring event message type %u", msg->msg_head.type);
+		return DP_ERROR;
+	}
+
+	mbuf_msg = rte_pktmbuf_mtod(m, struct dp_event_msg *);
+	memcpy(mbuf_msg, msg, sizeof(struct dp_event_msg));
+
+	ret = rte_ring_sp_enqueue(get_dpdk_layer()->monitoring_rx_queue, m);
+	if (DP_FAILED(ret)) {
+		DPS_LOG_ERR("Cannot enqueue monitoring event message %u %s", msg->msg_head.type, dp_strerror(ret));
+		return ret;
+	}
+
+	return DP_OK;
+}
+
+// Link-status message - sent when interface state changes
 
 static int dp_send_event_link_msg(uint16_t port_id, uint8_t status)
 {
-	dp_event_msg link_status_msg = {0};
-	int ret;
-
-	link_status_msg.msg_head.type = DP_STATUS_TYPE_LINK;
-	link_status_msg.msg_head.scope = DP_STATUS_SCOPE_LOCAL;
-	link_status_msg.event_entry.link_status.port_id = port_id;
-	link_status_msg.event_entry.link_status.status = status;
-
-	struct rte_mbuf *m = rte_pktmbuf_alloc(get_dpdk_layer()->rte_mempool);
-	dp_event_msg *status_msg = rte_pktmbuf_mtod(m, dp_event_msg*);
-
-	memcpy(status_msg, &link_status_msg, sizeof(link_status_msg));
-
-	ret = rte_ring_sp_enqueue(get_dpdk_layer()->monitoring_rx_queue, m);
-	if (ret < 0)
-		return ret;
-
-	return 0;
+	struct dp_event_msg link_status_msg = {
+		.msg_head = {
+			.type = DP_STATUS_TYPE_LINK,
+			.scope = DP_STATUS_SCOPE_LOCAL,
+		},
+		.event_entry = {
+			.link_status = {
+				.port_id = port_id,
+				.status = status,
+			},
+		},
+	};
+	return dp_send_event_msg(&link_status_msg);
 }
 
-int dp_link_status_change_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param,
-									 void *ret_param)
+int dp_link_status_change_event_callback(uint16_t port_id,
+										 enum rte_eth_event_type type,
+										 __rte_unused void *param,
+										 __rte_unused void *ret_param)
 {
 	struct rte_eth_link link;
 	int ret;
 
-	RTE_SET_USED(param);
-	RTE_SET_USED(ret_param);
-
 	ret = rte_eth_link_get_nowait(port_id, &link);
-	if (ret < 0) {
-		printf("Failed link get on port %d: %s\n",
-			   port_id, rte_strerror(-ret));
+	if (DP_FAILED(ret)) {
+		DPS_LOG_ERR("Link change failed to get link get on port %d %s", port_id, dp_strerror(ret));
 		return ret;
 	}
 
-	ret = dp_send_event_link_msg(port_id, link.link_status);
-	if (ret < 0)
-		return ret;
+	if (DP_FAILED(dp_send_event_link_msg(port_id, link.link_status)))
+		return DP_ERROR;
 
-	return 0;
+	return DP_OK;
 }
 
 void dp_process_event_link_msg(struct rte_mbuf *m)
 {
-	dp_event_msg *status_msg = rte_pktmbuf_mtod(m, dp_event_msg *);
+	struct dp_event_msg *status_msg = rte_pktmbuf_mtod(m, struct dp_event_msg *);
 	uint16_t port_id = status_msg->event_entry.link_status.port_id;
 	uint8_t status = status_msg->event_entry.link_status.status;
 
-	// TODO(plague) can fail
-	dp_port_set_link_status(port_id, status);
+	if (DP_FAILED(dp_port_set_link_status(port_id, status)))
+		DPS_LOG_WARNING("Cannot set link status of %u to %u", port_id, status);
 }
+
+// Flow-aging message - sent periodically to age-out conntracked flows
 
 int dp_send_event_flow_aging_msg()
 {
-	dp_event_msg flow_aging_msg = {0};
-	int ret;
-
-	flow_aging_msg.msg_head.type = DP_STATUS_TYPE_FLOW_AGING;
-	flow_aging_msg.msg_head.scope = DP_STATUS_SCOPE_LOCAL;
-
-	struct rte_mbuf *m = rte_pktmbuf_alloc(get_dpdk_layer()->rte_mempool);
-	dp_event_msg *event_msg = rte_pktmbuf_mtod(m, dp_event_msg*);
-
-	memcpy(event_msg, &flow_aging_msg, sizeof(dp_event_msg));
-
-	ret = rte_ring_sp_enqueue(get_dpdk_layer()->monitoring_rx_queue, m);
-	if (ret < 0)
-		return ret;
-
-	return 0;
+	struct dp_event_msg flow_aging_msg = {
+		.msg_head = {
+			.type = DP_STATUS_TYPE_FLOW_AGING,
+			.scope = DP_STATUS_SCOPE_LOCAL,
+		},
+	};
+	return dp_send_event_msg(&flow_aging_msg);
 }
 
 void dp_process_event_flow_aging_msg(struct rte_mbuf *m)

--- a/src/monitoring/dp_monitoring.c
+++ b/src/monitoring/dp_monitoring.c
@@ -5,7 +5,7 @@
 
 void dp_process_event_msg(struct rte_mbuf *m)
 {
-	dp_event_msg *event_msg = rte_pktmbuf_mtod(m, dp_event_msg *);
+	struct dp_event_msg *event_msg = rte_pktmbuf_mtod(m, struct dp_event_msg *);
 
 	switch (event_msg->msg_head.type) {
 	case DP_STATUS_TYPE_LINK:


### PR DESCRIPTION
I refactored the monitoring directories as they are nicely separated.

One change is the removal of typedefs, that also needed changes elsewhere.
Then I added new logging.
One bigger change was to move common code into one function and doing direct structure initialization instead of zeroing it and then assigning values.

I did `assert(!memcmp())` on the new vs old structure and ran tests. TCP timeout tests are directly testing one of the messages, so that is correct. I don't have any test to test the other message (link-state), but most of the code is shared now, so it should also be OK.