### PR TITLE
Prepare pytest grpc_client interface for golang client

### DIFF
--- a/test/config.py
+++ b/test/config.py
@@ -43,11 +43,9 @@ neigh_ul_ipv6 = "fc00:2::1"
 # Neighboring dp-service instance info (normally provided by metalnet)
 neigh_vni1_ul_ipv6 = "fc00:2::64:0:1"  # Hardcoded VNI, this would need to correspond to the other instance's config
 neigh_vni1_ov_ip_prefix = f"{ov_ip_prefix}{vni1}.2"
-neigh_vni1_ov_ip_range = f"{neigh_vni1_ov_ip_prefix}.0"
-neigh_vni1_ov_ip_range_len = 24
+neigh_vni1_ov_ip_route = f"{neigh_vni1_ov_ip_prefix}.0/24"
 neigh_vni1_ov_ipv6_prefix = f"{ov_ipv6_prefix}{vni1}:2"
-neigh_vni1_ov_ipv6_range = f"{neigh_vni1_ov_ipv6_prefix}::"
-neigh_vni1_ov_ipv6_range_len = 104
+neigh_vni1_ov_ipv6_route = f"{neigh_vni1_ov_ipv6_prefix}::/104"
 
 # DHCP response config
 dhcp_mtu = 1337

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -84,18 +84,18 @@ class DpService:
 		if not self.hardware:  # see above
 			interface_init(PF1.tap, self.port_redundancy)
 		grpc_client.init()
-		VM1.ul_ipv6 = grpc_client.addmachine(VM1.name, VM1.pci, VM1.vni, VM1.ip, VM1.ipv6)
-		VM2.ul_ipv6 = grpc_client.addmachine(VM2.name, VM2.pci, VM2.vni, VM2.ip, VM2.ipv6)
-		VM3.ul_ipv6 = grpc_client.addmachine(VM3.name, VM3.pci, VM3.vni, VM3.ip, VM3.ipv6)
-		grpc_client.addroute_ipv4(vni1, neigh_vni1_ov_ip_range, neigh_vni1_ov_ip_range_len, 0, neigh_vni1_ul_ipv6)
-		grpc_client.addroute_ipv6(vni1, neigh_vni1_ov_ipv6_range, neigh_vni1_ov_ipv6_range_len, 0, neigh_vni1_ul_ipv6)
-		grpc_client.addroute_ipv4(vni1, "0.0.0.0", 0, vni1, router_ul_ipv6)
-		grpc_client.addroute_ipv4(vni2, "0.0.0.0", 0, vni2, router_ul_ipv6)
+		VM1.ul_ipv6 = grpc_client.addinterface(VM1.name, VM1.pci, VM1.vni, VM1.ip, VM1.ipv6)
+		VM2.ul_ipv6 = grpc_client.addinterface(VM2.name, VM2.pci, VM2.vni, VM2.ip, VM2.ipv6)
+		VM3.ul_ipv6 = grpc_client.addinterface(VM3.name, VM3.pci, VM3.vni, VM3.ip, VM3.ipv6)
+		grpc_client.addroute(vni1, neigh_vni1_ov_ip_route, 0, neigh_vni1_ul_ipv6)
+		grpc_client.addroute(vni1, neigh_vni1_ov_ipv6_route, 0, neigh_vni1_ul_ipv6)
+		grpc_client.addroute(vni1, "0.0.0.0/0", vni1, router_ul_ipv6)
+		grpc_client.addroute(vni2, "0.0.0.0/0", vni2, router_ul_ipv6)
 
 	def attach(self, grpc_client):
-		VM1.ul_ipv6 = grpc_client.get_ul_ipv6(VM1.name)
-		VM2.ul_ipv6 = grpc_client.get_ul_ipv6(VM2.name)
-		VM3.ul_ipv6 = grpc_client.get_ul_ipv6(VM3.name)
+		VM1.ul_ipv6 = grpc_client.getinterface(VM1.name)['underlayRoute']
+		VM2.ul_ipv6 = grpc_client.getinterface(VM2.name)['underlayRoute']
+		VM3.ul_ipv6 = grpc_client.getinterface(VM3.name)['underlayRoute']
 
 	def get_vm_tap(self, idx):
 		iface = f"tap{idx}"

