### PR TITLE
Added miscellaneous documentation

### DIFF
--- a/docs/deployment/tcpdump.md
+++ b/docs/deployment/tcpdump.md
@@ -1,8 +1,10 @@
 # Dataplane service packet analysis using tcpdump
 Due to the fact, that dp-service uses DPDK and thus a poll-mode driver (PMD) instead of kernel network stack, traditional tools are unable to see traffic passing through dp-service-bound network cards.
 
+
 ## Offloaded mode
 Unfortunately, there is no way to see traffic going directly through the card itself as it never enters the host's I/O layer.
+
 
 ## Non-offloaded mode
 Normally, all traffic goes though the PMD and is accessed by the host's CPU via RDMA (Remote Direct Memory Access). `libpcap` (the library tcpdump uses) has support for RDMA devices and can use hardware-specific bindings to provide a virtual network interface for tcpdump (and other libpcap-based tools) to listen on.
@@ -26,3 +28,19 @@ Because of the changed behavior of custom-built tcpdump package, changes to AppA
   /etc/libibverbs.d/* r,
   /dev/infiniband/* rw,
 ```
+
+
+## Dumping dp-service traffic
+Unfortunately `tcpdump -i any` does not work for RDMA interfaces, specifying `mlx5_0` and later `mlx5_1` is the only way to see traffic for both physical ports (`mlx5_1` never shows any VF traffic).
+
+### VF communication
+To see VF-VF or VF-PF communication, i.e. overlay communication, you can simply use the standard `ip` BPF filtering as ususal, e.g. `tcpdump -n -i mlx5_0 "ip host 10.0.0.1"`.
+
+### PF communication
+To see PF communication (to/from the router), you can either look at the underlay communication and use `ip6` BPF filtering, as all VF communication is tunneled via IPIP tunneling.
+
+To filter based on overlay communication (i.e. the actual IPv4 packets from earlier), an advanced filter is needed. Unfortunately tcpdump does not support tunneled filters, therefore raw packet addressing has to be used.
+
+Example filter for IPv4 source IP in IPv6 tunnel: `ip6[52:4] = 0x01020304`, where the hex number is IPv4 in hexadecimal form.
+
+There are helper functions for bash in `hack/tcpdump_helpers.inc` you can source and use instead: `tcpdump -n -i mlx5_0 "ip6 proto 4 and $(ipip_host 1.2.3.4)"`

--- a/docs/deployment/telemetry.md
+++ b/docs/deployment/telemetry.md
@@ -1,0 +1,15 @@
+# Dataplane service telemetry
+As a DPDK-based application, dp-service supports telemetry over a UNIX socket. DPDK provides a command-line tool called `dpdk-telemetry.py`, but that is part of the whole DPDK package and as such it is not usually available on machines running dp-service.
+
+## Direct socket access
+Any standard tool that supports UNIX sockets can communicate with telemetry. This guide covers the simplest tool (not part of any programming/scripting language), `socat`. For easier output handling, python's socket module is probably more suitable.
+
+The socket to use is of type `SOCK_SEQPACKET` (5), the file path is `/var/run/dpdk/rte/dpdk_telemetry.v2` for root and `/run/user/<uid>/dpdk/rte/dpdk_telemetry.v2` for non-root users.
+
+To send telemetry requests, a node name with a parameter (must be zero if not present) is sent and a JSON responses can be read:
+```
+# echo "/dp_service/nat/used_port_count,0" | socat - UNIX:/var/run/dpdk/rte/dpdk_telemetry.v2,socktype=5
+{"version":"DPDK 21.11.0","pid":1369006,"max_output_len":16384}{"/dp_service/nat/used_port_count":{"vm1":1,"vm2":0,"vm3":0}}
+```
+
+For the complete list of commands (telemetry nodes), send `/,0`.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -21,6 +21,10 @@ For [automated testing](../testing/) (enabled via meson option `-Denable_tests=t
 sudo apt install python3-pytest python3-scapy
 ```
 
+#### Cross-compilation
+Dp-service currently only supports x86 architecture (amd64 instruction set actually). For cross-compilation, add `--cross-file config/arm/arm64_armv8_linux_gcc` to `meson setup` (see below).
+
+
 ### DPDK
 The dataplane service is built upon the [DPDK library](https://dpdk.org). Currently, the only supported version is 21.x, which most distros do not have in stable trees. Building from source also has the advantage of easier debugging later.
 ```bash

--- a/hack/tcpdump_helpers.inc
+++ b/hack/tcpdump_helpers.inc
@@ -1,0 +1,40 @@
+# Note that these functions are not intended for production use
+# Many checks are missing
+# This is only to help operations to work with tcpdump on tunneled packets
+
+ip2hex() {
+	printf "0x"
+	printf "%02x" ${1//./ }
+}
+
+ipip_src() {
+	printf "(ip6[52:4] = $(ip2hex $1))"
+}
+
+ipip_dst() {
+	printf "(ip6[56:4] = $(ip2hex $1))"
+}
+
+ipip_host() {
+	printf "($(ipip_src $1) or  $(ipip_dst $1))"
+}
+
+ipip_proto() {
+	printf "(ip6[49] == $1)"
+}
+
+ipip_src_udp_range() {
+	printf "(ip6[49] == 17 and ip6[60:2] >= $1 and ip6[60:2] <= $2)"
+}
+
+ipip_dst_udp_range() {
+	printf "(ip6[49] == 17 and ip6[62:2] >= $1 and ip6[62:2] <= $2)"
+}
+
+ipip_src_tcp_range() {
+	printf "(ip6[49] == 6 and ip6[60:2] >= $1 and ip6[60:2] <= $2)"
+}
+
+ipip_dst_tcp_range() {
+	printf "(ip6[49] == 6 and ip6[62:2] >= $1 and ip6[62:2] <= $2)"
+}


### PR DESCRIPTION
I created some scripts needed for operations when using tcpdump on mellanox and documented those.

And with telemetry being used in operations, I also added a guide to connect to it without DPDK tools.

As @vlorinc was compiling on M1 processor, I also added his cross-compilation note for meson.
