### PR TITLE
reset state vars used during cntrack key fast matching if a pkt is go…

### DIFF
--- a/include/dp_timers.h
+++ b/include/dp_timers.h
@@ -14,6 +14,7 @@ void dp_timers_free(void);
 int dp_timers_add_stats(rte_timer_cb_t stats_cb);
 
 uint64_t dp_timers_get_manage_interval_cycles(void);
+uint8_t dp_timers_get_flow_aging_interval(void);
 void dp_timers_signal_initialization(void);
 
 #ifdef __cplusplus

--- a/src/dp_timers.c
+++ b/src/dp_timers.c
@@ -77,6 +77,11 @@ uint64_t dp_timers_get_manage_interval_cycles(void)
 	return dp_timer_manage_interval_cycles;
 }
 
+uint8_t dp_timers_get_flow_aging_interval(void)
+{
+	return TIMER_FLOW_AGING_INTERVAL;
+}
+
 static inline int dp_timers_add(struct rte_timer *timer, int period, rte_timer_cb_t callback)
 {
 	uint64_t cycles = period * rte_get_timer_hz();

--- a/test/test_lb.py
+++ b/test/test_lb.py
@@ -122,3 +122,27 @@ def test_nat_to_lb_nat(prepare_ipv4, grpc_client, port_redundancy):
 	grpc_client.dellbtarget(lb_name, lb_vm1_ul_ipv6)
 	grpc_client.dellbprefix(VM1.name, lb_ip)
 	grpc_client.dellb(lb_name)
+
+def send_bounce_pkt_to_pf(ipv6_lb):
+	bouce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
+				 IPv6(dst=ipv6_lb, src=local_ul_ipv6, nh=4) /
+				 IP(dst=lb_ip, src=public_ip) /
+				 TCP(sport=8989, dport=80))
+	delayed_sendp(bouce_pkt, PF0.tap)
+
+def test_external_lb_relay(prepare_ipv4, grpc_client):
+
+	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
+	grpc_client.addlbtarget(lb_name, neigh_ul_ipv6)
+
+
+	threading.Thread(target=send_bounce_pkt_to_pf, args=(lb_ul_ipv6,)).start()
+	pkt = sniff_packet(PF0.tap, is_tcp_pkt, skip=1)
+
+	dst_ip = pkt[IPv6].dst
+	assert dst_ip == neigh_ul_ipv6, \
+		f"Wrong network-lb relayed packet (outer dst ipv6: {dst_ip})"
+
+
+	grpc_client.dellbtarget(lb_name, neigh_ul_ipv6)
+	grpc_client.dellb(lb_name)


### PR DESCRIPTION
reset state vars used during cntrack key fast matching if a pkt is going to be offloaded. fix #336.

flow_key and flow_val of the last packet is recorded for key fast matching. If a flow is offloaded, and since then no other packet is processed, its flow key and value will be stored and remain. As timers expire in both hardware and software, its corresponding entry will be deleted, but these stored flow_key and flow_val are kept and reused, which leads to invalid pointer issue. To resolve this, just reset these two variables if a packet's flow is supposed to be offloaded, since fast matching is meaningless for a offloaded flow anyway.
