### PR TITLE
Add ResetVni() GRPC function

### DIFF
--- a/include/dp_error.h
+++ b/include/dp_error.h
@@ -95,6 +95,7 @@ const char *dp_strerror(int error);
 	ERR(DEL_PREFIX_ROUTE_ERR,				700) \
 	ERR(DEL_PREFIX_NO_VM,					701) \
 	ERR(INIT_RESET_ERR,						710) \
+	ERR(VNI_TABLE_RESET_ERR,				711) \
 	ERR(ADD_LB_UNSUPP_IP,					750) \
 	ERR(ADD_LB_CREATE_ERR,					751) \
 	ERR(ADD_LB_VNF_ERR,						752) \

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -116,6 +116,7 @@ void dp_set_vm_pxe_ip4(uint16_t portid, uint32_t ip, int socketid);
 char* dp_get_vm_pxe_str(uint16_t portid);
 void dp_set_vm_pxe_str(uint16_t portid, char *p_str);
 int dp_lpm_reset_all_route_tables(int socketid);
+int dp_lpm_reset_route_tables(int vni, int socketid);
 struct dp_fwall_head *dp_get_fwall_head(int port_id);
 void dp_set_fwall_head(int port_id, struct dp_fwall_head *fwall_head);
 #ifdef __cplusplus

--- a/include/grpc/dp_async_grpc.h
+++ b/include/grpc/dp_async_grpc.h
@@ -77,6 +77,21 @@ public:
 	int Proceed() override;
 };
 
