### PR TITLE
Updated documentation for newest code

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -26,11 +26,13 @@ Dp-service currently only supports x86 architecture (amd64 instruction set actua
 
 
 ### DPDK
-The dataplane service is built upon the [DPDK library](https://dpdk.org). Currently, the only supported version is 21.x, which most distros do not have in stable trees. Building from source also has the advantage of easier debugging later.
+The dataplane service is built upon the [DPDK library](https://dpdk.org). Currently, the only supported version is 21.x. Unfortunately, some patching is needed, thus it needs to be built from source. Building from source also has the advantage of easier debugging later.
 ```bash
+git clone https://github.com/onmetal/net-dpservice.git
 wget http://fast.dpdk.org/rel/dpdk-21.11.2.tar.xz
 tar xf dpdk-21.11.2.tar.xz
 cd dpdk-stable-21.11.2
+patch -p1 < ../net-dpservice/hack/dpdk_21_11_log.patch
 meson setup build
 ninja -C build
 sudo ninja -C build install
@@ -47,7 +49,6 @@ Some systems do not put the resulting (installed) `pkgconf` directory with DPDK'
 
 ## Building the service
 ```bash
-git clone https://github.com/onmetal/net-dpservice.git
 cd net-dpservice/
 meson setup build
 ninja -C build

--- a/docs/development/mellanox.md
+++ b/docs/development/mellanox.md
@@ -78,3 +78,10 @@ This script uses the IPv6 address assigned to your loopback interface as the und
 
 ## Caveats
 Keep in mind, that many NICs require a working connection on their ports to actually put the ports up, i.e. connect them to a switch before looking for a problem elsewhere.
+
+### MTU
+Because of the fact, that dp-service uses IP-IP tunnel, the VM's MTU must be smaller than the host's to accomodate an IPv6 header. This can be done either by lowering the MTU of all VMs or by using jumbo-frames on the host:
+```bash
+ip link set enp3s0f0np0 mtu 9100
+ip link set enp3s0f1np1 mtu 9100
+```


### PR DESCRIPTION
Since the logging change, DPDK must be compiled with the log patch.

If this is something to be avoided, I can change dp-service code to look for some `ifdef` and throw a warning instead of failing to compile, but I did not see a reason to do it that way.

I also updated a small bit about the MTU (thanks @byteocean) needed to make host-host communication work.