### PR TITLE
Revert a previous bad fix for NAT telemetry

### DIFF
--- a/include/dp_internal_stats.h
+++ b/include/dp_internal_stats.h
@@ -27,10 +27,6 @@ extern struct dp_internal_stats _dp_stats;
 	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id]--; \
 } while (0)
 
-#define DP_STATS_NAT_RESET_USED_PORT_CNT(port_id) do { \
-	_dp_stats.nat_stats.dp_stat_nat_used_port_cnt[port_id] = 0; \
-} while (0)
-
 int dp_nat_get_used_ports_telemetry(struct rte_tel_data *dict);
 
 #ifdef __cplusplus

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -1,7 +1,6 @@
 #include "dp_error.h"
 #include "dp_lb.h"
 #include <time.h>
-#include "dp_internal_stats.h"
 #include "dp_lpm.h"
 #include "dp_nat.h"
 #ifdef ENABLE_VIRTSVC
@@ -845,8 +844,6 @@ static int dp_process_delnat(dp_request *req, dp_reply *rep)
 
 	rep->get_vip.vip.vip_addr = s_data->network_nat_ip;
 	dp_del_vm_dnat_ip(s_data->network_nat_ip, vm_vni);
-
-	DP_STATS_NAT_RESET_USED_PORT_CNT(port_id);
 
 	ret = dp_del_vm_network_snat_ip(dp_get_dhcp_range_ip4(port_id), dp_get_vm_vni(port_id));
 	if (ret)


### PR DESCRIPTION
While fixing the Ctrl+C, Ctrl+V bug in NAT telemetry, we also added resetting the used ports stat on NAT deletion.

This is wrong, as ports are marked free by connection flow aging in conntrack, not by NAT itself.

Confirmed (and confirmed fix working) in production of TSi, as without this change `used_port_count` underflows after deleting NAT and subsequent flow aging.