+class ResetVniCall final : BaseCall {
+	ServerContext ctx_;
+	ResetVniRequest request_;
+	Status reply_;
+	ServerAsyncResponseWriter<Status> responder_;
+
+public:
+	ResetVniCall(DPDKonmetal::AsyncService* service, ServerCompletionQueue* cq)
+	:BaseCall(service, cq, DP_REQ_TYPE_VNI_RESET), responder_(&ctx_) {
+		service_->RequestresetVni(&ctx_, &request_, &responder_, cq_, cq_,
+														   this);
+	}
+	int Proceed() override;
+};
+
 class DelLBTargetPfxCall final : BaseCall {
 	ServerContext ctx_;
 	DeleteInterfaceLoadBalancerPrefixRequest request_;

--- a/include/grpc/dp_grpc_impl.h
+++ b/include/grpc/dp_grpc_impl.h
@@ -51,6 +51,7 @@ typedef enum {
 	DP_REQ_TYPE_ADD_NEIGH_NAT,
 	DP_REQ_TYPE_DEL_NEIGH_NAT,
 	DP_REQ_TYPE_IS_VNI_IN_USE,
+	DP_REQ_TYPE_VNI_RESET,
 } dp_req_type;
 
 typedef enum {

--- a/proto/dpdk.proto
+++ b/proto/dpdk.proto
@@ -453,6 +453,10 @@ message IsVniInUseResponse {
 	Status status = 2;
 }
 
+message ResetVniRequest {
+	uint32 vni = 1;
+	VniType type = 2;
+}
 
 service DPDKonmetal {
 	//// INITIALIZATION
@@ -535,6 +539,7 @@ service DPDKonmetal {
 	// VNI can be in use by interfaces and by loadbalancer. So get information
 	// whether the VNI in question is in use or not.
 	rpc isVniInUse(IsVniInUseRequest) returns (IsVniInUseResponse) {}
+	rpc resetVni(ResetVniRequest) returns (Status) {}
 
 	//// FIREWALL
 	rpc listFirewallRules(ListFirewallRulesRequest) returns (ListFirewallRulesResponse) {}

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -391,6 +391,18 @@ err:
 	return ret;
 }
 
+static int dp_process_vni_reset(dp_request *req, dp_reply *rep)
+{
+	if (req->vni_in_use.type == DP_VNI_BOTH) {
+		if (DP_FAILED(dp_lpm_reset_route_tables(req->vni_in_use.vni, rte_eth_dev_socket_id(dp_port_get_pf0_id())))) {
+			rep->com_head.err_code = DP_GRPC_ERR_VNI_TABLE_RESET_ERR;
+			return EXIT_FAILURE;
+		}
+	}
+
+	return EXIT_SUCCESS;
+}
+
 static int dp_process_addvip(dp_request *req, dp_reply *rep)
 {
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
@@ -1143,6 +1155,9 @@ int dp_process_request(struct rte_mbuf *m)
 		break;
 	case DP_REQ_TYPE_IS_VNI_IN_USE:
 		ret = dp_process_vni_in_use(req, &rep);
+		break;
+	case DP_REQ_TYPE_VNI_RESET:
+		ret = dp_process_vni_reset(req, &rep);
 		break;
 	case DP_REQ_TYPE_CREATELB:
 		ret = dp_process_add_lb(req, &rep);

--- a/src/grpc/dp_grpc_service.cpp
+++ b/src/grpc/dp_grpc_service.cpp
@@ -91,6 +91,7 @@ void GRPCService::HandleRpcs()
 	new DelFirewallRuleCall(this, cq_.get());
 	new ListFirewallRulesCall(this, cq_.get());
 	new IsVniInUseCall(this, cq_.get());
+	new ResetVniCall(this, cq_.get());
 
 	while (true) {
 		GPR_ASSERT(cq_->Next(&tag, &ok));

--- a/test/grpc_client.py
+++ b/test/grpc_client.py
@@ -275,6 +275,12 @@ class GrpcClient:
 		match = re.search(r'(?:^|[\n\r])Vni: '+str(vni)+' is (.*in use)', output)
 		return match.group(1) == 'in use'
 
+	def resetvni(self, vni):
+		output = self._call(f"--reset_vni --vni {vni}", "")
+		match = re.search(r'(?:^|[\n\r])Vni: '+str(vni)+' (.*resetted)', output)
+		return match.group(1) == 'resetted'
+
+
 	@staticmethod
 	def port_open():
 		with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/test/test_vni.py
+++ b/test/test_vni.py
@@ -17,3 +17,23 @@ def test_vni_existence(prepare_ipv4, grpc_client):
 	grpc_client.dellb(lb_name)
 	assert not grpc_client.vniinuse(vni3), \
 		f"VNI {vni3} should not be in use anymore"
+
+
+def test_vni_reset(prepare_ipv4, grpc_client):
+	grpc_client.addinterface(VM4.name, VM4.pci, vni3, VM4.ip, VM4.ipv6)
+	grpc_client.addroute(vni3, neigh_vni1_ov_ip_route, 0, neigh_vni1_ul_ipv6)
+
+
+	routespec = { "vni": vni3, "prefix": neigh_vni1_ov_ip_route, "nextHop": { "vni": 0, "ip": neigh_vni1_ul_ipv6 } }
+	routes = grpc_client.listroutes(vni3)
+	assert routespec in routes, \
+		"List of routes does not contain the added route"
+
+	assert grpc_client.resetvni(vni3), \
+		f"VNI {vni3} should be resettable"
+
+	routes = grpc_client.listroutes(vni3)
+	assert routespec not in routes, \
+		"List of routes contains the route although vni resetted"
+
+	grpc_client.delinterface(VM4.name)

--- a/tools/dp_grpc_client.cpp
+++ b/tools/dp_grpc_client.cpp
@@ -31,6 +31,7 @@ typedef enum {
 	DP_CMD_DEL_ROUTE,
 	DP_CMD_GET_ROUTE,
 	DP_CMD_GET_VNI,
+	DP_CMD_RESET_VNI,
 	DP_CMD_ADD_VIP,
 	DP_CMD_DEL_VIP,
 	DP_CMD_GET_VIP,
@@ -167,6 +168,7 @@ static uint32_t priority = 1000;
 #define CMD_LINE_OPT_FWALL_ACTION	"action"
 #define CMD_LINE_OPT_FWALL_PRIO		"priority"
 #define CMD_LINE_OPT_VNI_IN_USE		"vni_in_use"
+#define CMD_LINE_OPT_RESET_VNI		"reset_vni"
 
 enum {
 	CMD_LINE_OPT_MIN_NUM = 256,
@@ -178,6 +180,7 @@ enum {
 	CMD_LINE_OPT_DEL_ROUTE_NUM,
 	CMD_LINE_OPT_GET_ROUTE_NUM,
 	CMD_LINE_OPT_VNI_IN_USE_NUM,
+	CMD_LINE_OPT_RESET_VNI_NUM,
 	CMD_LINE_OPT_VNI_NUM,
 	CMD_LINE_OPT_T_VNI_NUM,
 	CMD_LINE_OPT_PRIMARY_IPV4_NUM,
@@ -245,6 +248,7 @@ static const struct option lgopts[] = {
 	{CMD_LINE_OPT_DEL_ROUTE, 0, 0, CMD_LINE_OPT_DEL_ROUTE_NUM},
 	{CMD_LINE_OPT_GET_ROUTE, 0, 0, CMD_LINE_OPT_GET_ROUTE_NUM},
 	{CMD_LINE_OPT_VNI_IN_USE, 0, 0, CMD_LINE_OPT_VNI_IN_USE_NUM},
+	{CMD_LINE_OPT_RESET_VNI, 0, 0, CMD_LINE_OPT_RESET_VNI_NUM},
 	{CMD_LINE_OPT_VNI, 1, 0, CMD_LINE_OPT_VNI_NUM},
 	{CMD_LINE_OPT_T_VNI, 1, 0, CMD_LINE_OPT_T_VNI_NUM},
 	{CMD_LINE_OPT_PRIMARY_IPV4, 1, 0, CMD_LINE_OPT_PRIMARY_IPV4_NUM},
@@ -365,6 +369,9 @@ int parse_args(int argc, char **argv)
 			break;
 		case CMD_LINE_OPT_VNI_IN_USE_NUM:
 			command = DP_CMD_GET_VNI;
+			break;
+		case CMD_LINE_OPT_RESET_VNI_NUM:
+			command = DP_CMD_RESET_VNI;
 			break;
 		case CMD_LINE_OPT_VNI_NUM:
 			strncpy(vni_str, optarg, 29);
@@ -714,6 +721,21 @@ public:
 				printf("Vni: %d is in use\n", vni);
 			else
 				printf("Vni: %d is not in use\n", vni);
+	}
+
+	void ResetVni() {
+			ResetVniRequest request;
+			Status reply;
+			ClientContext context;
+
+			request.set_vni(vni);
+			request.set_type(dpdkonmetal::VniIpv4AndIpv6);
+
+			stub_->resetVni(&context, request, &reply);
+			if (reply.error())
+				printf("Received an error %d\n", reply.error());
+			else
+				printf("Vni: %d resetted\n", vni);
 	}
 
 	void AddLBVIP() {
@@ -1476,6 +1498,10 @@ int main(int argc, char** argv)
 	case DP_CMD_GET_VNI:
 		std::cout << "IsVniInUse called " << std::endl;
 		dpdk_client.VniInUse();
+		break;
+	case DP_CMD_RESET_VNI:
+		std::cout << "ResetVni called " << std::endl;
+		dpdk_client.ResetVni();
 		break;
 	case DP_CMD_DEL_ROUTE:
 		dpdk_client.DelRoute();


### PR DESCRIPTION
Add a GRPC function to reset the VNI route table contents. This is needed in the context of VNI peering.
Checkpatch errors are from cpp part.