### PR TITLE
Fail addmachine call on port start error

### DIFF
--- a/include/dp_error.h
+++ b/include/dp_error.h
@@ -34,6 +34,7 @@ const char *dp_strerror(int error);
 #define DP_ERROR_VM_ALREADY_ALLOCATED				109
 #define DP_ERROR_VM_CANT_GET_NAME					110
 #define DP_ERROR_VM_ADD_VM_VNF_ERROR				111
+#define DP_ERROR_VM_ADD_VM_PORT_START				112
 #define DP_ERROR_VM_DEL								150
 #define DP_ERROR_VM_DEL_VM_NOT_FND					151
 #define DP_ERROR_VM_GET_VM_NOT_FND					171


### PR DESCRIPTION
As noticed in production `dp_port_start()` can fail due to insufficient memory in the mempool (see #260). That has not been fixed.

But this error never propagated via gRPC to metalnet, so everything expected the interface to be up and running, which caused a chain of failures.

I am not sure how to actually address the memory issue though.