### PR TITLE
Fix NAT VIP deletion removing DNAT when another is still present

### DIFF
--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -87,6 +87,8 @@ int dp_set_vm_dnat_ip(uint32_t d_ip, uint32_t vm_ip, uint32_t vni);
 void dp_nat_chg_ip(struct dp_flow *df_ptr, struct rte_ipv4_hdr *ipv4_hdr,
 				   struct rte_mbuf *m);
 
+void dp_del_vip_from_dnat(uint32_t d_ip, uint32_t vni);
+
 int dp_add_network_nat_entry(uint32_t nat_ipv4, uint8_t *nat_ipv6,
 								uint32_t vni, uint16_t min_port, uint16_t max_port,
 								uint8_t *underlay_ipv6);

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -409,6 +409,8 @@ static int dp_process_delvip(dp_request *req, dp_reply *rep)
 
 	rep->get_vip.vip.vip_addr = s_data->vip_ip;
 
+	// always delete, i.e. do not use dp_del_vip_from_dnat(),
+	// because 1:1 VIP is not shared with anything
 	dp_del_vm_dnat_ip(s_data->vip_ip, dp_get_vm_vni(port_id));
 	dp_del_vm_snat_ip(dp_get_dhcp_range_ip4(port_id), dp_get_vm_vni(port_id));
 
@@ -843,7 +845,7 @@ static int dp_process_delnat(dp_request *req, dp_reply *rep)
 	dp_remove_vnf_with_key(s_data->ul_nat_ip6);
 
 	rep->get_vip.vip.vip_addr = s_data->network_nat_ip;
-	dp_del_vm_dnat_ip(s_data->network_nat_ip, vm_vni);
+	dp_del_vip_from_dnat(s_data->network_nat_ip, vm_vni);
 
 	ret = dp_del_vm_network_snat_ip(dp_get_dhcp_range_ip4(port_id), dp_get_vm_vni(port_id));
 	if (ret)
@@ -927,6 +929,8 @@ static int dp_process_del_neigh_nat(dp_request *req, dp_reply *rep)
 								(uint16_t)req->del_nat_vip.port_range[0], (uint16_t)req->del_nat_vip.port_range[1]);
 		if (ret)
 			goto err;
+
+		dp_del_vip_from_dnat(ntohl(req->del_nat_vip.vip.vip_addr), req->del_nat_vip.vni);
 	}
 	return ret;
 err:


### PR DESCRIPTION
This is a continuation of #277, as I have missed the fact, that the same problem remains for the NAT VIP itself.

If dp-service contains two interfaces, each with NAT with the same IP and VNI, just different port ranges, and one of them gets deleted, the DNAT entry disappears, breaking packet_relay.

Since this was the same fix, I moved the functionality from the previous solution into a separate function and restored the original code flow, just replacing `dp_del_vm_dnat_ip()` with the new `dp_del_vip_from_dnat()` which checks for any remaining NAT entries that still need the DNAT table entry.

(there was also a bug in test_nat.py introduced by my other PR, which I had to fix here by renaming the test function)