### PR TITLE
Enable graph tracing during meson build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY tools/ tools/
 
 RUN CC=clang CXX=clang++ meson build && cd ./build && ninja
 RUN rm -rf build && meson build --buildtype=release && cd ./build && ninja
-RUN rm -rf build && meson build && cd ./build && ninja
+RUN rm -rf build && meson build -Denable_graphtrace=true && cd ./build && ninja
 
 FROM debian:11-slim
 


### PR DESCRIPTION
Enable graph tracing during meson build