### PR TITLE
Fix nat packet relay not working after deleting a neighbor

### DIFF
--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -927,8 +927,6 @@ static int dp_process_del_neigh_nat(dp_request *req, dp_reply *rep)
 								(uint16_t)req->del_nat_vip.port_range[0], (uint16_t)req->del_nat_vip.port_range[1]);
 		if (ret)
 			goto err;
-
-		dp_del_vm_dnat_ip(ntohl(req->del_nat_vip.vip.vip_addr), req->del_nat_vip.vni);
 	}
 	return ret;
 err:

--- a/test/test_nat.py
+++ b/test/test_nat.py
@@ -28,6 +28,10 @@ def test_network_nat_pkt_relay(prepare_ifaces, grpc_client):
 
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 	grpc_client.addneighnat(nat_vip, vni1, nat_neigh_min_port, nat_neigh_max_port, neigh_vni1_ul_ipv6)
+	# Add another neighbor and remove it to check if that does not break the other entry
+	# (doing it here becaise a separate test would be a big Ctrl+C, Ctrl+V of this one)
+	grpc_client.addneighnat(nat_vip, vni1, nat_neigh_max_port+1, nat_neigh_max_port+2, neigh_vni1_ul_ipv6)
+	grpc_client.delneighnat(nat_vip, vni1, nat_neigh_max_port+1, nat_neigh_max_port+2)
 
 	threading.Thread(target=send_bounce_pkt_to_pf,  args=(nat_ul_ipv6,)).start()
 


### PR DESCRIPTION
After deleting a neighbor entry from NAT, NAT's virtual IP was removed from DNAT.

That should only happen when there are no more entries in the table of neighbors.

The actual fix is just on lines 517-523 (and the removal of one line in dp_grpc_impl.c), the rest is refactoring due to my reusal of code.

Fixes #270 