### PR TITLE
Log refactoring in dp_flow.c

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -115,10 +115,11 @@ struct flow_age_ctx {
 
 bool dp_are_flows_identical(struct flow_key *key1, struct flow_key *key2);
 int dp_get_flow_data(struct flow_key *key, void **data);
-void dp_add_flow_data(struct flow_key *key, void *data);
-void dp_add_flow(struct flow_key *key);
+// TODO(plague): followup PR to actually check this value
+int dp_add_flow_data(struct flow_key *key, void *data);
+// TODO(plague): followup PR to actually check this value (and maybe rename to _key to match delete)
+int dp_add_flow(struct flow_key *key);
 void dp_delete_flow_key(struct flow_key *key);
-bool dp_flow_exists(struct flow_key *key);
 int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(struct flow_key *key /* in / out */);
 int dp_flow_init(int socket_id);
@@ -129,8 +130,6 @@ void dp_free_flow(struct dp_ref *ref);
 void dp_free_network_nat_port(struct flow_value *cntrack);
 
 hash_sig_t dp_get_conntrack_flow_hash_value(struct flow_key *key);
-
-void dp_output_flow_key_info(struct flow_key *key);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
After encountering multiple `Attempt to delete a non-existing hash key` in production, I refactored logging in `dp_flow.c`.

Apart from the obvious refactoring, I also added return values to some functions, checking that in callers will be a separate PR.

I also noticed debug outputs for hash key, generating which actually did some work, so I added a condition in a macro to test the loglevel. The reason the macro is `DP_FLOW_LOG*` instead of `DP_LOG_FLOW*` is to differentiate it from the standard logging macros as it is local to this file.

And as `rte_*` hashtable functions already check for existence by default I removed the `dp_flow_exists()`.