### PR TITLE
Fixed undefined TCP timeout flow value in some situations

### DIFF
--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -75,12 +75,10 @@ static __rte_always_inline void dp_cntrack_tcp_state(struct flow_value *flow_val
 
 static __rte_always_inline void dp_cntrack_set_timeout_tcp_flow(struct flow_value *flow_val)
 {
-
 	if (flow_val->l4_state.tcp_state == DP_FLOW_TCP_STATE_ESTABLISHED)
 		flow_val->timeout_value = DP_FLOW_TCP_EXTENDED_TIMEOUT;
-	else if (flow_val->l4_state.tcp_state == DP_FLOW_TCP_STATE_RST_FIN)
+	else
 		flow_val->timeout_value = flow_timeout;
-
 }
 
 


### PR DESCRIPTION
In production we found that some NAT used ports were kept at a high value despite the fact that the underlying VM's `netstat` did not show that many.

I found that the value for TCP flow timeout in dp-service is undefined in many TCP states, thus probably using an old value wich in the case of FINWAIT state that comes *after* ESTABLISHED meant that the value is kept high.