--- a/test/grpc_client.py
+++ b/test/grpc_client.py
@@ -6,18 +6,40 @@ import re
 from config import grpc_port
 
 
+class GrpcError(Exception):
+	def __init__(self, errcode, message):
+		self.errcode = errcode
+		self.message = message
+	def __str__(self):
+		return f"Error #{self.errcode}: {self.message}";
+
 class GrpcClient:
 
 	def __init__(self, build_path):
 		self.cmd = build_path + "/tools/dp_grpc_client"
 		self.re_ipv6 = re.compile(r'(?:^|[\n\r])Received underlay route : ([a-f0-9:]+)(?:$|[\n\r])')
-		self.re_machine_ipv6 = re.compile(r'(?:^|[\n\r])Interface with ipv4 [0-9\.]+ ipv6 [a-f0-9:]+ vni [0-9]+ pci [^ ]+ underlayroute ([a-f0-9:]+)(?:$|[\n\r])')
+		self.re_error = re.compile(r'(?:^|[\n\r])Received an error ([1-9][0-9][0-9])(?:$|[\n\r])')
+		self.expectedError = 0
 
-	def assert_output(self, args, req_output, negate=False):
+	def expect_error(self, errcode):
+		self.expectedError = errcode
+		return self
+
+	def _call(self, args, req_output, negate=False):
+		expectedError = self.expectedError
+		self.expectedError = 0
+
 		ipv6_address = ""
 		print("dp_grpc_client", args)
 		output = subprocess.check_output([self.cmd] + shlex.split(args)).decode('utf8').strip()
 		print(" >", output.replace("\n", "\n > "))
+
+		errors = self.re_error.search(output)
+		if errors:
+			errcode = int(errors.group(1))
+			if errcode == expectedError:
+				return None
+			raise GrpcError(errcode, "Legacy gRPC call failed with error")
 
 		if negate:
 			assert req_output not in output, "Forbidden GRPC output present"
@@ -26,105 +48,232 @@ class GrpcClient:
 
 		return output
 
-	def find_ipv6(self, text, regex=None):
-		if regex is None:
-			regex = self.re_ipv6
-		match = regex.search(text)
-		return match.group(1)
+	def _getUnderlayRoute(self, args, req_output):
+		output = self._call(args, req_output)
+		if not output:
+			return None
+		return self.re_ipv6.search(output).group(1)
 
 	def init(self):
-		self.assert_output("--init", "Init called")
+		self._call("--init", "Init called")
 
