### PR TITLE
Added default route to gRPC list routes, refactored code

### DIFF
--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -203,9 +203,9 @@ def test_grpc_add_list_del_routes_big_reply(prepare_ifaces, grpc_client):
 		grpc_client.addroute(vni1, ov_target_pfx, 0, neigh_vni1_ul_ipv6)
 
 	specs = grpc_client.listroutes(vni1)
-	# +1 for the one already there (from env setup)
-	assert len(specs) == MAX_LINES_ROUTE_REPLY + 1, \
-		f"Not all routes have been added ({len(specs)}/{MAX_LINES_ROUTE_REPLY+1})"
+	# +2 for the ones already there (from env setup)
+	assert len(specs) == MAX_LINES_ROUTE_REPLY + 2, \
+		f"Not all routes have been added ({len(specs)}/{MAX_LINES_ROUTE_REPLY+2})"
 
 	for subnet in range(30, 30+MAX_LINES_ROUTE_REPLY):
 		ov_target_pfx = f"192.168.{subnet}.0/32"


### PR DESCRIPTION
I found it confusing that the default route was not part of the gRPC call "list routes". As you suggested, that is more of a limitation of the DPDK RIB traversal function, so I added an explicit lookup for it.

To prevent code reuse, I refactored the route listing implementation. It could be simplified a bit given that some of its arguments are actually constant (i.e. it is never called for internal routes and any other port id than 0), but I left that for the future.

I looked into metalnet and it does not seem to ever call the route listing, so the addition of a new entry (or a possible bug in refactoring) should not break anything anyway. But best to verify that.