### PR TITLE
Feature/dpdk logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,10 @@ RUN unzip dpdk-${DPDK_VER}.zip
 
 ENV DPDK_DIR=/workspace/dpdk-${DPDK_VER}
 
-# Copy DPDK patch
-COPY hack/dpdk_21_11_clang.patch hack/dpdk_21_11_clang.patch
+# Copy DPDK patches
+COPY hack/dpdk_21_11_clang.patch hack/dpdk_21_11_log.patch hack/
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_21_11_clang.patch
+RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_21_11_log.patch
 
 # Compile DPDK
 RUN cd $DPDK_DIR && meson -Dmax_ethports=132 -Dplatform=generic -Ddisable_drivers=common/dpaax,\

--- a/hack/dpdk_21_11_log.patch
+++ b/hack/dpdk_21_11_log.patch
@@ -1,0 +1,77 @@
+diff --git a/lib/eal/common/eal_common_log.c b/lib/eal/common/eal_common_log.c
+index 1be35f5397..159beb63ab 100644
+--- a/lib/eal/common/eal_common_log.c
++++ b/lib/eal/common/eal_common_log.c
+@@ -29,11 +29,14 @@ static struct rte_logs {
+ 	uint32_t type;  /**< Bitfield with enabled logs. */
+ 	uint32_t level; /**< Log level. */
+ 	FILE *file;     /**< Output file set by rte_openlog_stream, or NULL. */
++	/** Print function set by rte_log_set_print_func, or vfprintf. */
++	int (*func)(FILE *stream, const char *format, va_list ap);
+ 	size_t dynamic_types_len;
+ 	struct rte_log_dynamic_type *dynamic_types;
+ } rte_logs = {
+ 	.type = UINT32_MAX,
+ 	.level = RTE_LOG_DEBUG,
++	.func = vfprintf,
+ };
+ 
+ struct rte_eal_opt_loglevel {
+@@ -78,6 +81,13 @@ rte_openlog_stream(FILE *f)
+ 	return 0;
+ }
+ 
++/* Change the print function that will be used by the logging system. */
++void
++rte_log_set_print_func(int (*func)(FILE *stream, const char *format, va_list ap))
++{
++	rte_logs.func = func;
++}
++
+ FILE *
+ rte_log_get_stream(void)
+ {
+@@ -500,7 +510,7 @@ rte_vlog(uint32_t level, uint32_t logtype, const char *format, va_list ap)
+ 	RTE_PER_LCORE(log_cur_msg).loglevel = level;
+ 	RTE_PER_LCORE(log_cur_msg).logtype = logtype;
+ 
+-	ret = vfprintf(f, format, ap);
++	ret = rte_logs.func(f, format, ap);
+ 	fflush(f);
+ 	return ret;
+ }
+diff --git a/lib/eal/include/rte_log.h b/lib/eal/include/rte_log.h
+index 319e4044a5..ee17cf93a0 100644
+--- a/lib/eal/include/rte_log.h
++++ b/lib/eal/include/rte_log.h
+@@ -88,6 +88,18 @@ extern "C" {
+  */
+ int rte_openlog_stream(FILE *f);
+ 
++/**
++ * Change the print function that will be used by the logging system.
++ *
++ * This can be done at any time. The func argument represents
++ * the vfprintf-like function to be used to print the logs.
++ * Without calling this function, the default (vfprintf) is used.
++ *
++ * @param func
++ *   Pointer to the print function.
++ */
++void rte_log_set_print_func(int (*func)(FILE *stream, const char *format, va_list ap));
++
+ /**
+  * Retrieve the stream used by the logging system (see rte_openlog_stream()
+  * to change it).
+diff --git a/lib/eal/version.map b/lib/eal/version.map
+index ab28c22791..72c8a18111 100644
+--- a/lib/eal/version.map
++++ b/lib/eal/version.map
+@@ -141,6 +141,7 @@ DPDK_22 {
+ 	rte_log_set_level;
+ 	rte_log_set_level_pattern;
+ 	rte_log_set_level_regexp;
++	rte_log_set_print_func;
+ 	rte_malloc;
+ 	rte_malloc_dump_heaps;
+ 	rte_malloc_dump_stats;

--- a/src/dp_log.c
+++ b/src/dp_log.c
@@ -69,6 +69,21 @@ void dp_log_set_thread_name(const char *name)
 	snprintf(thread_name, sizeof(thread_name), "%s", name);
 }
 
+static int dp_log_eal(FILE *stream, const char *format, va_list ap)
+{
+	char buf[2048];
+	int ret;
+
+	ret = vsnprintf(buf, sizeof(buf), format, ap);
+
+	// as _dp_log only supports custom logtypes, provide one directly
+	// logleves are supported fully
+	_dp_log(rte_log_cur_msg_loglevel(), RTE_LOGTYPE_DPSERVICE,
+			__FILE__, __LINE__, __FUNCTION__,
+			"EAL log message", _DP_LOG_STR("eal_msg", buf), NULL);
+
+	return ret;
+}
 
 int dp_log_init()
 {
@@ -80,6 +95,8 @@ int dp_log_init()
 		DP_EARLY_ERR("Cannot open logging stream %s", dp_strerror_verbose(ret));
 		return ret;
 	}
+
+	rte_log_set_print_func(dp_log_eal);
 
 	log_json = dp_conf_get_log_format() == DP_CONF_LOG_FORMAT_JSON;
 	if (log_json) {


### PR DESCRIPTION
I added a new function to DPDK to set the logging (log printing) function, instead of using `vfprintf` directly. 

This enables dp-service to provide it's own printing function to encapsulate logging into its format(s).

The only drawback is the fact that initial loglines from DPDK are not encapsulated. This would be solvable at the cost of non-standard argument parsing, initializing logging early, etc., which currently does not seem the right way to go. 

To test this, just add `--log-level=*:8` to dp-service and DPDK will become much more verbose, like:
```
{ "ts": "2023-07-04 14:16:35.431", "thread_id": 1, "thread_name": "control", "level": "Debug", "logger": "service", "msg": "EAL log message", "eal_msg": "mlx5_net: table_level 0 table_id 0 tunnel 0 group 0 registered.\u000a", "caller": "../src/dp_log.c:82:dp_log_eal()" }
{ "ts": "2023-07-04 14:16:35.431", "thread_id": 1, "thread_name": "control", "level": "Debug", "logger": "service", "msg": "EAL log message", "eal_msg": "mlx5_common: mlx5 list FDB_ingress_0_0_matcher_list entry 0x16c1593c0 new: 1.\u000a", "caller": "../src/dp_log.c:82:dp_log_eal()" }
```

Docker image build worked for me locally, thus the patch is working at least on the compiler-level there. The image has not been run.