### PR TITLE
judge pkt's direction using metadta field instead of cntrack's flow direction

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -97,7 +97,6 @@ struct flow_value {
 	uint8_t			lb_dst_addr6[16];
 	uint8_t			flow_status; // record if a flow is natted in any means
 	uint8_t			flow_state; // track if a flow has been seen in one or both directions
-	uint8_t			dir;
 	uint8_t			fwall_action[DP_FLOW_DIR_MAX];
 	struct {
 		uint8_t orig : 4;

--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -23,11 +23,12 @@ enum dp_periodic_type {
 
 struct dp_flow {
 	struct {
-		uint8_t	flow_type : 2;		// local,outgoing,incoming
-		uint8_t public_flow : 1;
-		uint8_t	overlay_type: 1;	// supported overlay type
-		uint8_t	nat : 3;
-		uint8_t offload_ipv6 : 1;	// tmp solution to set if we should offload ipv6 pkts
+		uint16_t	flow_type : 2;		// local,outgoing,incoming
+		uint16_t	public_flow : 1;
+		uint16_t	overlay_type: 1;	// supported overlay type
+		uint16_t	nat : 3;
+		uint16_t	offload_ipv6 : 1;	// tmp solution to set if we should offload ipv6 pkts
+		uint16_t	dir : 2;			// store the direction of each packet
 	} flags;
 	uint16_t	l3_type;  //layer-3 for inner packets. it can be crafted or extracted from raw frames
 	union {

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -224,8 +224,8 @@ void dp_free_flow(struct dp_ref *ref)
 	struct flow_value *cntrack = container_of(ref, struct flow_value, ref_count);
 
 	dp_free_network_nat_port(cntrack);
-	dp_delete_flow_key(&cntrack->flow_key[cntrack->dir]);
-	dp_delete_flow_key(&cntrack->flow_key[!cntrack->dir]);
+	dp_delete_flow_key(&cntrack->flow_key[DP_FLOW_DIR_ORG]);
+	dp_delete_flow_key(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
 
 	rte_free(cntrack);
 }

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -100,10 +100,11 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	flow_val->flow_key[DP_FLOW_DIR_ORG] = *key;
 	flow_val->flow_state = DP_FLOW_STATE_NEW;
 	flow_val->flow_status = DP_FLOW_STATUS_NONE;
-	flow_val->dir = DP_FLOW_DIR_ORG;
 	flow_val->nat_info.nat_type = DP_FLOW_NAT_TYPE_NONE;
 	flow_val->timeout_value = flow_timeout;
 	flow_val->created_port_id = m->port;
+
+	df->flags.dir = DP_FLOW_DIR_ORG;
 
 	if (offload_mode_enabled && df->l4_type != IPPROTO_TCP) {
 		flow_val->offload_flags.orig = DP_FLOW_OFFLOAD_INSTALL;
@@ -137,7 +138,8 @@ static __rte_always_inline void change_flow_state_dir(struct flow_key *key, stru
 		if (dp_are_flows_identical(key, &flow_val->flow_key[DP_FLOW_DIR_ORG])) {
 			if (flow_val->flow_state == DP_FLOW_STATE_NEW)
 				flow_val->flow_state = DP_FLOW_STATE_ESTABLISHED;
-			flow_val->dir = DP_FLOW_DIR_ORG;
+
+			df->flags.dir = DP_FLOW_DIR_ORG;
 		}
 	} else {
 		if (dp_are_flows_identical(key, &flow_val->flow_key[DP_FLOW_DIR_REPLY])) {
@@ -149,8 +151,7 @@ static __rte_always_inline void change_flow_state_dir(struct flow_key *key, stru
 			if (flow_val->flow_state == DP_FLOW_STATE_NEW)
 				flow_val->flow_state = DP_FLOW_STATE_ESTABLISHED;
 
-			
-			flow_val->dir = DP_FLOW_DIR_REPLY;
+			df->flags.dir = DP_FLOW_DIR_REPLY;
 		}
 
 		if (dp_are_flows_identical(key, &flow_val->flow_key[DP_FLOW_DIR_ORG])) {
@@ -164,7 +165,7 @@ static __rte_always_inline void change_flow_state_dir(struct flow_key *key, stru
 			if (df->l4_type == IPPROTO_UDP && flow_val->flow_state == DP_FLOW_STATE_NEW)
 				flow_val->flow_state = DP_FLOW_STATE_ESTABLISHED;
 
-			flow_val->dir = DP_FLOW_DIR_ORG;
+			df->flags.dir = DP_FLOW_DIR_ORG;
 		}
 	}
 	df->dp_flow_hash = dp_get_conntrack_flow_hash_value(key);

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -27,7 +27,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	if (!cntrack)
 		return DNAT_NEXT_IPV4_LOOKUP;
 
-	if (cntrack->flow_state == DP_FLOW_STATE_NEW && cntrack->dir == DP_FLOW_DIR_ORG) {
+	if (cntrack->flow_state == DP_FLOW_STATE_NEW && df->flags.dir == DP_FLOW_DIR_ORG) {
 		dst_ip = ntohl(df->dst.dst_addr);
 		vni = df->tun_info.dst_vni == 0 ? dp_get_vm_vni(m->port) : df->tun_info.dst_vni;
 
@@ -87,7 +87,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	}
 
 	if (cntrack->flow_status == DP_FLOW_STATUS_DST_NAT &&
-		cntrack->dir == DP_FLOW_DIR_ORG) {
+		df->flags.dir == DP_FLOW_DIR_ORG) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].ip_src);
 		df->flags.nat = DP_NAT_CHG_DST_IP;
@@ -98,7 +98,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 
 	/* We already know what to do */
 	if (cntrack->flow_status == DP_FLOW_STATUS_SRC_NAT &&
-		cntrack->dir == DP_FLOW_DIR_REPLY) {
+		df->flags.dir == DP_FLOW_DIR_REPLY) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].ip_src);
 		if (cntrack->nat_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {

--- a/src/nodes/firewall_node.c
+++ b/src/nodes/firewall_node.c
@@ -17,14 +17,14 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	struct flow_value *cntrack = df->conntrack;
 	enum dp_fwall_action action;
 
-	if (cntrack->flow_state == DP_FLOW_STATE_NEW && cntrack->dir == DP_FLOW_DIR_ORG) {
+	if (cntrack->flow_state == DP_FLOW_STATE_NEW && df->flags.dir == DP_FLOW_DIR_ORG) {
 		action = dp_get_firewall_action(df, dp_get_ipv4_hdr(m), m->port);
 		cntrack->fwall_action[DP_FLOW_DIR_ORG] = (uint8_t)action;
 		cntrack->fwall_action[DP_FLOW_DIR_REPLY] = (uint8_t)action;
 	}
 
 	if (cntrack->flow_state == DP_FLOW_STATE_ESTABLISHED)
-		action = (enum dp_fwall_action)cntrack->fwall_action[cntrack->dir];
+		action = (enum dp_fwall_action)cntrack->fwall_action[df->flags.dir];
 
 	/* Ignore the drop actions till we have the metalnet ready to set the firewall rules */
 	/*if (action == DP_FWALL_DROP)

--- a/src/nodes/lb_node.c
+++ b/src/nodes/lb_node.c
@@ -41,7 +41,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	vni = df->tun_info.dst_vni == 0 ? dp_get_vm_vni(m->port) : df->tun_info.dst_vni;
 
 	if (cntrack->flow_state == DP_FLOW_STATE_NEW
-		&& cntrack->dir == DP_FLOW_DIR_ORG
+		&& df->flags.dir == DP_FLOW_DIR_ORG
 		&& dp_is_ip_lb(dst_ip, vni)
 		&& cntrack->flow_status == DP_FLOW_STATUS_NONE
 	) {
@@ -61,7 +61,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		return LB_NEXT_OVERLAY_SWITCH;
 	}
 
-	if (cntrack->flow_status == DP_FLOW_STATUS_DST_LB && cntrack->dir == DP_FLOW_DIR_ORG) {
+	if (cntrack->flow_status == DP_FLOW_STATUS_DST_LB && df->flags.dir == DP_FLOW_DIR_ORG) {
 		rte_memcpy(df->tun_info.ul_dst_addr6, cntrack->lb_dst_addr6, sizeof(df->tun_info.ul_dst_addr6));
 		dp_lb_pfx_vnf_check(df, m->port);
 		return LB_NEXT_OVERLAY_SWITCH;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -27,7 +27,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	if (!cntrack)
 		return SNAT_NEXT_FIREWALL;
 
-	if (cntrack->flow_state == DP_FLOW_STATE_NEW && cntrack->dir == DP_FLOW_DIR_ORG) {
+	if (cntrack->flow_state == DP_FLOW_STATE_NEW && df->flags.dir == DP_FLOW_DIR_ORG) {
 		uint16_t nat_port;
 		uint32_t vni =  dp_get_vm_vni(m->port);
 		src_ip = ntohl(df->src.src_addr);
@@ -96,7 +96,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 
 	/* We already know what to do */
 	if (cntrack->flow_status == DP_FLOW_STATUS_SRC_NAT &&
-		cntrack->dir == DP_FLOW_DIR_ORG) {
+		df->flags.dir == DP_FLOW_DIR_ORG) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].ip_dst);
 
@@ -125,7 +125,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	}
 
 	if (((cntrack->flow_status == DP_FLOW_STATUS_DST_NAT) || (cntrack->flow_status == DP_FLOW_STATUS_DST_LB))
-		&& (cntrack->dir == DP_FLOW_DIR_REPLY)) {
+		&& (df->flags.dir == DP_FLOW_DIR_REPLY)) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		df->src.src_addr = ipv4_hdr->src_addr;
 		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].ip_dst);

--- a/src/nodes/tx_node.c
+++ b/src/nodes/tx_node.c
@@ -106,7 +106,7 @@ static uint16_t tx_node_process(struct rte_graph *graph,
 		}
 
 		if (df->conntrack) {
-			if (df->conntrack->dir == DP_FLOW_DIR_ORG)
+			if (df->flags.dir == DP_FLOW_DIR_ORG)
 				offload_flag = df->conntrack->offload_flags.orig;
 			else
 				offload_flag = df->conntrack->offload_flags.reply;


### PR DESCRIPTION
Directions of cntrack entry can be changed multiple times if request/reply packets exist in cntrack's pkt queue, thus leading the consequence that some pkts skipped the ip&port replacement code routine. Use per packet based direction instead of per flow based direction on some condition statements.