### PR TITLE
Better (meson) way of generating version.h

### DIFF
--- a/include/dp_version.h.in
+++ b/include/dp_version.h.in
@@ -1,1 +1,1 @@
-#define DP_SERVICE_VERSION "@GIT_TAG_VERSION@"
+#define DP_SERVICE_VERSION "@dpservice_version@"

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,7 @@
+version_data = configuration_data()
+version_data.set('dpservice_version', meson.project_version())
+version_h = configure_file(
+  input: 'dp_version.h.in',
+  output: 'dp_version.h',
+  configuration: version_data
+)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('dp_service', 'c', 'cpp',
-  version: run_command('git', 'describe', '--tags').stdout(),
+  version: run_command('git', 'describe', '--tags').stdout().strip(),
   license: 'MIT',
   default_options: ['warning_level=2', 'werror=true'])
 
@@ -81,6 +81,7 @@ endif
 includes = include_directories('include')
 
 subdir('proto')
+subdir('include')
 subdir('src')
 subdir('tools')
 if get_option('enable_tests')

--- a/src/meson.build
+++ b/src/meson.build
@@ -69,15 +69,8 @@ if get_option('enable_graphtrace')
   ]
 endif
 
-version_h = vcs_tag(
-  command: ['git', 'describe', '--tags'],
-  input: '../include/dp_version.h.in',
-  output: 'dp_version.h',
-  replace_string: '@GIT_TAG_VERSION@'
-)
-
 exe = executable('dp_service',
-  sources: [ dp_sources, grpc_generated, version_h ],
+  sources: [ dp_sources, grpc_generated ],
   include_directories: [ includes ],
   dependencies: [ dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep, libuuid_dep ]
 )


### PR DESCRIPTION
This fixes broken `meson test` and makes the call to `git describe --tags` only happen in configuration phase of meson.

The only possible drawback is that if the tag changes, you need to reconfigure your build-directory. Which in github actions happens anyway, so it should not pose a problem.