### PR TITLE
Updated pytest HW testing code

### DIFF
--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -450,6 +450,9 @@ int dp_port_start(uint16_t port_id)
 
 	if (dp_conf_get_nic_type() != DP_CONF_NIC_TYPE_TAP) {
 		if (dp_conf_is_offload_enabled()) {
+#ifdef ENABLE_PYTEST
+			if (port->peer_pf_port_id != dp_port_get_pf1_id())
+#endif
 			if (DP_FAILED(dp_port_bind_port_hairpins(port)))
 				return DP_ERROR;
 		}

--- a/test/test_lb.py
+++ b/test/test_lb.py
@@ -99,10 +99,12 @@ def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy
 	# cannot be run twice in a row, since the flows need to age-out
 
 
-def test_nat_to_lb_nat(prepare_ipv4, grpc_client, port_redundancy):
+def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 
 	if port_redundancy:
 		pytest.skip("Port redundancy is not supported for NAT <-> LB+NAT test")
+	if request.config.getoption("--hw"):
+		pytest.skip("Hardware testing is not supported for NAT <-> LB+NAT test")
 
 	# Create a VM on VNI1 under a loadbalancer and NAT
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")


### PR DESCRIPTION
As the pytest hardware testing utilizes the second NIC port, it must disable hairpins to it.

(Also one specific test needs a fourth VM, which is not really needed to be tested in HW, so I skip that test too).

This should not harm anything as ENABLE_PYTEST needs specific meson setup to be defined.

After this, all tests seem to be working with hardware *and* offloading.
Closes #255 