### PR TITLE
Changed LB and LB VIP limits

### DIFF
--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -7,8 +7,8 @@ extern "C" {
 
 #include "grpc/dp_grpc_responder.h"
 
-#define DP_LB_TABLE_MAX			100
-#define DP_LB_MAX_IPS_PER_VIP	20
+#define DP_LB_TABLE_MAX			256
+#define DP_LB_MAX_IPS_PER_VIP	64
 
 #define DP_LB_OFF	0
 #define DP_LB_ON	1


### PR DESCRIPTION
I increased the LB limits based on the need for more than 20 LB targets in OSC.

The new numbers are arbitrary, just bigger.