-	def addmachine(self, vm_name, pci, vni, ipv4, ipv6):
-		output = self.assert_output(f"--addmachine {vm_name} --vm_pci {pci} --vni {vni} --ipv4 {ipv4} --ipv6 {ipv6}",
+	def addinterface(self, vm_name, pci, vni, ipv4, ipv6):
+		return self._getUnderlayRoute(f"--addmachine {vm_name} --vm_pci {pci} --vni {vni} --ipv4 {ipv4} --ipv6 {ipv6}",
 			f"Allocated VF for you {pci}")
-		return self.find_ipv6(output)
 
-	def delmachine(self, vm_name):
-		self.assert_output(f"--delmachine {vm_name}", "Interface deleted")
+	def getinterface(self, vm_name):
+		output = self._call(f"--getmachine {vm_name}", "")
+		if not output:
+			return None
+		match = re.search(r'(?:^|[\n\r])Interface with ipv4 ([0-9\.]+) ipv6 ([0-9a-fA-F:]+) vni ([0-9]+) pci ([^ ]+) underlayroute ([0-9a-fA-F:]+)', output)
+		return { 'vni': int(match.group(3)), 'device': match.group(4), 'ips': [ match.group(1), match.group(2) ], 'underlayRoute': match.group(5) }
 
-	def get_ul_ipv6(self, vm_name):
-		output = self.assert_output(f"--getmachine {vm_name}",
-			f" underlayroute ")
-		return self.find_ipv6(output, self.re_machine_ipv6)
+	def delinterface(self, vm_name):
+		self._call(f"--delmachine {vm_name}", "Interface deleted")
 
-	def addroute_ipv4(self, vni, ipv4_addr, ipv4_len, t_vni, t_ipv6):
-		self.assert_output(f"--addroute --vni {vni} --ipv4 {ipv4_addr} --length {ipv4_len} --t_vni {t_vni} --t_ipv6 {t_ipv6}",
-			f"Route ip {ipv4_addr} length {ipv4_len} vni {vni}")
+	def listinterfaces(self):
+		output = self._call("--getmachines", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r'(?:^|[\n\r])Interface [a-zA-Z0-9_]+ ipv4 ([0-9\.]+) ipv6 ([0-9a-fA-F:]+) vni ([0-9]+) pci ([^ ]+) underlayroute ([0-9a-fA-F:]+)', output):
+			specs.append({ 'vni': int(match.group(3)), 'device': match.group(4), 'ips': [ match.group(1), match.group(2) ], 'underlayRoute': match.group(5) })
+		return specs
 
-	def delroute_ipv4(self, vni, ipv4_addr, ipv4_len):
-		self.assert_output(f"--delroute --vni {vni} --ipv4 {ipv4_addr} --length {ipv4_len}",
+	def addroute(self, vni, prefix, t_vni, t_ipv6):
+		pfx_addr, pfx_len = prefix.split('/')
+		if ':' in pfx_addr:
+			self._call(f"--addroute --vni {vni} --ipv6 {pfx_addr} --length {pfx_len} --t_vni {t_vni} --t_ipv6 {t_ipv6}",
+				f"target ipv6 {pfx_addr} target vni {t_vni}")
+		else:
+			self._call(f"--addroute --vni {vni} --ipv4 {pfx_addr} --length {pfx_len} --t_vni {t_vni} --t_ipv6 {t_ipv6}",
+				f"Route ip {pfx_addr} length {pfx_len} vni {vni}")
+
+	def delroute(self, vni, prefix):
+		pfx_addr, pfx_len = prefix.split('/')
+		ipver = '--ipv6' if ':' in pfx_addr else '--ipv4'
+		self._call(f"--delroute --vni {vni} {ipver} {pfx_addr} --length {pfx_len}",
 			"Route deleted")
 
-	def addroute_ipv6(self, vni, ipv6_addr, ipv6_len, t_vni, t_ipv6):
-		self.assert_output(f"--addroute --vni {vni} --ipv6 {ipv6_addr} --length {ipv6_len} --t_vni {t_vni} --t_ipv6 {t_ipv6}",
-			f"target ipv6 {ipv6_addr} target vni {t_vni}")
+	def listroutes(self, vni):
+		output = self._call(f"--listroutes --vni {vni}", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r'(?:^|[\n\r])Route prefix ([0-9\.]+) len ([0-9]+) target vni ([0-9]+) target ipv6 ([0-9a-fA-F:]+)', output):
+			specs.append({ "vni": vni, "prefix": match.group(1)+'/'+match.group(2), "nextHop": { "vni": int(match.group(3)), "ip": match.group(4) } })
+		return specs
 
-	def addpfx(self, vm_name, ipv4_addr, ipv4_len):
-		output = self.assert_output(f"--addpfx {vm_name} --ipv4 {ipv4_addr} --length {ipv4_len}",
-			"Received underlay route : ")
-		return self.find_ipv6(output)
+	def addprefix(self, vm_name, prefix):
+		pfx_addr, pfx_len = prefix.split('/')
+		return self._getUnderlayRoute(f"--addpfx {vm_name} --ipv4 {pfx_addr} --length {pfx_len}", "")
 
-	def delpfx(self, vm_name, ipv4_addr, ipv4_len):
-		self.assert_output(f"--delpfx {vm_name} --ipv4 {ipv4_addr} --length {ipv4_len}",
-			"Prefix deleted")
+	def delprefix(self, vm_name, prefix):
+		pfx_addr, pfx_len = prefix.split('/')
+		self._call(f"--delpfx {vm_name} --ipv4 {pfx_addr} --length {pfx_len}", "")
 
-	def createlb(self, name, vni, vip, port, proto):
-		output = self.assert_output(f"--createlb {name} --vni {vni} --ipv4 {vip} --port {port} --protocol {proto}",
+	def listprefixes(self, vm_name):
+		output = self._call(f"--listpfx {vm_name}", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r'(?:^|[\n\r])Route prefix ([0-9\.]+) len ([0-9]+) underlayroute ([0-9a-fA-F:]+)', output):
+			specs.append({ "prefix": match.group(1)+'/'+match.group(2), "underlayRoute": match.group(3) })
+		return specs
+
+	def createlb(self, name, vni, vip, portspecs):
+		proto, port = portspecs.split('/')
+		return self._getUnderlayRoute(f"--createlb {name} --vni {vni} --ipv4 {vip} --port {port} --protocol {proto}",
 			f"VIP {vip}, vni {vni}")
-		return self.find_ipv6(output)
+
+	def getlb(self, name):
+		output = self._call(f"--getlb {name}", "")
+		if not output:
+			return None
+		match = re.search(r'(?:^|[\n\r])Received LB with vni: ([0-9]+) UL: ([0-9a-fA-F:]+) LB ip: ([0-9\.]+) with ports: ([^\r\n]+)', output)
+		portspecs = match.group(4)
+		lbports = []
+		for portspec in portspecs.split(' '):
+			port, proto = portspec.split(',')
+			if proto.lower() == 'tcp':
+				proto = 6
+			elif proto.lower() == 'udp':
+				proto = 17
+			elif proto.lower() == 'icmp':
+				proto = 1
+			lbports.append({ 'protocol': proto, 'port': int(port) })
+		return { "vni": int(match.group(1)), "lbVipIP": match.group(3), "lbports": lbports, "underlayRoute": match.group(2) }
 
 	def dellb(self, name):
-		self.assert_output(f"--dellb {name}", "LB deleted")
+		self._call(f"--dellb {name}", "LB deleted")
 
-	def addlbvip(self, name, ipv6):
-		self.assert_output(f"--addlbvip {name} --t_ipv6 {ipv6}", "LB VIP added")
+	def addlbtarget(self, lb_name, ipv6):
+		self._call(f"--addlbvip {lb_name} --t_ipv6 {ipv6}", "LB VIP added")
 
-	def dellbvip(self, name, ipv6):
-		self.assert_output(f"--dellbvip {name} --t_ipv6 {ipv6}", "LB VIP deleted")
+	def dellbtarget(self, lb_name, ipv6):
+		self._call(f"--dellbvip {lb_name} --t_ipv6 {ipv6}", "LB VIP deleted")
 
-	def addlbpfx(self, name, vip):
-		output = self.assert_output(f"--addlbpfx {name} --ipv4 {vip} --length 32",
+	def listlbtargets(self, lb_name):
+		output = self._call(f"--listbackips {lb_name}", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r'(?:^|[\n\r])Backend ip ([0-9a-fA-F:]+)', output):
+			specs.append({ 'targetIP': match.group(1) })
+		return specs
+
+	def addlbprefix(self, vm_name, vip):
+		return self._getUnderlayRoute(f"--addlbpfx {vm_name} --ipv4 {vip} --length 32",
 			"Received underlay route : ")
-		return self.find_ipv6(output)
 
-	def dellbpfx(self, name, vip):
-		self.assert_output(f"--dellbpfx {name} --ipv4 {vip} --length 32",
+	def dellbprefix(self, vm_name, vip):
+		self._call(f"--dellbpfx {vm_name} --ipv4 {vip} --length 32",
 			"LB prefix deleted")
 
+	def listlbprefixes(self, vm_name):
+		output = self._call(f"--listlbpfx {vm_name}", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r'(?:^|[\n\r])LB Route prefix ([0-9\.]+) len ([0-9]+) underlayroute ([0-9a-fA-F:]+)', output):
+			specs.append({ "prefix": match.group(1)+'/'+match.group(2), "underlayRoute": match.group(3) })
+		return specs
+
 	def addvip(self, vm_name, vip):
-		output = self.assert_output(f"--addvip {vm_name} --ipv4 {vip}",
+		return self._getUnderlayRoute(f"--addvip {vm_name} --ipv4 {vip}",
 			"Received underlay route : ")
-		return self.find_ipv6(output)
+
+	def getvip(self, vm_name):
+		output = self._call(f"--getvip {vm_name}", "")
+		if not output:
+			return None
+		match = re.search(r'Received VIP ([0-9\.]+) underlayroute ([a-f0-9:]+)', output)
+		return { 'vipIP': match.group(1), 'underlayRoute': match.group(2) }
 
 	def delvip(self, vm_name):
-		self.assert_output(f"--delvip {vm_name}", "VIP deleted")
+		self._call(f"--delvip {vm_name}", "VIP deleted")
 
 	def addnat(self, vm_name, vip, min_port, max_port):
-		output = self.assert_output(f"--addnat {vm_name} --ipv4 {vip} --min_port {min_port} --max_port {max_port}",
+		return self._getUnderlayRoute(f"--addnat {vm_name} --ipv4 {vip} --min_port {min_port} --max_port {max_port}",
 			"Received underlay route : ")
-		return self.find_ipv6(output)
+
+	def getnat(self, vm_name):
+		output = self._call(f"--getnat {vm_name}", "")
+		if not output:
+			return None
+		match = re.search(r'Received NAT IP ([0-9\.]+) with min port: ([0-9]+) and max port: ([0-9]+) underlay ([a-f0-9:]+)', output)
+		return { 'natVIPIP': match.group(1), 'underlayRoute': match.group(4), 'minPort': int(match.group(2)), 'maxPort': int(match.group(3)) }
 
 	def delnat(self, vm_name):
-		self.assert_output(f"--delnat {vm_name}", "NAT deleted")
+		self._call(f"--delnat {vm_name}", "NAT deleted")
+
+	def getnatinfo(self, nat_vip, info_type):
+		output = self._call(f"--getnatinfo {info_type} --ipv4 {nat_vip}", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r'(?:^|[\n\r]) *[0-9]+: min_port ([0-9]+), max_port ([0-9]+) --> Underlay IPv6 ([a-f0-9:]+)(?:$|[\n\r])', output):
+			specs.append({ 'natVIPIP': nat_vip, 'underlayRoute': match.group(3), 'minPort': int(match.group(1)), 'maxPort': int(match.group(2)) })
+		return specs
 
 	def addneighnat(self, nat_vip, vni, min_port, max_port, t_ipv6):
-		self.assert_output(f"--addneighnat --ipv4 {nat_vip} --vni {vni} --min_port {min_port} --max_port {max_port} --t_ipv6 {t_ipv6}",
+		self._call(f"--addneighnat --ipv4 {nat_vip} --vni {vni} --min_port {min_port} --max_port {max_port} --t_ipv6 {t_ipv6}",
 			"Neighbor NAT added")
 
 	def delneighnat(self, nat_vip, vni, min_port, max_port):
-		self.assert_output(f"--delneighnat --ipv4 {nat_vip} --vni {vni} --min_port {min_port} --max_port {max_port}",
+		self._call(f"--delneighnat --ipv4 {nat_vip} --vni {vni} --min_port {min_port} --max_port {max_port}",
 			"Neighbor NAT deleted")
 
-	def addfwallrule(self, vm_name, rule_id, src_ip, src_ip_len, dst_ip, dst_ip_len, src_port_min, src_port_max, dst_port_min, dst_port_max, proto, action, direction):
-		self.assert_output(f"--addfwrule  {vm_name} --fw_ruleid {rule_id} --src_ip {src_ip} --src_length {src_ip_len}  --dst_ip {dst_ip} --dst_length {dst_ip_len} "
-							f"--src_port_min {src_port_min} --src_port_max {src_port_max} --dst_port_min {dst_port_min} --dst_port_max {dst_port_max} --protocol {proto} "
-							f"--action {action} --direction {direction}",
-							"Add FirewallRule called")
+	def addfwallrule(self, vm_name, rule_id,
+				     src_prefix="0.0.0.0/0", dst_prefix="0.0.0.0/0", proto=None,
+				     src_port_min=-1, src_port_max=-1, dst_port_min=-1, dst_port_max=-1,
+				     action="accept", direction="ingress", priority=None):
+		protospec = "" if proto is None else f"--protocol {proto}"
+		priospec = "" if priority is None else f"--priority {priority}"
+		src_addr, src_len = src_prefix.split('/')
+		dst_addr, dst_len = dst_prefix.split('/')
+		self._call(f"--addfwrule {vm_name} --fw_ruleid {rule_id} --src_ip {src_addr} --src_length {src_len} --dst_ip {dst_addr} --dst_length {dst_len} {protospec}"
+				  f" --src_port_min {src_port_min} --src_port_max {src_port_max} --dst_port_min {dst_port_min} --dst_port_max {dst_port_max}"
+				  f" --action {action} --direction {direction} {priospec}",
+			"Add FirewallRule called")
+
+	def getfwallrule(self, vm_name, rule_id):
+		output = self._call(f"--getfwrule {vm_name} --fw_ruleid {rule_id}", "")
+		if not output:
+			return None
+		match = re.search(rule_id + r' / src_ip: ([0-9\.]+) / src_ip pfx length: ([0-9]+) / dst_ip: ([0-9\.]+) / dst_ip pfx length: ([0-9]+) \n'
+						r'protocol: ([a-z]+) / src_port_min: (\-?[0-9]+) / src_port_max: (\-?[0-9]+) / dst_port_min: (\-?[0-9]+) / dst_port_max: (\-?[0-9]+) \n'
+						r'direction: ([a-z]+) / action: ([a-z]+)', output)
+		return { "trafficDirection": match.group(10).capitalize(), "firewallAction": match.group(11).capitalize(), "priority": 1000, "ipVersion": "IPv4",
+				 "sourcePrefix": match.group(1)+'/'+match.group(2), "destinationPrefix": match.group(3)+'/'+match.group(4),
+				 "protocolFilter": { "Filter": { match.group(5).capitalize(): {
+					 "srcPortLower": int(match.group(6)), "srcPortUpper": int(match.group(7)), "dstPortLower": int(match.group(8)), "dstPortUpper": int(match.group(9))
+				 } } } }
 
 	def delfwallrule(self, vm_name, rule_id):
-		self.assert_output(f"--delfwrule  {vm_name} --fw_ruleid {rule_id}",
-							"Firewall Rule Deleted")
+		self._call(f"--delfwrule {vm_name} --fw_ruleid {rule_id}",
+			"Firewall Rule Deleted")
+
+	def listfwallrules(self, vm_name):
+		output = self._call(f"--listfwrules {vm_name}", "")
+		if not output:
+			return None
+		specs = []
+		for match in re.finditer(r' / src_ip: ([0-9\.]+) / src_ip pfx length: ([0-9]+) / dst_ip: ([0-9\.]+) / dst_ip pfx length: ([0-9]+) \n'
+						r'protocol: ([a-z]+) / src_port_min: (\-?[0-9]+) / src_port_max: (\-?[0-9]+) / dst_port_min: (\-?[0-9]+) / dst_port_max: (\-?[0-9]+) \n'
+						r'direction: ([a-z]+) / action: ([a-z]+)', output):
+			specs.append({
+				"trafficDirection": match.group(10).capitalize(), "firewallAction": match.group(11).capitalize(), "priority": 1000, "ipVersion": "IPv4",
+				"sourcePrefix": match.group(1)+'/'+match.group(2), "destinationPrefix": match.group(3)+'/'+match.group(4),
+				"protocolFilter": { "Filter": { match.group(5).capitalize(): {
+					"srcPortLower": int(match.group(6)), "srcPortUpper": int(match.group(7)), "dstPortLower": int(match.group(8)), "dstPortUpper": int(match.group(9))
+				} } } })
+		return specs
+
+	def vniinuse(self, vni):
+		output = self._call(f"--vni_in_use --vni {vni}", "")
+		match = re.search(r'(?:^|[\n\r])Vni: '+str(vni)+' is (.*in use)', output)
+		return match.group(1) == 'in use'
 
 	@staticmethod
 	def port_open():

--- a/test/test_pf_to_vf.py
+++ b/test/test_pf_to_vf.py
@@ -12,20 +12,20 @@ def send_lb_pkt_to_pf(lb_ul_ipv6):
 
 def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 
-	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, 80, "tcp")
-	lbpfx_ul_ipv6 = grpc_client.addlbpfx(VM1.name, lb_ip)
-	grpc_client.addlbvip(lb_name, lbpfx_ul_ipv6)
+	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
+	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_ip)
+	grpc_client.addlbtarget(lb_name, lbpfx_ul_ipv6)
 
 	threading.Thread(target=send_lb_pkt_to_pf, args=(lb_ul_ipv6,)).start()
-	grpc_client.addfwallrule(VM1.name, "fw0-vm1", "0.0.0.0", 0, "0.0.0.0", 0, -1, -1, 80, 80, "tcp", "accept", "ingress")
+	grpc_client.addfwallrule(VM1.name, "fw0-vm1", proto="tcp", dst_port_min=80, dst_port_max=80)
 	pkt = sniff_packet(VM1.tap, is_tcp_pkt)
 	dst_ip = pkt[IP].dst
 	dport = pkt[TCP].dport
 	assert dst_ip == lb_ip and dport == 80, \
 		f"Wrong packet received (ip: {dst_ip}, dport: {dport})"
 
-	grpc_client.dellbvip(VM1.name, lbpfx_ul_ipv6)
-	grpc_client.dellbpfx(VM1.name, lb_ip)
+	grpc_client.dellbtarget(VM1.name, lbpfx_ul_ipv6)
+	grpc_client.dellbprefix(VM1.name, lb_ip)
 	grpc_client.dellb(lb_name)
 	grpc_client.delfwallrule(VM1.name, "fw0-vm1")
 	# TODO: Currently, to use this test again with the same port(s)

--- a/test/test_vf_to_pf.py
+++ b/test/test_vf_to_pf.py
@@ -160,7 +160,7 @@ def test_vf_to_pf_firewall_tcp(prepare_ipv4, grpc_client):
 	resp_thread = threading.Thread(target=sniff_tcp_fwall_packet, args=(PF0.tap, sniff_tcp_data, negated))
 	resp_thread.start()
 	#Allow only tcp packets to leave the VM with destination port 453
-	grpc_client.addfwallrule(VM1.name, "fw0-vm1", 0, 0, "0.0.0.0", 0, -1, -1, 453, 453, "tcp", "accept", "egress")
+	grpc_client.addfwallrule(VM1.name, "fw0-vm1", proto="tcp", dst_port_min=453, dst_port_max=453, direction="egress")
 	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
 			   IP(dst=public_ip, src=VM1.ip) /
 			   TCP(dport=1024))
@@ -178,7 +178,7 @@ def test2_vf_to_pf_firewall_tcp(prepare_ipv4, grpc_client, port_redundancy):
 	resp_thread = threading.Thread(target=sniff_tcp_fwall_packet, args=(PF0.tap, sniff_tcp_data,))
 	resp_thread.start()
 	#Allow only tcp packets to leave the VM with destination port 453
-	grpc_client.addfwallrule(VM1.name, "fw1-vm1", 0, 0, "0.0.0.0", 0, -1, -1, 453, 453, "tcp", "accept", "egress")
+	grpc_client.addfwallrule(VM1.name, "fw1-vm1", proto="tcp", dst_port_min=453, dst_port_max=453, direction="egress")
 	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
 			   IP(dst=public_ip, src=VM1.ip) /
 			   TCP(dport=453))

--- a/test/test_vf_to_vf.py
+++ b/test/test_vf_to_vf.py
@@ -16,7 +16,7 @@ def test_vf_to_vf_tcp(prepare_ipv4, grpc_client):
 
 	threading.Thread(target=vf_to_vf_tcp_responder, args=(VM2.tap,)).start()
 
-	grpc_client.addfwallrule(VM2.name, "fw0-vm2", "0.0.0.0", 0, "0.0.0.0", 0, -1, -1, 1234, 1234, "tcp", "accept", "ingress")
+	grpc_client.addfwallrule(VM2.name, "fw0-vm2", proto="tcp", dst_port_min=1234, dst_port_max=1234)
 	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
 			   IP(dst=VM2.ip, src=VM1.ip) /
 			   TCP(dport=1234))
@@ -31,7 +31,7 @@ def test_vf_to_vf_vip_dnat(prepare_ipv4, grpc_client):
 	threading.Thread(target=vf_to_vf_tcp_responder, args=(VM2.tap,)).start()
 
 	grpc_client.addvip(VM2.name, vip_vip)
-	grpc_client.addfwallrule(VM2.name, "fw0-vm2", "0.0.0.0", 0, "0.0.0.0", 0, -1, -1, 1235, 1235, "tcp", "accept", "ingress")
+	grpc_client.addfwallrule(VM2.name, "fw0-vm2", proto="tcp", dst_port_min=1235, dst_port_max=1235)
 
 	# vm1 (vf0) -> vm2 (vf2), vm2 has VIP, send packet to VIP from vm1 side, whether the packet is received
 	# and sent back by vm2 (DNAT)
@@ -52,7 +52,7 @@ def test1_vf_to_vf_firewall_tcp(prepare_ipv4, grpc_client):
 	resp_thread.start()
 
 	#Accept only tcp packets from the source ip VM1.ip / 32, do not care about the rest
-	grpc_client.addfwallrule(VM2.name, "fw1-vm2", f"{VM1.ip}", 32, "0.0.0.0", 0, -1, -1, -1, -1, "tcp", "accept", "ingress")
+	grpc_client.addfwallrule(VM2.name, "fw1-vm2", src_prefix=f"{VM1.ip}/32", proto="tcp")
 	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
 			   IP(dst=VM2.ip, src=VM1.ip) /
 			   TCP(sport=1001, dport=1234))
@@ -71,7 +71,7 @@ def test2_vf_to_vf_firewall_tcp(prepare_ipv4, grpc_client):
 	resp_thread.start()
 
 	#Accept only tcp packets from the source ip 1.2.3.4 / 16 range, do not care about the rest
-	grpc_client.addfwallrule(VM2.name, "fw0-vm2", "1.2.3.4", 16, "0.0.0.0", 0, -1, -1, -1, -1, "tcp", "accept", "ingress")
+	grpc_client.addfwallrule(VM2.name, "fw0-vm2", src_prefix="1.2.3.4/16", proto="tcp")
 	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
 			   IP(dst=VM2.ip, src=VM1.ip) /
 			   TCP(sport=1002, dport=1234))

--- a/test/test_vni.py
+++ b/test/test_vni.py
@@ -2,18 +2,18 @@ from helpers import *
 
 
 def test_vni_existence(prepare_ipv4, grpc_client):
-	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni3, lb_ip, 80, "tcp")
-	grpc_client.assert_output(f"--vni_in_use  --vni {vni3}",
-		f"not in use", negate=True)
+	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni3, lb_ip, "tcp/80")
+	assert grpc_client.vniinuse(vni3), \
+		f"VNI {vni3} should be in use"
 
