### PR TITLE
Optimized dp_get_nat_* functions for underlay ipv6

### DIFF
--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -94,8 +94,8 @@ int dp_add_network_nat_entry(uint32_t nat_ipv4, uint8_t *nat_ipv6,
 int dp_del_network_nat_entry(uint32_t nat_ipv4, uint8_t *nat_ipv6,
 								uint32_t vni, uint16_t min_port, uint16_t max_port);
 
-int dp_get_network_nat_underlay_ip(uint32_t nat_ipv4, uint8_t *nat_ipv6,
-								uint32_t vni, uint16_t min_port, uint16_t max_port, uint8_t *underlay_ipv6);
+const uint8_t *dp_get_network_nat_underlay_ip(uint32_t nat_ipv4, uint8_t *nat_ipv6,
+											   uint32_t vni, uint16_t min_port, uint16_t max_port);
 
 int dp_check_if_ip_natted(uint32_t vm_ip, uint32_t vni, struct nat_check_result *result);
 uint32_t dp_get_vm_network_snat_ip(uint32_t vm_ip, uint32_t vni);
@@ -103,7 +103,7 @@ int dp_set_vm_network_snat_ip(uint32_t vm_ip, uint32_t s_ip, uint32_t vni, uint1
 							  uint8_t *ul_ipv6);
 int dp_del_vm_network_snat_ip(uint32_t vm_ip, uint32_t vni);
 int dp_allocate_network_snat_port(struct dp_flow *df_ptr, uint32_t vni);
-int dp_lookup_network_nat_underlay_ip(struct rte_mbuf *pkt, uint8_t *underlay_ipv6);
+const uint8_t *dp_lookup_network_nat_underlay_ip(struct dp_flow *df_ptr);
 int dp_remove_network_snat_port(struct flow_value *cntrack);
 int dp_list_nat_local_entry(struct rte_mbuf *m, struct rte_mbuf *rep_arr[], uint32_t nat_ip);
 int dp_list_nat_neigh_entry(struct rte_mbuf *m, struct rte_mbuf *rep_arr[], uint32_t nat_ip);

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -21,7 +21,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	struct flow_value *cntrack = df_ptr->conntrack;
 	struct rte_ipv4_hdr *ipv4_hdr;
 	uint32_t dst_ip, vni, dnat_ip;
-	uint8_t underlay_dst[16];
+	const uint8_t *underlay_dst;
 	struct dp_icmp_err_ip_info icmp_err_ip_info;
 
 	if (!cntrack)
@@ -46,7 +46,8 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 				}
 
 				// only perform this lookup on unknown dnat (Distributed NAted) traffic flows
-				if (dp_lookup_network_nat_underlay_ip(m, underlay_dst)) {
+				underlay_dst = dp_lookup_network_nat_underlay_ip(df_ptr);
+				if (underlay_dst) {
 					cntrack->nat_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_NEIGH;
 					cntrack->nat_info.l4_type = df_ptr->l4_type;
 					memcpy(cntrack->nat_info.underlay_dst, underlay_dst, sizeof(cntrack->nat_info.underlay_dst));


### PR DESCRIPTION
While researching something in nat code, I noticed that `dp_lookup_network_nat_underlay_ip` does a `memcpy()` of the address and it immediately gets copied again.

As the function is called `dp_lookup_` (and there is another unused one, `dp_get_`, I chosen to return the value directly. With the `const` keyword this seems to be safe from unintentional data corruption by the caller.

Though if we would like to have it more thread-safe (opaque) and more consistent with `dp_add_network_nat_entry` which also can return underlay ipv6. I could revert this change and instead just change the caller to pass destination memory instead of an intermediate buffer.

(Also, there was an unnecessary `get_dp_flow_ptr(m)` which I also got rid of by changing the function signature)