### PR TITLE
enable underlay IPv6 addr without randomness to assist development.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,9 @@ endif
 if get_option('enable_dpdk_22_11_support')
   add_global_arguments('-DENABLE_DPDK_22_11', language: 'c')
 endif
+if get_option('enable_static_underlay_ip')
+  add_global_arguments('-DENABLE_STATIC_UNDERLAY_IP', language: 'c')
+endif
 
 dpdk_dep = dependency('libdpdk', version: '>=21.11.0')
 proto_dep = dependency('protobuf')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,5 @@ option('enable_dpdk_22_11_support', type: 'boolean', value: false, description:
        'Enable compatibility code for dpdk version 22.11')
 option('enable_virtual_services', type: 'boolean', value: false, description:
        'Build with virtual services functionality')
+option('enable_static_underlay_ip', type: 'boolean', value: false, description:
+       'Build with generating underlay ipv6 address without randomness')

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -52,8 +52,18 @@ static __rte_always_inline void dp_generate_underlay_ipv6(uint8_t *route)
 	rte_memcpy(route, get_underlay_conf()->src_ip6, DP_VNF_IPV6_ADDR_SIZE);
 	/* Following 2 bytes for kernel routing and 1 byte reserved */
 	memset(route + 8, 0, 3);
-	/* 1 byte random value */
-	rte_memcpy(route + 11, &random_byte, 1);
+
+	#ifdef ENABLE_STATIC_UNDERLAY_IP
+		/* 1 byte static value */
+		uint8_t static_byte = 0x01;
+
+		rte_memcpy(route + 11, &static_byte, 1);
+		RTE_SET_USED(random_byte);
+	#else
+		/* 1 byte random value */
+		rte_memcpy(route + 11, &random_byte, 1);
+	#endif
+
 	/* 4 byte counter */
 	rte_memcpy(route + 12, &local, 4);
 


### PR DESCRIPTION
To assist development when manual operations are needed (e.g., avoid re-enter different routes every time).