### PR TITLE
Added VNI to the output of getnatinfo

### DIFF
--- a/include/grpc/dp_grpc_api.h
+++ b/include/grpc/dp_grpc_api.h
@@ -125,7 +125,7 @@ struct dpgrpc_nat {
 	};
 	uint16_t		min_port;
 	uint16_t		max_port;
-	uint32_t		neigh_vni;							// neighnat only
+	uint32_t		vni;								// neighnat or reply only
 	uint8_t			neigh_addr6[DP_VNF_IPV6_ADDR_SIZE];	// neighnat only
 	uint8_t			type;  // enum dp_natinfo_type		// reply only
 	uint8_t			ul_addr6[DP_VNF_IPV6_ADDR_SIZE];	// reply only

--- a/proto/dpdk.proto
+++ b/proto/dpdk.proto
@@ -317,6 +317,7 @@ message NATInfoEntry {
 	uint32 minPort = 3; 
 	uint32 maxPort = 4;
 	bytes underlayRoute = 5;
+	uint32 vni = 6;
 }
 
 message GetNATInfoResponse {

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -580,6 +580,7 @@ int dp_list_nat_local_entries(uint32_t nat_ip, struct dp_grpc_responder *respond
 			reply->min_port = data->network_nat_port_range[0];
 			reply->max_port = data->network_nat_port_range[1];
 			reply->addr = nkey->ip;
+			reply->vni = nkey->vni;
 		}
 	}
 
@@ -601,6 +602,7 @@ int dp_list_nat_neigh_entries(uint32_t nat_ip, struct dp_grpc_responder *respond
 			reply->type = DP_NATINFO_TYPE_NEIGHBOR;
 			reply->min_port = current->port_range[0];
 			reply->max_port = current->port_range[1];
+			reply->vni = current->vni;
 			rte_memcpy(reply->ul_addr6, current->dst_ipv6, sizeof(current->dst_ipv6));
 		}
 	}

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -1552,7 +1552,7 @@ int AddNeighborNATCall::Proceed()
 		// maybe add a validity check here to ensure minport is not greater than 2^30
 		request.add_neighnat.min_port = request_.minport();
 		request.add_neighnat.max_port = request_.maxport();
-		request.add_neighnat.neigh_vni = request_.vni();
+		request.add_neighnat.vni = request_.vni();
 		ret_val = inet_pton(AF_INET6, request_.underlayroute().c_str(),
 				request.add_neighnat.neigh_addr6);
 		if (ret_val <= 0)
@@ -1607,7 +1607,7 @@ int DeleteNeighborNATCall::Proceed()
 		// maybe add a validity check here to ensure minport is not greater than 2^30
 		request.del_neighnat.min_port = request_.minport();
 		request.del_neighnat.max_port = request_.maxport();
-		request.del_neighnat.neigh_vni = request_.vni();
+		request.del_neighnat.vni = request_.vni();
 		// neigh_addr6 field is implied by this unique NAT definition
 		dp_send_to_worker(&request);  // TODO can fail
 		status_ = AWAIT_MSG;
@@ -1691,6 +1691,7 @@ void GetNATInfoCall::ListCallbackLocal(void *reply, void *context)
 	rep_nat_entry->set_address(inet_ntoa(addr));
 	rep_nat_entry->set_minport(nat->min_port);
 	rep_nat_entry->set_maxport(nat->max_port);
+	rep_nat_entry->set_vni(nat->vni);
 }
 
 void GetNATInfoCall::ListCallbackNeigh(void *reply, void *context)
@@ -1705,6 +1706,7 @@ void GetNATInfoCall::ListCallbackNeigh(void *reply, void *context)
 	rep_nat_entry->set_underlayroute(buf);
 	rep_nat_entry->set_minport(nat->min_port);
 	rep_nat_entry->set_maxport(nat->max_port);
+	rep_nat_entry->set_vni(nat->vni);
 }
 
 int GetNATInfoCall::Proceed()

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -733,14 +733,14 @@ static int dp_process_add_neighnat(struct dp_grpc_responder *responder)
 
 	if (request->ip_type == RTE_ETHER_TYPE_IPV4) {
 		ret = dp_add_network_nat_entry(ntohl(request->addr), NULL,
-									   request->neigh_vni,
+									   request->vni,
 									   request->min_port,
 									   request->max_port,
 									   request->neigh_addr6);
 		if (DP_FAILED(ret))
 			return ret;
 
-		ret = dp_set_dnat_ip(ntohl(request->addr), 0, request->neigh_vni);
+		ret = dp_set_dnat_ip(ntohl(request->addr), 0, request->vni);
 		if (DP_FAILED(ret) && ret != DP_GRPC_ERR_DNAT_EXISTS)
 			return ret;
 	} else
@@ -756,13 +756,13 @@ static int dp_process_del_neighnat(struct dp_grpc_responder *responder)
 
 	if (request->ip_type == RTE_ETHER_TYPE_IPV4) {
 		ret = dp_del_network_nat_entry(ntohl(request->addr), NULL,
-									   request->neigh_vni,
+									   request->vni,
 									   request->min_port,
 									   request->max_port);
 		if (DP_FAILED(ret))
 			return ret;
 
-		dp_del_vip_from_dnat(ntohl(request->addr), request->neigh_vni);
+		dp_del_vip_from_dnat(ntohl(request->addr), request->vni);
 	} else
 		return DP_GRPC_ERR_BAD_IPVER;
 

--- a/tools/dp_grpc_client.cpp
+++ b/tools/dp_grpc_client.cpp
@@ -1413,19 +1413,21 @@ public:
 		if (reply.natinfotype() == dpdkonmetal::NATInfoType::NATInfoLocal) {
 			printf("Following private IPs are NAT into this IPv4 NAT address: %s\n", reply.natvipip().address().c_str());
 			for (i = 0; i < reply.natinfoentries_size(); i++) {
-				printf("  %d: IP %s, min_port %d, max_port %d\n", i+1,
+				printf("  %d: IP %s, min_port %u, max_port %u, vni: %u\n", i+1,
 				reply.natinfoentries(i).address().c_str(),
 				reply.natinfoentries(i).minport(),
-				reply.natinfoentries(i).maxport());
+				reply.natinfoentries(i).maxport(),
+				reply.natinfoentries(i).vni());
 			}
 		}
 
 		if (reply.natinfotype() == dpdkonmetal::NATInfoType::NATInfoNeigh) {
 			printf("Following port ranges and their route of neighbor NAT exists for this IPv4 NAT address: %s\n", reply.natvipip().address().c_str());
 			for (i = 0; i < reply.natinfoentries_size(); i++) {
-				printf("  %d: min_port %d, max_port %d --> Underlay IPv6 %s\n", i+1,
+				printf("  %d: min_port %u, max_port %u, vni %u --> Underlay IPv6 %s\n", i+1,
 				reply.natinfoentries(i).minport(),
 				reply.natinfoentries(i).maxport(),
+				reply.natinfoentries(i).vni(),
 				reply.natinfoentries(i).underlayroute().c_str());
 			}
 		}


### PR DESCRIPTION
I added VNI field to the output of gRPC `getnatinfo` because it did not make sense without it, there can be mutliple same NAT entries if we disregard VNI.

This required a change of protocol. but as far as I tested (i.e. using the new command-line Go client), this should be backwards-compatible as I only added a new field at the end.

And also this call is never done by metalnet anyway.

I am putting this PR first as this repo is the source of truth for protofiles.