-	grpc_client.addmachine(VM4.name, VM4.pci, vni3, VM4.ip, VM4.ipv6)
-	grpc_client.assert_output(f"--vni_in_use  --vni {vni3}",
-		f"not in use", negate=True)
+	grpc_client.addinterface(VM4.name, VM4.pci, vni3, VM4.ip, VM4.ipv6)
+	assert grpc_client.vniinuse(vni3), \
+		f"VNI {vni3} should be in use"
 
-	grpc_client.delmachine(VM4.name)
-	grpc_client.assert_output(f"--vni_in_use  --vni {vni3}",
-		f"not in use", negate=True)
+	grpc_client.delinterface(VM4.name)
+	assert grpc_client.vniinuse(vni3), \
+		f"VNI {vni3} should be in use"
 
 	grpc_client.dellb(lb_name)
-	grpc_client.assert_output(f"--vni_in_use  --vni {vni3}",
-		f"not in use")
+	assert not grpc_client.vniinuse(vni3), \
+		f"VNI {vni3} should not be in use anymore"


### PR DESCRIPTION
There was a need to adapt pytest to the new golang gRPC client.

But as the actual integration can take more due to dependencies and making the CLI easier for OPs on TSi side, metalnet discussion, etc. I wanted to prevent unnecessary git conflicts with any new features done to dp-service in the meantime.

Therefore I would like to change the pytest `grpc_client` API in advance, so the only change needed is then to replace the `grpc_client` class itself, with all tests left untouched and additions working seamlessly (this is currently not possible due to all the searching in standard output).

Aside from the `grpc_client` itself (which does now look worse/complex, but that is temporary), all affected tests should actually be easier to read now:
1. Instead of `assert_output` textually, the returned value is an object, so now for example testing that deletion from a list worked is easy: `if spec not in list`
2. Instead of looking for "Error ###" in the output manually, an exception is raised
3. To test error states, there is an `except_error(number)` call to instead throw an exception when this error **does not** occur
4. Small things like renaming `machine` to `interface` as per protocol, implicit values for firewall rules, etc.
