### PR TITLE
Drop incoming packets to NAT underlay IPv6 with foreign IPv4

### DIFF
--- a/test/config.py
+++ b/test/config.py
@@ -83,6 +83,7 @@ virtsvc_tcp_virtual_port = 4443
 
 # Helper functions config
 sniff_timeout = 2
+sniff_short_timeout = 1
 grpc_port = 1337
 
 # Extra testing options

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -53,8 +53,11 @@ def is_icmpv6echo_pkt(pkt):
 def is_encaped_icmpv6_pkt(pkt):
 	return IPv6 in pkt and pkt[IPv6].nh == 0x29 and ICMPv6EchoRequest in pkt
 
+def is_ipip_pkt(pkt):
+	return IPv6 in pkt and pkt[IPv6].nh == 4
+
 def is_encaped_icmp_pkt(pkt):
-	return IPv6 in pkt and pkt[IPv6].nh == 4 and ICMP in pkt
+	return is_ipip_pkt(pkt) and ICMP in pkt
 
 
 def delayed_sendp(packet, interface):
@@ -140,8 +143,7 @@ def sniff_packet(iface, lfilter, skip=0):
 
 def sniff_tcp_fwall_packet(tap, sniff_tcp_data, negated=False):
 	if negated:
-		s_timeout = sniff_timeout - 1
-		pkt_list = sniff(count=1, lfilter=is_tcp_pkt, iface=tap, timeout=s_timeout)
+		pkt_list = sniff(count=1, lfilter=is_tcp_pkt, iface=tap, timeout=sniff_short_timeout)
 		if len(pkt_list) == 0:
 			sniff_tcp_data["pkt"] = None
 		else:


### PR DESCRIPTION
When a packet with the right underlay IPv6 of a NAT contains an IPv4 that is not the VIP of this NAT, the packet gets sent out back to the router (without changing src/dst, etc.).

What's more due to the graph path, it gets stripped of Ether headers twice, resulting in a corrupted packet.

I changed ipv4_lookup so that it drops all incoming packets that are routed back to a PF, as this redirection (PF->PF) should only be done in packet_relay.

Fixes #272 

For easier review, this the actual fix:
https://github.com/onmetal/net-dpservice/commit/77846fb0a69b17ef41f5fea50bacf1b21591a175
Everything else is just subsequent refactoring of the code as I introduced a duplicity in function calls and condition evaluation.