### PR TITLE
Reduced logging for unknown ICMP types.

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -119,7 +119,7 @@ void dp_add_flow_data(struct flow_key *key, void *data);
 void dp_add_flow(struct flow_key *key);
 void dp_delete_flow_key(struct flow_key *key);
 bool dp_flow_exists(struct flow_key *key);
-int8_t dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
+int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(struct flow_key *key /* in / out */);
 int dp_flow_init(int socket_id);
 void dp_flow_free();

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -235,10 +235,8 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 		key = curr_key;
 
 		memset(key, 0, sizeof(struct flow_key));
-		if (unlikely(dp_build_flow_key(key, m) < 0)) {
-			DPNODE_LOG_WARNING(node, "Failed to build a flow key\n");
+		if (unlikely(DP_FAILED(dp_build_flow_key(key, m))))
 			return CONNTRACK_NEXT_DROP;
-		}
 
 		if (prev_key)
 			key_cmp_result = dp_test_next_n_bytes_identical((const unsigned char *)prev_key,
@@ -249,11 +247,11 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 			if (unlikely(key_search_result == -ENOENT)) {
 				flow_val = flow_table_insert_entry(key, df_ptr, m);
 				if (!flow_val) {
-					DPNODE_LOG_WARNING(node, "Failed to add a flow table entry due to NULL flow_val pointer\n");
+					DPNODE_LOG_WARNING(node, "Failed to add a flow table entry due to NULL flow_val pointer");
 					return CONNTRACK_NEXT_DROP;
 				}
 			} else if (key_search_result == -EINVAL) {
-				DPNODE_LOG_ERR(node, "Conntrack operation: hash key search failed due to invalid parameters\n");
+				DPNODE_LOG_WARNING(node, "Conntrack operation: hash key search failed due to invalid parameters");
 				return CONNTRACK_NEXT_DROP;
 			} else {
 				change_flow_state_dir(key, flow_val, df_ptr);


### PR DESCRIPTION
In TSi production, there were many lines of `Failed to build a flow key`. The reason seem to be ICMP REDIRECT messages (type 5), which are not implemented in `dp_build_flow_key()`.

As this does not seem to me as a problem, I only changed the logging to be debug-level in the event of unsupported ICMP type and added a more comprehensive message there.

I also refactored the return types to DP_OK-style since I was already there.