### PR TITLE
Fix wrong optimization for virtual service pointer in packet data.

### DIFF
--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -69,12 +69,10 @@ struct dp_flow {
 	uint8_t					vnf_type;
 	uint8_t					nxt_hop;
 	enum dp_periodic_type	periodic_type;
-	union {
-		struct flow_value	*conntrack;
+	struct flow_value	*conntrack;
 #ifdef ENABLE_VIRTSVC
-		struct dp_virtsvc	*virtsvc;
+	struct dp_virtsvc	*virtsvc;
 #endif
-	};
 };
 static_assert(sizeof(struct dp_flow) <= DP_MBUF_PRIV_DATA_SIZE,
 			  "struct dp_flow is too big to fit in packet");


### PR DESCRIPTION
The optimization for private packet data size for virtual services was wrong as the `conntrack` pointer is not only used during connection tracking, but also by Tx nodes for every packet.

This of course resulted in an invalid memory access (manifested by attempts to offload the flow for virtual service even when offloading is disabled).