### PR TITLE
Return empty list in gRPC list calls with an error

### DIFF
--- a/include/grpc/dp_grpc_responder.h
+++ b/include/grpc/dp_grpc_responder.h
@@ -36,7 +36,6 @@ static inline void dp_grpc_set_multireply(struct dp_grpc_responder *responder, s
 {
 	responder->msg_size = msg_size;
 	responder->rep_capacity = responder->rep_max_size / msg_size;
-	responder->rep_msgcount = 0;
 }
 
 int dp_grpc_alloc_reply(struct dp_grpc_responder *responder);

--- a/src/grpc/dp_grpc_queue.c
+++ b/src/grpc/dp_grpc_queue.c
@@ -40,7 +40,7 @@ int dp_recv_from_worker(struct dpgrpc_reply *reply, uint16_t request_type)
 	if (reply->type != request_type) {
 		DPGRPC_LOG_WARNING("Invalid response received", DP_LOG_GRPCREQUEST(request_type));
 		ret = DP_ERROR;
-	} else if (reply->is_chained || reply->msg_count != 1) {
+	} else if (reply->is_chained || reply->msg_count != 0) {
 		DPGRPC_LOG_WARNING("Single response expected, multiresponse received", DP_LOG_GRPCREQUEST(request_type));
 		ret = DP_ERROR;
 	}

--- a/src/grpc/dp_grpc_responder.c
+++ b/src/grpc/dp_grpc_responder.c
@@ -16,7 +16,7 @@ uint16_t dp_grpc_init_responder(struct dp_grpc_responder *responder, struct rte_
 	// by default, only one reply with one message
 	responder->rep_capacity = 1;
 	responder->msg_size = sizeof(struct dpgrpc_reply);
-	responder->rep_msgcount = 1;
+	responder->rep_msgcount = 0;
 	responder->rep = (struct dpgrpc_reply *)req_payload;  // again, due to reusal of the request mbuf
 	responder->rep->type = responder->request.type;
 	responder->rep->is_chained = 0;

--- a/test/grpc_client.py
+++ b/test/grpc_client.py
@@ -214,8 +214,8 @@ class GrpcClient:
 		if not output:
 			return None
 		specs = []
-		for match in re.finditer(r'(?:^|[\n\r]) *[0-9]+: min_port ([0-9]+), max_port ([0-9]+) --> Underlay IPv6 ([a-f0-9:]+)(?:$|[\n\r])', output):
-			specs.append({ 'natVIPIP': nat_vip, 'underlayRoute': match.group(3), 'minPort': int(match.group(1)), 'maxPort': int(match.group(2)) })
+		for match in re.finditer(r'(?:^|[\n\r]) *[0-9]+: min_port ([0-9]+), max_port ([0-9]+), vni ([0-9]+) --> Underlay IPv6 ([a-f0-9:]+)(?:$|[\n\r])', output):
+			specs.append({ 'natVIPIP': nat_vip, 'underlayRoute': match.group(4), 'minPort': int(match.group(1)), 'maxPort': int(match.group(2)) })
 		return specs
 
 	def addneighnat(self, nat_vip, vni, min_port, max_port, t_ipv6):


### PR DESCRIPTION
For gRPC calls that produce a list of entries, no status is actually received (that is something to address in a future discussion).

When an error is encountered, instead of returning an empty list, there was a zero-filled entry returned instead. (That may have been introduced by the refactoring, but lists were misbehaving even before that.)

I have fixed this strange state, thus even in error (like invalid LB to list targets from) returns an empty list.

---
(Also there was a small bug in test suite introduced by adding VNIs to the list of NATs).