### PR TITLE
Introduce an one-shot timer which runs more often after init() call

### DIFF
--- a/include/dp_timers.h
+++ b/include/dp_timers.h
@@ -14,6 +14,7 @@ void dp_timers_free(void);
 int dp_timers_add_stats(rte_timer_cb_t stats_cb);
 
 uint64_t dp_timers_get_manage_interval_cycles(void);
+void dp_timers_signal_initialization(void);
 
 #ifdef __cplusplus
 }

--- a/src/dp_timers.c
+++ b/src/dp_timers.c
@@ -17,10 +17,13 @@
 
 // how often to perform network maintenance tasks (ND, GARP, ...)
 #define TIMER_DP_MAINTENANCE_INTERVAL 30
+#define TIMER_DP_MAINTENANCE_STARTUP_INTERVAL 5
+#define TIMER_DP_MAINTENANCE_STARTUP_CYCLES 5
 
 // timer for stats printing
 #define TIMER_STATS_INTERVAL 1
 
+static int dp_maintenance_interval = TIMER_DP_MAINTENANCE_STARTUP_INTERVAL;
 
 static struct rte_timer dp_flow_aging_timer;
 static struct rte_timer dp_maintenance_timer;
@@ -35,13 +38,38 @@ static void dp_flow_aging_timer_cb(__rte_unused struct rte_timer *timer, __rte_u
 		DPS_LOG_WARNING("Cannot send flow aging event", DP_LOG_RET(ret));
 }
 
-static void dp_maintenance_timer_cb(__rte_unused struct rte_timer *timer, __rte_unused void *arg)
+static inline void dp_maintenance_timer_cb_core(void)
 {
 	if (dp_conf_is_ipv6_overlay_enabled()) {
 		trigger_nd_ra();
 		trigger_nd_unsol_adv();
 	}
 	trigger_garp();
+}
+
+static void dp_maintenance_timer_cb(__rte_unused struct rte_timer *timer, __rte_unused void *arg)
+{
+	dp_maintenance_timer_cb_core();
+}
+
+static void dp_maintenance_startup_timer_cb(struct rte_timer *timer, __rte_unused void *arg)
+{
+	static unsigned int counter = 0;
+	uint64_t cycles;
+
+	dp_maintenance_timer_cb_core();
+
+	// This is a simple back-off of the maintenance timer. Only at the beginning of the timer life time,
+	// do it every TIMER_DP_MAINTENANCE_STARTUP_INTERVAL seconds. After TIMER_DP_MAINTENANCE_STARTUP_CYCLES times
+	// and dp_maintenance_interval is set to a greater value, reset the timer with the greater value.
+	if ((dp_maintenance_interval > TIMER_DP_MAINTENANCE_STARTUP_INTERVAL) && (counter <= TIMER_DP_MAINTENANCE_STARTUP_CYCLES)) {
+		counter++;
+		if (counter == TIMER_DP_MAINTENANCE_STARTUP_CYCLES) {
+			cycles = dp_maintenance_interval * rte_get_timer_hz();
+			if (DP_FAILED(rte_timer_reset(timer, cycles, PERIODICAL, rte_lcore_id(), dp_maintenance_timer_cb, NULL)))
+				DPS_LOG_ERR("Cannot start maintenance timer");
+		}
+	}
 }
 
 uint64_t dp_timers_get_manage_interval_cycles(void)
@@ -61,6 +89,11 @@ static inline int dp_timers_add(struct rte_timer *timer, int period, rte_timer_c
 
 	// there is no errno for this call, so log the failure in caller for better call stack
 	return rte_timer_reset(timer, cycles, PERIODICAL, rte_lcore_id(), callback, NULL);
+}
+
+void dp_timers_signal_initialization(void)
+{
+	dp_maintenance_interval = TIMER_DP_MAINTENANCE_INTERVAL;
 }
 
 int dp_timers_init(void)
@@ -84,8 +117,8 @@ int dp_timers_init(void)
 		return DP_ERROR;
 	}
 
-	if (DP_FAILED(dp_timers_add(&dp_maintenance_timer, TIMER_DP_MAINTENANCE_INTERVAL, dp_maintenance_timer_cb))) {
-		DPS_LOG_ERR("Cannot start maintenance timer");
+	if (DP_FAILED(dp_timers_add(&dp_maintenance_timer, dp_maintenance_interval, dp_maintenance_startup_timer_cb))) {
+		DPS_LOG_ERR("Cannot start maintenance startup timer");
 		return DP_ERROR;
 	}
 

--- a/src/grpc/dp_grpc_service.cpp
+++ b/src/grpc/dp_grpc_service.cpp
@@ -5,6 +5,7 @@
 #include "dpdk_layer.h"
 #include <rte_mbuf.h>
 #include "dp_log.h"
+#include "dp_timers.h"
 
 
 GRPCService::GRPCService()
@@ -43,6 +44,7 @@ char* GRPCService::GetUUID()
 
 void GRPCService::SetInitStatus(bool status)
 {
+	dp_timers_signal_initialization();
 	initialized = status;
 }
 


### PR DESCRIPTION
One shot timer gets kicked after the init() grpc call and sends the ARP requests more often for the first 30 seconds. After that the normal interval is used. (30 seconds)
