### PR TITLE
fix hairpin config leading to unconfiged vf-pf hairpin pattern

### DIFF
--- a/src/dp_hairpin.c
+++ b/src/dp_hairpin.c
@@ -65,8 +65,7 @@ static int setup_hairpin_rx_tx_queues(uint16_t port_id,
 
 int dp_hairpin_setup(struct dp_port *port)
 {
-	if (port->port_type == DP_PORT_VF)
-		return DP_OK;
+
 	uint16_t hairpin_queue_id = 0;
 	uint16_t peer_hairpin_queue_id = 0;
 

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -448,16 +448,14 @@ int dp_port_start(uint16_t port_id)
 	port->link_status = RTE_ETH_LINK_UP;
 	port->allocated = true;
 
-	if (port->port_type == DP_PORT_PF && dp_conf_get_nic_type() != DP_CONF_NIC_TYPE_TAP) {
+	if (dp_conf_get_nic_type() != DP_CONF_NIC_TYPE_TAP) {
 		if (dp_conf_is_offload_enabled()) {
 			if (DP_FAILED(dp_port_bind_port_hairpins(port)))
 				return DP_ERROR;
 		}
-		// first, finish pf-pf hairpin binding, then install isolation rules
-		if (port_id == dp_port_get_pf1_id()) {
-			if (DP_FAILED(dp_port_install_isolated_mode(dp_port_get_pf0_id())))
-				return DP_ERROR;
-			if (DP_FAILED(dp_port_install_isolated_mode(dp_port_get_pf1_id())))
+
+		if (port->port_type == DP_PORT_PF) {
+			if (DP_FAILED(dp_port_install_isolated_mode(port_id)))
 				return DP_ERROR;
 		}
 	}


### PR DESCRIPTION
caused by commit 8c6b730.
The changes in this commit enables the correct config for pf-pf hairpin setup and binding, but breaks the config for vf-pf hairpin setup and binding. fixed with alternative logic. 

tested with
1)  vf-pf hairpin setup and binding. VM2VM (cross hypervisors) traffic but forced one VM to use another PF (pf1) to send and receive traffic; 
2) pf-pf hairpin setup and binding. lb bouncing traffic as in-network pkt processing.