### PR TITLE
Added VF name+address to gRPC CreateInterface response

### DIFF
--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <net/if.h>
+#include <rte_pci.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,6 +37,7 @@ struct dp_port {
 	uint8_t							peer_pf_hairpin_tx_rx_queue_offset;
 	uint16_t						peer_pf_port_id;
 	enum dp_vf_port_attach_status	attach_status;
+	struct rte_pci_addr				pci_addr;
 };
 
 struct dp_ports {

--- a/test/dp_grpc_client.py
+++ b/test/dp_grpc_client.py
@@ -61,7 +61,7 @@ class DpGrpcClient:
 
 	def addinterface(self, vm_name, pci, vni, ipv4, ipv6):
 		return self._getUnderlayRoute(f"--addmachine {vm_name} --vm_pci {pci} --vni {vni} --ipv4 {ipv4} --ipv6 {ipv6}",
-			f"Allocated VF for you {pci}")
+			f"Allocated VF for you")
 
 	def getinterface(self, vm_name):
 		output = self._call(f"--getmachine {vm_name}", "")


### PR DESCRIPTION
There was an old TODO in the code to fill-in the PCI address and name of allocated VF, so I implemented that.
```
dpservice-cli add interface --id=vm1 --device=0000:03:00.0_representor_vf0 --vni=100 --ipv4=10.100.1.1 --ipv6=2000:100:1::1
{"kind":"","metadata":{"id":"vm1"},"spec":{"vni":100,"device":"0000:03:00.0_representor_vf0","primary_ipv4":"10.100.1.1","primary_ipv6":"2000:100:1::1","underlay_route":"fc00:1::68:0:1","virtual_function":{"name":"enp3s0f0npf0vf0","domain":0,"bus":3,"slot":0,"function":0},"pxe":{}},"status":{"code":0,"message":"Success"}}
```
TAP devices do not have an PCI address:
```
dpservice-cli add interface --id=vm1 --device=net_tap2 --vni=100 --ipv4=10.100.1.1 --ipv6=2000:100:1::1
{"kind":"","metadata":{"id":"vm1"},"spec":{"vni":100,"device":"net_tap2","primary_ipv4":"10.100.1.1","primary_ipv6":"2000:100:1::1","underlay_route":"fc00:1::d:0:1","virtual_function":{"name":"dtapvf_0","domain":0,"bus":0,"slot":0,"function":0},"pxe":{}},"status":{"code":0,"message":"Success"}}
```

I now return the OS name of the function instead of the DPDK name, because that one is part of the request (and spec) thus already known to the caller.

Also there was a TODO to return the name/address for already allocated error, but that is currently not possible due to the way errors are handled in gRPC code (fail fast). If this was essential to the operation, a separate PR is neede to allow this to happen.
