### PR TITLE
Fixed NAT port telemetry and made virtsvc telemetry consistent with nat

### DIFF
--- a/include/dp_internal_stats.h
+++ b/include/dp_internal_stats.h
@@ -19,17 +19,17 @@ struct dp_internal_stats {
 
 extern struct dp_internal_stats _dp_stats;
 
-#define DP_STATS_NAT_INC_USED_PORT_CNT(port_id) \
-do { \
-	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id]++;	\
-} \
-while (0)
+#define DP_STATS_NAT_INC_USED_PORT_CNT(port_id) do { \
+	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id]++; \
+} while (0)
 
-#define DP_STATS_NAT_DEC_USED_PORT_CNT(port_id) \
-do { \
-	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id]++;	\
-} \
-while (0)
+#define DP_STATS_NAT_DEC_USED_PORT_CNT(port_id) do { \
+	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id]--; \
+} while (0)
+
+#define DP_STATS_NAT_RESET_USED_PORT_CNT(port_id) do { \
+	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id] = 0; \
+} while (0)
 
 int dp_nat_get_used_ports_telemetry(struct rte_tel_data *dict);
 

--- a/include/dp_virtsvc.h
+++ b/include/dp_virtsvc.h
@@ -103,7 +103,7 @@ int dp_virtsvc_get_pf_route(struct dp_virtsvc *virtsvc,
 
 void dp_virtsvc_del_vm(uint16_t port_id);
 
-int dp_virtsvc_get_free_ports_telemetry(struct rte_tel_data *dict);
+int dp_virtsvc_get_used_ports_telemetry(struct rte_tel_data *dict);
 
 #ifdef __cplusplus
 }

--- a/src/dp_telemetry.c
+++ b/src/dp_telemetry.c
@@ -146,12 +146,12 @@ DP_TELEMETRY_CREATE_GRAPH_HANDLER(cycle_count, cycles)
 DP_TELEMETRY_CREATE_GRAPH_HANDLER(realloc_count, realloc_count)
 
 #ifdef ENABLE_VIRTSVC
-static int dp_telemetry_handle_virtsvc_free_ports(const char *cmd,
+static int dp_telemetry_handle_virtsvc_used_port_count(const char *cmd,
 												  __rte_unused const char *params,
 												  struct rte_tel_data *data)
 {
 	if (DP_FAILED(dp_telemetry_start_dict(data, cmd))
-		|| DP_FAILED(dp_virtsvc_get_free_ports_telemetry(data)))
+		|| DP_FAILED(dp_virtsvc_get_used_ports_telemetry(data)))
 		return DP_ERROR;
 	return DP_OK;
 }
@@ -196,9 +196,9 @@ int dp_telemetry_init(void)
 		DP_TELEMETRY_REGISTER_COMMAND(graph, call_count, "Returns total number of calls made by each graph node."),
 		DP_TELEMETRY_REGISTER_COMMAND(graph, cycle_count, "Returns total number of cycles used by each graph node."),
 		DP_TELEMETRY_REGISTER_COMMAND(graph, realloc_count, "Returns total number of reallocations done by each graph node."),
-		DP_TELEMETRY_REGISTER_COMMAND(nat, used_port_count, "Return the number of nat ports in use by each VF interface (attached VM)."),
+		DP_TELEMETRY_REGISTER_COMMAND(nat, used_port_count, "Returns the number of nat ports in use by each VF interface (attached VM)."),
 #ifdef ENABLE_VIRTSVC
-		DP_TELEMETRY_REGISTER_COMMAND(virtsvc, free_ports, "Returns number of free ports remaining in each virtual service."),
+		DP_TELEMETRY_REGISTER_COMMAND(virtsvc, used_port_count, "Returns the number of ports in use by each virtual service."),
 #endif
 	};
 

--- a/src/dp_virtsvc.c
+++ b/src/dp_virtsvc.c
@@ -372,19 +372,19 @@ void dp_virtsvc_del_vm(uint16_t port_id)
 	}
 }
 
-static inline uint64_t dp_virtsvc_get_free_port_count(struct dp_virtsvc *virtsvc)
+static inline uint64_t dp_virtsvc_get_used_port_count(struct dp_virtsvc *virtsvc)
 {
-	uint64_t free_ports = 0;
+	uint64_t used_ports = 0;
 	uint64_t current_tsc = rte_get_timer_cycles();
 
 	for (int port = 0; port < DP_VIRTSVC_PORTCOUNT; ++port) {
-		if (dp_virtsvc_is_connection_old(&virtsvc->connections[port], current_tsc))
-		++free_ports;
+		if (!dp_virtsvc_is_connection_old(&virtsvc->connections[port], current_tsc))
+			++used_ports;
 	}
-	return free_ports;
+	return used_ports;
 }
 
-int dp_virtsvc_get_free_ports_telemetry(struct rte_tel_data *dict)
+int dp_virtsvc_get_used_ports_telemetry(struct rte_tel_data *dict)
 {
 	int ret;
 	char virtsvc_name[DP_VIRTSVC_TELEMETRY_MAX_NAME_SIZE];
@@ -395,7 +395,7 @@ int dp_virtsvc_get_free_ports_telemetry(struct rte_tel_data *dict)
 				 service->proto == IPPROTO_TCP ? "TCP" : "UDP",
 				 DP_IPV4_PRINT_BYTES(service->virtual_addr),
 				 ntohs(service->virtual_port));
-		ret = rte_tel_data_add_dict_u64(dict, virtsvc_name, dp_virtsvc_get_free_port_count(service));
+		ret = rte_tel_data_add_dict_u64(dict, virtsvc_name, dp_virtsvc_get_used_port_count(service));
 		if (DP_FAILED(ret)) {
 			DPS_LOG_ERR("Failed to add virtsvc telemetry data %s", dp_strerror(ret));
 			return ret;

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -1,6 +1,7 @@
 #include "dp_error.h"
 #include "dp_lb.h"
 #include <time.h>
+#include "dp_internal_stats.h"
 #include "dp_lpm.h"
 #include "dp_nat.h"
 #ifdef ENABLE_VIRTSVC
@@ -844,6 +845,8 @@ static int dp_process_delnat(dp_request *req, dp_reply *rep)
 
 	rep->get_vip.vip.vip_addr = s_data->network_nat_ip;
 	dp_del_vm_dnat_ip(s_data->network_nat_ip, vm_vni);
+
+	DP_STATS_NAT_RESET_USED_PORT_CNT(port_id);
 
 	ret = dp_del_vm_network_snat_ip(dp_get_dhcp_range_ip4(port_id), dp_get_vm_vni(port_id));
 	if (ret)


### PR DESCRIPTION
There was a typo in NAT used port stats (no decrement). Additionally, stats were not reset after deleteNAT.

I also changed virtual services' telemetry to be consistent with NAT's, i.e. same naming scheme and it now shows the used count as opposed to the free count.