### PR TITLE
Migrated pytest from C++ to golang gRPC client

### DIFF
--- a/docs/testing/grpc_client.md
+++ b/docs/testing/grpc_client.md
@@ -1,85 +1,67 @@
 # Dataplane Service GRPC Client
 
-To communicate with the `dp_service` process, you need to use GRPC (currently running hardcoded at localhost on port 1337).
+To communicate with the `dp_service` process, you need to use GRPC (running on localhost at default port 1337).
 
-This repository comes with a simple command-line GRPC client with dataplane service commands presented as command-line arguments. You can find it in the build directory as `test/dp_grpc_client`. To communicate with dp-service, you need to first [initialize a connection](#initialize-a-connection) with it.
+There is a golang command-line client [dpservice-cli](https://github.com/onmetal/dpservice-cli/), with full [command-line documentation](https://github.com/onmetal/dpservice-cli/tree/osc-main/docs/commands#dpservice-cli-commands).
 
 
-## Initialize a connection
+## Sample commands for testing
 ```bash
-dp_grpc_client --init
+dpservice-cli init
+dpservice-cli add interface --id testvm1 --device 0000:01:00.0_representor_vf0 --vni 100 --ip 172.32.0.1 --ip 2010::1
+dpservice-cli add interface --id testvm2 --device 0000:01:00.0_representor_vf1 --vni 100 --ip 172.32.0.2 --ip 2010::2
+dpservice-cli add route --vni 100 --prefix 192.168.129.0/24 --next-hop-vni 200 --next-hop-ip 2a10:afc0:e01f:209::
+dpservice-cli add nat --interface-id testvm1 --nat-ip 192.168.0.1 --minport 1024 --maxport 2048
+# ...
+dpservice-cli del nat --interface-id testvm1
+dpservice-cli del route --vni 100 --prefix 192.168.129.0/24
+dpservice-cli del interface --id testvm2
+dpservice-cli del interface --id testvm1
 ```
-This command needs to be run once after starting a new `dp_service` process. Only then you can run other commands. You need to have dp-service up and running on the same machine.
 
-## Add a virtual interface (machine)
+
+## Useful debugging commands
+Get list of managed interfaces:
 ```bash
-dp_grpc_client --addmachine testvm1 --vm_pci 0000:01:00.0_representor_vf0 --vni 100 --ipv4 172.32.4.9
+$ dpservice-cli list interfaces
+ ID   VNI  Device                        IPs                         UnderlayRoute
+ vm1  100  0000:03:00.0_representor_vf0  [10.100.1.1 2000:100:1::1]  fc00:1::7a:0:1
+ vm2  100  0000:03:00.0_representor_vf1  [10.100.1.2 2000:100:1::2]  fc00:1::7a:0:2
+ vm3  200  0000:03:00.0_representor_vf2  [10.200.1.3 2000:200:1::3]  fc00:1::7a:0:3
 ```
-This command adds a virtual machine with VNI 100 (Virtual Network Identifier) and IPv4 overlay 172.32.4.9 and assigns the name `testvm1` to the VM. You need to specify the virtual port to assign to the VM. (In case of TAP devices, use the `net_tap#` EAL name instead of a PCI address.)
-
-Use the name `testvm1` in order to address this VM again.
+What is the NAT setting for interface `vm1`:
 ```bash
-dp_grpc_client --addmachine testvm1 --vm_pci 0000:01:00.0_representor_vf0 --vni 100 --ipv4 172.32.4.9 --ipv6 2010::1
+$ dpservice-cli get nat --interface-id=vm1
+ InterfaceID  NatIP       MinPort  MaxPort  UnderlayRoute
+ vm1          172.21.1.1      100      102  fc00:1::f8:0:4
 ```
-You can also specify overlay IPv6 to assign. The overlay can be dual-stack possible.
+Alternatively, you can list all NATs by using `list nats` or use the `--wide` option for `list interfaces`:
 ```bash
-dp_grpc_client --addmachine testvm1 --vm_pci 0000:01:00.0_representor_vf0 --vni 100 --ipv4 172.32.4.9 --ipv6 2010::1 --pxe_ip 192.168.129.1 --pxe_str /ipxe/boot.ipxe
+$ dpservice-cli list interfaces -w
+ ID   VNI  Device                        IPs                         UnderlayRoute   Nat                       VirtualIP
+ vm1  100  0000:03:00.0_representor_vf0  [10.100.1.1 2000:100:1::1]  fc00:1::7a:0:1  192.168.0.1 <1024, 2048>
+ vm2  100  0000:03:00.0_representor_vf1  [10.100.1.2 2000:100:1::2]  fc00:1::7a:0:2
+ vm3  200  0000:03:00.0_representor_vf2  [10.200.1.3 2000:200:1::3]  fc00:1::7a:0:3
 ```
-In case the VM needs pxe-boot, the options for the pxe-boot can be added. `--pxe_ip` is the overlay IP where TFTP and HTTP pxe servers are residing, `--pxe_str` is the path for ipxe file on the HTTP server.
-
-
-## Delete a virtual interface (machine)
+Who are other members of this NAT:
 ```bash
-dp_grpc_client --delmachine testvm1
+$ ./dpservice-cli get natinfo --nat-ip=172.21.1.1
+ VNI  IP          MinPort  MaxPort  UnderlayRoute   NatInfoType
+ 100  10.100.1.2      112      113  <nil>           Local
+ 100  10.100.1.1      100      102  <nil>           Local
+ 100  <nil>           500      520  fc00:2::64:0:1  Neighbor
+ 100  <nil>           521      522  fc00:2::64:0:1  Neighbor
 ```
-This command deletes a virtual machine with the name `testvm1`.
-> If this VM is the last one using the VNI assigned to it, the corresponding VNI will also be deleted.
-
-
-## List virtual interfaces
+List loadbalancer targets (round-robin):
 ```bash
-dp_grpc_client --getmachines
+$ dpservice-cli list lbtargets --lb-id=my_lb
+ IpVersion  Address
+      IPv6  fc00:1::30:0:7
+      IPv6  fc00:1::30:0:8
 ```
-This command lists all the virtual machines (i.e. their virtual port) controlled by the service.
-
-
-## Add a route
+Get info on the loadbalancer setting:
 ```bash
-dp_grpc_client --addroute --vni 100 --ipv4 192.168.129.0 --length 24 --t_vni 200 --t_ipv6 2a10:afc0:e01f:209::
+$ dpservice-cli get lb --id=my_lb
+ ID     VNI  LbVipIP  Lbports   UnderlayRoute
+ my_lb  100  1.2.3.4  [TCP/80]  fc00:1::c0:0:6
 ```
-This command adds a route to VNI 100 with an overlay prefix 192.168.129.0/24 on the current hypervisor which can be routed to VNI 200 on another hypervisor with an underlay IPv6 address 2a10:afc0:e01f:209::
-
-
-## Delete a route
-```bash
-dp_grpc_client --delroute --vni 100 --ipv4 192.168.129.0 --length 24 --t_vni 200 --t_ipv6 2a10:afc0:e01f:209::
-```
-This command deletes a route of VNI 100 with an overlay prefix 192.168.129.0/24 on the current hypervisor which can be routed to VNI 200 on another hypervisor with an underlay IPv6 address 2a10:afc0:e01f:209::
-
-
-## List routes
-```bash
-dp_grpc_client --listroutes --vni 100
-```
-This command lists all routes of VNI 100 on current hypervisor.
-
-
-## Set virtual IP of an existing VM
-```bash
-dp_grpc_client --addvip testvm1 --ipv4 172.32.20.2
-```
-This command assigns a virtual IP to "testvm1" VM which will be used for egress traffic of the VM as a source address (SNAT).
-
-
-## Delete the virtual IP of a VM
-```bash
-dp_grpc_client --delvip testvm1
-```
-This command deletes the virtual ip of "testvm1" VM. After deletion the VM will continue using its original IP address which it has obtained via DHCP. If there is no virtual IP assigned then this command does nothing.
-
-
-## Get the virtual IP of a VM
-```bash
-dp_grpc_client --getvip testvm1
-```
-This reads the virtual ip of the "testvm1" VM (if present).

--- a/hack/rel_download.sh
+++ b/hack/rel_download.sh
@@ -9,6 +9,7 @@
 # Example usage:
 # ./hack/rel_download.sh -dir=exporter -owner=onmetal -repo=prometheus-dpdk-exporter -pat=MY_PAT
 
+set -e
 
 if [ "$#" -lt 4 ]; then
 	echo "Usage: $0 -dir=<Destination Directory> -owner=<Repository Owner> -repo=<Repository Name> -pat=<Personal Access Token> [-release=<Release Tag>]"

--- a/test/grpc_client.py
+++ b/test/grpc_client.py
@@ -1,8 +1,12 @@
+import json
+import os
+import pytest
+import re
 import shlex
 import socket
 import subprocess
+import sys
 import time
-import re
 from config import grpc_port
 
 
@@ -16,272 +20,188 @@ class GrpcError(Exception):
 class GrpcClient:
 
 	def __init__(self, build_path):
-		self.cmd = build_path + "/tools/dp_grpc_client"
-		self.re_ipv6 = re.compile(r'(?:^|[\n\r])Received underlay route : ([a-f0-9:]+)(?:$|[\n\r])')
-		self.re_error = re.compile(r'(?:^|[\n\r])Received an error ([1-9][0-9][0-9])(?:$|[\n\r])')
+		self.cmd = build_path + "/dpservice-cli"
 		self.expectedError = 0
+		if not os.access(self.cmd, os.X_OK):
+			self.cmd = build_path + "/github.com/onmetal/dpservice-cli"
+			if not os.access(self.cmd, os.X_OK):
+				print(f"""
+Missing executable grpc client
+To solve this, you have a few options:
+ - build one locally and copy it to {build_path}/
+ - download one from GitHub manually to {build_path}/
+ - use provided download script with your GitHub PAT:
+ ./hack/rel_download.sh -dir=build -owner=onmetal -repo=dpservice-cli -pat=<PAT>
+""", file=sys.stderr)
+				raise RuntimeError("no gRPC client")
 
 	def expect_error(self, errcode):
 		self.expectedError = errcode
 		return self
 
-	def _call(self, args, req_output, negate=False):
+	def _call(self, args):
 		expectedError = self.expectedError
 		self.expectedError = 0
 
-		ipv6_address = ""
-		print("dp_grpc_client", args)
-		output = subprocess.check_output([self.cmd] + shlex.split(args)).decode('utf8').strip()
-		print(" >", output.replace("\n", "\n > "))
-
-		errors = self.re_error.search(output)
-		if errors:
-			errcode = int(errors.group(1))
-			if errcode == expectedError:
-				return None
-			raise GrpcError(errcode, "Legacy gRPC call failed with error")
-		else:
-			assert not expectedError, f"Legacy gRPC call did not fail with error {expectedError}"
-
-		if negate:
-			assert req_output not in output, "Forbidden GRPC output present"
-		else:
-			assert req_output in output, "Required GRPC output missing"
-
-		return output
-
-	def _getUnderlayRoute(self, args, req_output):
-		output = self._call(args, req_output)
-		if not output:
+		print("dpservice-cli", args)
+		p = subprocess.run([self.cmd, '-o', 'json'] + shlex.split(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		# server errors (retcode 2) are handled as a JSON response too
+		if p.returncode != 0 and p.returncode != 2:
+			if len(p.stderr):
+				print(" !", p.stderr.decode('utf8').strip().replace("\n", "\n ! "))
+			raise RuntimeError("Grpc client failed")
+		output = p.stdout.decode('utf8').strip()
+		if len(output) == 0:
 			return None
-		return self.re_ipv6.search(output).group(1)
+		print(" >", output.replace("\n", "\n > "))
+		response = json.loads(output)
+		status = response['status']
+		errcode = status['error']
+		if errcode != 0:
+			assert p.returncode == 2, \
+				"Grpc client process returned invalid error value"
+			message = status['message']
+			assert message, \
+				f"dp-service not sending any error message for error code {errcode}"
+			if expectedError == errcode:
+				return None
+			raise GrpcError(errcode, message)
+		else:
+			assert p.returncode == 0, \
+				"Grpc client returned an error value without status"
+			if expectedError:
+				raise AssertionError(f"Error {expectedError} expected, none received")
+
+		return response
+
+	def _getSpec(self, args):
+		response = self._call(args)
+		return response['spec'] if response else None
+
+	def _getSpecList(self, args):
+		response = self._call(args)
+		if not response:
+			return None
+		specs = []
+		for item in response['items']:
+			specs.append(item['spec'])
+		return specs
+
+	def _getUnderlayRoute(self, args):
+		spec = self._getSpec(args)
+		return spec['underlayRoute'] if spec else None
 
 	def init(self):
-		self._call("--init", "Init called")
+		self._call("init")
 
 	def addinterface(self, vm_name, pci, vni, ipv4, ipv6):
-		return self._getUnderlayRoute(f"--addmachine {vm_name} --vm_pci {pci} --vni {vni} --ipv4 {ipv4} --ipv6 {ipv6}",
-			f"Allocated VF for you {pci}")
+		return self._getUnderlayRoute(f"add interface --id={vm_name} --device={pci} --vni={vni} --ip={ipv4} --ip={ipv6}")
 
 	def getinterface(self, vm_name):
-		output = self._call(f"--getmachine {vm_name}", "")
-		if not output:
-			return None
-		match = re.search(r'(?:^|[\n\r])Interface with ipv4 ([0-9\.]+) ipv6 ([0-9a-fA-F:]+) vni ([0-9]+) pci ([^ ]+) underlayroute ([0-9a-fA-F:]+)', output)
-		return { 'vni': int(match.group(3)), 'device': match.group(4), 'ips': [ match.group(1), match.group(2) ], 'underlayRoute': match.group(5) }
+		return self._getSpec(f"get interface --id={vm_name}")
 
 	def delinterface(self, vm_name):
-		self._call(f"--delmachine {vm_name}", "Interface deleted")
+		self._call(f"del interface --id={vm_name}")
 
 	def listinterfaces(self):
-		output = self._call("--getmachines", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r'(?:^|[\n\r])Interface [a-zA-Z0-9_]+ ipv4 ([0-9\.]+) ipv6 ([0-9a-fA-F:]+) vni ([0-9]+) pci ([^ ]+) underlayroute ([0-9a-fA-F:]+)', output):
-			specs.append({ 'vni': int(match.group(3)), 'device': match.group(4), 'ips': [ match.group(1), match.group(2) ], 'underlayRoute': match.group(5) })
-		return specs
+		return self._getSpecList("list interfaces")
 
 	def addroute(self, vni, prefix, t_vni, t_ipv6):
-		pfx_addr, pfx_len = prefix.split('/')
-		if ':' in pfx_addr:
-			self._call(f"--addroute --vni {vni} --ipv6 {pfx_addr} --length {pfx_len} --t_vni {t_vni} --t_ipv6 {t_ipv6}",
-				f"target ipv6 {pfx_addr} target vni {t_vni}")
-		else:
-			self._call(f"--addroute --vni {vni} --ipv4 {pfx_addr} --length {pfx_len} --t_vni {t_vni} --t_ipv6 {t_ipv6}",
-				f"Route ip {pfx_addr} length {pfx_len} vni {vni}")
+		self._call(f"add route --vni={vni} --prefix={prefix} --next-hop-vni={t_vni} --next-hop-ip={t_ipv6}")
 
 	def delroute(self, vni, prefix):
-		pfx_addr, pfx_len = prefix.split('/')
-		ipver = '--ipv6' if ':' in pfx_addr else '--ipv4'
-		self._call(f"--delroute --vni {vni} {ipver} {pfx_addr} --length {pfx_len}",
-			"Route deleted")
+		self._call(f"del route --vni={vni} --prefix={prefix}")
 
 	def listroutes(self, vni):
-		output = self._call(f"--listroutes --vni {vni}", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r'(?:^|[\n\r])Route prefix ([0-9\.]+) len ([0-9]+) target vni ([0-9]+) target ipv6 ([0-9a-fA-F:]+)', output):
-			specs.append({ "vni": vni, "prefix": match.group(1)+'/'+match.group(2), "nextHop": { "vni": int(match.group(3)), "ip": match.group(4) } })
-		return specs
+		return self._getSpecList(f"list routes --vni={vni}")
 
 	def addprefix(self, vm_name, prefix):
-		pfx_addr, pfx_len = prefix.split('/')
-		return self._getUnderlayRoute(f"--addpfx {vm_name} --ipv4 {pfx_addr} --length {pfx_len}", "")
+		return self._getUnderlayRoute(f"add prefix --interface-id={vm_name} --prefix={prefix}")
 
 	def delprefix(self, vm_name, prefix):
-		pfx_addr, pfx_len = prefix.split('/')
-		self._call(f"--delpfx {vm_name} --ipv4 {pfx_addr} --length {pfx_len}", "")
+		self._call(f"del prefix --interface-id={vm_name} --prefix={prefix}")
 
 	def listprefixes(self, vm_name):
-		output = self._call(f"--listpfx {vm_name}", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r'(?:^|[\n\r])Route prefix ([0-9\.]+) len ([0-9]+) underlayroute ([0-9a-fA-F:]+)', output):
-			specs.append({ "prefix": match.group(1)+'/'+match.group(2), "underlayRoute": match.group(3) })
-		return specs
+		return self._getSpecList(f"list prefixes --interface-id={vm_name}")
 
 	def createlb(self, name, vni, vip, portspecs):
-		proto, port = portspecs.split('/')
-		return self._getUnderlayRoute(f"--createlb {name} --vni {vni} --ipv4 {vip} --port {port} --protocol {proto}",
-			f"VIP {vip}, vni {vni}")
+		return self._getUnderlayRoute(f"add loadbalancer --id={name} --vni={vni} --vip={vip} --lbports={portspecs}")
 
 	def getlb(self, name):
-		output = self._call(f"--getlb {name}", "")
-		if not output:
-			return None
-		match = re.search(r'(?:^|[\n\r])Received LB with vni: ([0-9]+) UL: ([0-9a-fA-F:]+) LB ip: ([0-9\.]+) with ports: ([^\r\n]+)', output)
-		portspecs = match.group(4)
-		lbports = []
-		for portspec in portspecs.split(' '):
-			port, proto = portspec.split(',')
-			if proto.lower() == 'tcp':
-				proto = 6
-			elif proto.lower() == 'udp':
-				proto = 17
-			elif proto.lower() == 'icmp':
-				proto = 1
-			lbports.append({ 'protocol': proto, 'port': int(port) })
-		return { "vni": int(match.group(1)), "lbVipIP": match.group(3), "lbports": lbports, "underlayRoute": match.group(2) }
+		return self._getSpec(f"get loadbalancer --id={name}")
 
 	def dellb(self, name):
-		self._call(f"--dellb {name}", "LB deleted")
+		self._call(f"delete loadbalancer --id={name}")
 
 	def addlbtarget(self, lb_name, ipv6):
-		self._call(f"--addlbvip {lb_name} --t_ipv6 {ipv6}", "LB VIP added")
+		self._call(f"add lbtarget --lb-id={lb_name} --target-ip={ipv6}")
 
 	def dellbtarget(self, lb_name, ipv6):
-		self._call(f"--dellbvip {lb_name} --t_ipv6 {ipv6}", "LB VIP deleted")
+		self._call(f"del lbtarget --lb-id={lb_name} --target-ip={ipv6}")
 
 	def listlbtargets(self, lb_name):
-		output = self._call(f"--listbackips {lb_name}", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r'(?:^|[\n\r])Backend ip ([0-9a-fA-F:]+)', output):
-			specs.append({ 'targetIP': match.group(1) })
-		return specs
+		return self._getSpecList(f"list lbtargets --lb-id={lb_name}")
 
 	def addlbprefix(self, vm_name, vip):
-		return self._getUnderlayRoute(f"--addlbpfx {vm_name} --ipv4 {vip} --length 32",
-			"Received underlay route : ")
+		return self._getUnderlayRoute(f"add lbprefix --interface-id={vm_name} --prefix={vip}/32")
 
 	def dellbprefix(self, vm_name, vip):
-		self._call(f"--dellbpfx {vm_name} --ipv4 {vip} --length 32",
-			"LB prefix deleted")
+		self._call(f"del lbprefix --interface-id={vm_name} --prefix={vip}/32")
 
 	def listlbprefixes(self, vm_name):
-		output = self._call(f"--listlbpfx {vm_name}", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r'(?:^|[\n\r])LB Route prefix ([0-9\.]+) len ([0-9]+) underlayroute ([0-9a-fA-F:]+)', output):
-			specs.append({ "prefix": match.group(1)+'/'+match.group(2), "underlayRoute": match.group(3) })
-		return specs
+		return self._getSpecList(f"list lbprefixes --interface-id={vm_name}")
 
 	def addvip(self, vm_name, vip):
-		return self._getUnderlayRoute(f"--addvip {vm_name} --ipv4 {vip}",
-			"Received underlay route : ")
+		return self._getUnderlayRoute(f"add virtualip --interface-id={vm_name} --vip={vip}")
 
 	def getvip(self, vm_name):
-		output = self._call(f"--getvip {vm_name}", "")
-		if not output:
-			return None
-		match = re.search(r'Received VIP ([0-9\.]+) underlayroute ([a-f0-9:]+)', output)
-		return { 'vipIP': match.group(1), 'underlayRoute': match.group(2) }
+		return self._getSpec(f"get virtualip --interface-id={vm_name}")
 
 	def delvip(self, vm_name):
-		self._call(f"--delvip {vm_name}", "VIP deleted")
+		self._call(f"del vip --interface-id={vm_name}")
 
 	def addnat(self, vm_name, vip, min_port, max_port):
-		return self._getUnderlayRoute(f"--addnat {vm_name} --ipv4 {vip} --min_port {min_port} --max_port {max_port}",
-			"Received underlay route : ")
+		return self._getUnderlayRoute(f"add nat --interface-id={vm_name} --nat-ip={vip} --minport={min_port} --maxport={max_port}")
 
 	def getnat(self, vm_name):
-		output = self._call(f"--getnat {vm_name}", "")
-		if not output:
-			return None
-		match = re.search(r'Received NAT IP ([0-9\.]+) with min port: ([0-9]+) and max port: ([0-9]+) underlay ([a-f0-9:]+)', output)
-		return { 'natVIPIP': match.group(1), 'underlayRoute': match.group(4), 'minPort': int(match.group(2)), 'maxPort': int(match.group(3)) }
+		return self._getSpec(f"get nat --interface-id={vm_name}")
 
 	def delnat(self, vm_name):
-		self._call(f"--delnat {vm_name}", "NAT deleted")
+		self._call(f"del nat --interface-id={vm_name}")
 
 	def getnatinfo(self, nat_vip, info_type):
-		output = self._call(f"--getnatinfo {info_type} --ipv4 {nat_vip}", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r'(?:^|[\n\r]) *[0-9]+: min_port ([0-9]+), max_port ([0-9]+), vni ([0-9]+) --> Underlay IPv6 ([a-f0-9:]+)(?:$|[\n\r])', output):
-			specs.append({ 'natVIPIP': nat_vip, 'underlayRoute': match.group(4), 'minPort': int(match.group(1)), 'maxPort': int(match.group(2)) })
-		return specs
+		return self._getSpecList(f"get natinfo --nat-ip={nat_vip} --info-type={info_type}")
 
 	def addneighnat(self, nat_vip, vni, min_port, max_port, t_ipv6):
-		self._call(f"--addneighnat --ipv4 {nat_vip} --vni {vni} --min_port {min_port} --max_port {max_port} --t_ipv6 {t_ipv6}",
-			"Neighbor NAT added")
+		self._call(f"add neighnat --nat-ip={nat_vip} --vni={vni} --minport={min_port} --maxport={max_port} --underlayroute={t_ipv6}")
 
 	def delneighnat(self, nat_vip, vni, min_port, max_port):
-		self._call(f"--delneighnat --ipv4 {nat_vip} --vni {vni} --min_port {min_port} --max_port {max_port}",
-			"Neighbor NAT deleted")
+		self._call(f"del neighnat --nat-ip={nat_vip} --vni={vni} --minport={min_port} --maxport={max_port}")
 
 	def addfwallrule(self, vm_name, rule_id,
 				     src_prefix="0.0.0.0/0", dst_prefix="0.0.0.0/0", proto=None,
 				     src_port_min=-1, src_port_max=-1, dst_port_min=-1, dst_port_max=-1,
 				     action="accept", direction="ingress", priority=None):
-		protospec = "" if proto is None else f"--protocol {proto}"
-		priospec = "" if priority is None else f"--priority {priority}"
-		src_addr, src_len = src_prefix.split('/')
-		dst_addr, dst_len = dst_prefix.split('/')
-		self._call(f"--addfwrule {vm_name} --fw_ruleid {rule_id} --src_ip {src_addr} --src_length {src_len} --dst_ip {dst_addr} --dst_length {dst_len} {protospec}"
-				  f" --src_port_min {src_port_min} --src_port_max {src_port_max} --dst_port_min {dst_port_min} --dst_port_max {dst_port_max}"
-				  f" --action {action} --direction {direction} {priospec}",
-			"Add FirewallRule called")
+		protospec = "" if proto is None else f"--protocol={proto}"
+		priospec = "" if priority is None else f"--priority={priority}"
+		self._call(f"add fwrule --interface-id={vm_name} --rule-id={rule_id} --ipver=ipv4 --src={src_prefix} --dst={dst_prefix} {protospec}"
+				  f" --src-port-min={src_port_min} --src-port-max={src_port_max} --dst-port-min={dst_port_min} --dst-port-max={dst_port_max}"
+				  f" --action={action} --direction={direction} {priospec}")
 
 	def getfwallrule(self, vm_name, rule_id):
-		output = self._call(f"--getfwrule {vm_name} --fw_ruleid {rule_id}", "")
-		if not output:
-			return None
-		match = re.search(rule_id + r' / src_ip: ([0-9\.]+) / src_ip pfx length: ([0-9]+) / dst_ip: ([0-9\.]+) / dst_ip pfx length: ([0-9]+) \n'
-						r'protocol: ([a-z]+) / src_port_min: (\-?[0-9]+) / src_port_max: (\-?[0-9]+) / dst_port_min: (\-?[0-9]+) / dst_port_max: (\-?[0-9]+) \n'
-						r'direction: ([a-z]+) / action: ([a-z]+)', output)
-		return { "trafficDirection": match.group(10).capitalize(), "firewallAction": match.group(11).capitalize(), "priority": 1000, "ipVersion": "IPv4",
-				 "sourcePrefix": match.group(1)+'/'+match.group(2), "destinationPrefix": match.group(3)+'/'+match.group(4),
-				 "protocolFilter": { "Filter": { match.group(5).capitalize(): {
-					 "srcPortLower": int(match.group(6)), "srcPortUpper": int(match.group(7)), "dstPortLower": int(match.group(8)), "dstPortUpper": int(match.group(9))
-				 } } } }
+		return self._getSpec(f"get fwrule --interface-id={vm_name} --rule-id={rule_id}")
 
 	def delfwallrule(self, vm_name, rule_id):
-		self._call(f"--delfwrule {vm_name} --fw_ruleid {rule_id}",
-			"Firewall Rule Deleted")
+		self._call(f"del fwrule --interface-id={vm_name} --rule-id={rule_id}")
 
 	def listfwallrules(self, vm_name):
-		output = self._call(f"--listfwrules {vm_name}", "")
-		if not output:
-			return None
-		specs = []
-		for match in re.finditer(r' / src_ip: ([0-9\.]+) / src_ip pfx length: ([0-9]+) / dst_ip: ([0-9\.]+) / dst_ip pfx length: ([0-9]+) \n'
-						r'protocol: ([a-z]+) / src_port_min: (\-?[0-9]+) / src_port_max: (\-?[0-9]+) / dst_port_min: (\-?[0-9]+) / dst_port_max: (\-?[0-9]+) \n'
-						r'direction: ([a-z]+) / action: ([a-z]+)', output):
-			specs.append({
-				"trafficDirection": match.group(10).capitalize(), "firewallAction": match.group(11).capitalize(), "priority": 1000, "ipVersion": "IPv4",
-				"sourcePrefix": match.group(1)+'/'+match.group(2), "destinationPrefix": match.group(3)+'/'+match.group(4),
-				"protocolFilter": { "Filter": { match.group(5).capitalize(): {
-					"srcPortLower": int(match.group(6)), "srcPortUpper": int(match.group(7)), "dstPortLower": int(match.group(8)), "dstPortUpper": int(match.group(9))
-				} } } })
-		return specs
+		return self._getSpecList(f"list fwrules --interface-id={vm_name}")
 
-	def vniinuse(self, vni):
-		output = self._call(f"--vni_in_use --vni {vni}", "")
-		match = re.search(r'(?:^|[\n\r])Vni: '+str(vni)+' is (.*in use)', output)
-		return match.group(1) == 'in use'
+	def getvni(self, vni):
+		return self._getSpec(f"get vni --vni={vni} --vni-type=0")
 
 	def resetvni(self, vni):
-		output = self._call(f"--reset_vni --vni {vni}", "")
-		match = re.search(r'(?:^|[\n\r])Vni: '+str(vni)+' (.*resetted)', output)
-		return match.group(1) == 'resetted'
-
+		self._call(f"reset vni --vni={vni}")
 
 	@staticmethod
 	def port_open():

--- a/test/test_nat.py
+++ b/test/test_nat.py
@@ -50,7 +50,7 @@ def test_network_nat_pkt_relay(prepare_ifaces, grpc_client):
 	assert spec == localspec, \
 		"Failed to add NAT properly"
 
-	neighspec = { 'natVIPIP': nat_vip, 'underlayRoute': neigh_vni1_ul_ipv6, 'minPort': nat_neigh_min_port, 'maxPort': nat_neigh_max_port }
+	neighspec = { 'underlayRoute': neigh_vni1_ul_ipv6, 'minPort': nat_neigh_min_port, 'maxPort': nat_neigh_max_port, 'vni': vni1 }
 	specs = grpc_client.getnatinfo(nat_vip, "neigh")
 	assert specs == [neighspec], \
 		"Invalid neighboring NAT list"
@@ -101,7 +101,7 @@ def test_network_nat_vip_co_existence_on_same_vm(prepare_ifaces, grpc_client):
 	assert spec == natspec, \
 		"Failed to add NAT properly"
 
-	vipspec = { 'vipIP': vip_vip, 'underlayRoute': vip_ul_ipv6 }
+	vipspec = { 'ip': vip_vip, 'underlayRoute': vip_ul_ipv6 }
 	spec = grpc_client.getvip(VM1.name)
 	assert spec == vipspec, \
 		"Failed to add VIP properly"

--- a/test/test_vni.py
+++ b/test/test_vni.py
@@ -3,19 +3,19 @@ from helpers import *
 
 def test_vni_existence(prepare_ipv4, grpc_client):
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni3, lb_ip, "tcp/80")
-	assert grpc_client.vniinuse(vni3), \
+	assert grpc_client.getvni(vni3)['inUse'], \
 		f"VNI {vni3} should be in use"
 
 	grpc_client.addinterface(VM4.name, VM4.pci, vni3, VM4.ip, VM4.ipv6)
-	assert grpc_client.vniinuse(vni3), \
+	assert grpc_client.getvni(vni3)['inUse'], \
 		f"VNI {vni3} should be in use"
 
 	grpc_client.delinterface(VM4.name)
-	assert grpc_client.vniinuse(vni3), \
+	assert grpc_client.getvni(vni3)['inUse'], \
 		f"VNI {vni3} should be in use"
 
 	grpc_client.dellb(lb_name)
-	assert not grpc_client.vniinuse(vni3), \
+	assert not grpc_client.getvni(vni3)['inUse'], \
 		f"VNI {vni3} should not be in use anymore"
 
 
@@ -23,17 +23,23 @@ def test_vni_reset(prepare_ipv4, grpc_client):
 	grpc_client.addinterface(VM4.name, VM4.pci, vni3, VM4.ip, VM4.ipv6)
 	grpc_client.addroute(vni3, neigh_vni1_ov_ip_route, 0, neigh_vni1_ul_ipv6)
 
+	# Also test invalid vni reset and its impact (does not fail though)
+	grpc_client.resetvni(999)
 
-	routespec = { "vni": vni3, "prefix": neigh_vni1_ov_ip_route, "nextHop": { "vni": 0, "ip": neigh_vni1_ul_ipv6 } }
+	# This is intentionally the same as in VNI1 (see the last test)
+	routespec = { "prefix": neigh_vni1_ov_ip_route, "nextHop": { "vni": 0, "ip": neigh_vni1_ul_ipv6 } }
 	routes = grpc_client.listroutes(vni3)
 	assert routespec in routes, \
 		"List of routes does not contain the added route"
 
-	assert grpc_client.resetvni(vni3), \
-		f"VNI {vni3} should be resettable"
+	grpc_client.resetvni(vni3)
 
 	routes = grpc_client.listroutes(vni3)
 	assert routespec not in routes, \
-		"List of routes contains the route although vni resetted"
+		"List of routes contains the route although vni is reset"
+
+	routes = grpc_client.listroutes(vni1)
+	assert routespec in routes, \
+		"Resetting a vni tainted another vni"
 
 	grpc_client.delinterface(VM4.name)

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -44,7 +44,7 @@ def test_grpc_addroute_route_exists(prepare_ifaces, grpc_client):
 def test_grpc_list_delroutes(prepare_ifaces, grpc_client):
 	# Try to list routes, delete one of them, list and add again
 	# NOTE this route has to be the one in DpService::init_ifaces()
-	routespec = { "vni": vni1, "prefix": neigh_vni1_ov_ip_route, "nextHop": { "vni": 0, "ip": neigh_vni1_ul_ipv6 } }
+	routespec = { "prefix": neigh_vni1_ov_ip_route, "nextHop": { "ip": neigh_vni1_ul_ipv6, "vni": 0 } }
 	routes = grpc_client.listroutes(vni1)
 	assert routespec in routes, \
 		"List of routes does not contain an initial route"
@@ -64,7 +64,7 @@ def test_grpc_add_NAT_and_VIP_same_IP(prepare_ifaces, grpc_client):
 	grpc_client.delnat(VM2.name)
 
 	vip_ul_ipv6 = grpc_client.addvip(VM2.name, vip_vip)
-	vipspec = { "vipIP": vip_vip, "underlayRoute": vip_ul_ipv6}
+	vipspec = { "ip": vip_vip, "underlayRoute": vip_ul_ipv6}
 	spec = grpc_client.getvip(VM2.name)
 	assert spec == vipspec, \
 		"VIP not set properly"
@@ -75,7 +75,7 @@ def test_grpc_add_NAT_and_VIP_same_IP(prepare_ifaces, grpc_client):
 def test_grpc_add_list_delVIP(prepare_ifaces, grpc_client):
 	# Try to add VIP, list, test error cases, delete vip and list again
 	ul_ipv6 = grpc_client.addvip(VM2.name, vip_vip)
-	vipspec = { "vipIP": vip_vip, "underlayRoute": ul_ipv6}
+	vipspec = { "ip": vip_vip, "underlayRoute": ul_ipv6}
 	spec = grpc_client.getvip(VM2.name)
 	assert spec == vipspec, \
 		"VIP not set properly"
@@ -162,7 +162,8 @@ def test_grpc_add_list_delFirewallRules(prepare_ifaces, grpc_client):
 	# Used rule-id
 	grpc_client.expect_error(202).addfwallrule(VM3.name, "fw0-vm3", src_prefix="1.2.3.4/16", proto="tcp", action="drop")
 
-	rulespec = { "trafficDirection": "Ingress", "firewallAction": "Accept", "priority": 1000, "ipVersion": "IPv4",
+	rulespec = { "ruleID": "fw0-vm3",
+				 "trafficDirection": "Ingress", "firewallAction": "Accept", "priority": 1000, "ipVersion": "IPv4",
 				 "sourcePrefix": "1.2.3.4/16", "destinationPrefix": "0.0.0.0/0",
 				 "protocolFilter": { "Filter": { "Tcp": {
 					 "srcPortLower": -1, "srcPortUpper": -1, "dstPortLower": -1, "dstPortUpper": -1


### PR DESCRIPTION
The test suite now uses `dpservice-cli` golang client.

Most changes are concentrated into `grpc_client.py` since that is completely different now. The rest are just details due to some added features of the client or format specifics.

As for the Dockefile, I reorganized it a bit to make the downloaded dpservice-cli (and prometheus) done after DPDK compilation (due to docker layer caching when building manually).

In pytest, I simply check for presence of the client in `build/`. If not there, pytest will exit and print a guide on how to get the client:
 - clone and make your own, copy to `build/`
 - just click on github and save to `build/`
 - use the `rel_download.sh` (arguemtns provided) with your PAT, this should put it into `build/github.com/onmetal/dpservice-cli`
This way you can have a release version of the client in build/github.com, but at the same time copy your local one for testing and then simply removing it will go back to the release version without the need to download it again.

Note that I added `set -e` to the downloader, so it fails on error and does not only print the error and continue. This is not really needed, but it does not hurt the current state. I originally integrated the script into meson, where this was needed for it to fail properly.