### PR TITLE
dp_rte_flow refactoring

### DIFF
--- a/include/rte_flow/dp_rte_flow.h
+++ b/include/rte_flow/dp_rte_flow.h
@@ -1,5 +1,5 @@
-#ifndef __INCLUDE_DP_RTE_FLOW_H
-#define __INCLUDE_DP_RTE_FLOW_H
+#ifndef __INCLUDE_DP_RTE_FLOW_H__
+#define __INCLUDE_DP_RTE_FLOW_H__
 
 #ifdef __cplusplus
 extern "C"
@@ -22,9 +22,6 @@ extern "C"
 #define DP_FLOW_WEST_EAST		0
 #define DP_FLOW_SOUTH_NORTH		1
 
-#define DP_IS_SRC false
-#define DP_IS_DST true
-
 #define DP_L4_PORT_DIR_SRC 1
 #define DP_L4_PORT_DIR_DST 2
 
@@ -34,19 +31,16 @@ extern "C"
 #define DP_IP_ICMP_CODE_DST_PORT_UNREACHABLE 3
 #define DP_IP_ICMP_CODE_FRAGMENT_NEEDED 4
 
-#define DP_RTE_TCP_CNTL_FLAGS \
-	(RTE_TCP_FIN_FLAG|RTE_TCP_SYN_FLAG|RTE_TCP_RST_FLAG)
-
-typedef struct dp_icmp_err_ip_info {
+struct dp_icmp_err_ip_info {
 	struct rte_ipv4_hdr *err_ipv4_hdr;
 	rte_be16_t	l4_src_port;
 	rte_be16_t	l4_dst_port;
-} dp_icmp_err_ip_info;
+};
 
 uint16_t extract_inner_ethernet_header(struct rte_mbuf *pkt);
 uint16_t extract_outer_ethernet_header(struct rte_mbuf *pkt);
 int extract_inner_l3_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset); // offset, ipv4/ipv6 header
-int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset); // offset,  tcp/udp/icmp header
+int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset); // offset, tcp/udp/icmp header
 int extract_outer_ipv6_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset);
 struct rte_ipv4_hdr *dp_get_ipv4_hdr(struct rte_mbuf *m);
 struct rte_tcp_hdr *dp_get_tcp_hdr(struct rte_mbuf *m, uint16_t offset);
@@ -58,140 +52,15 @@ void dp_change_icmp_err_l4_src_port(struct rte_mbuf *m, struct dp_icmp_err_ip_in
 void dp_change_l4_hdr_port(struct rte_mbuf *m, uint8_t port_type, uint16_t new_val);
 void dp_change_icmp_identifier(struct rte_mbuf *m, uint16_t new_val);
 
-// functions to craft actions/patterns are added later
-void create_rte_flow_rule_attr(struct rte_flow_attr *attr, uint32_t group, uint32_t priority, uint32_t ingress, uint32_t egress, uint32_t transfer);
+int dp_destroy_rte_flow_agectx(struct flow_age_ctx *agectx);
 
-int insert_ethernet_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-									struct rte_flow_item_eth *eth_spec,
-									struct rte_flow_item_eth *eth_mask,
-									struct rte_ether_addr *src, size_t nr_src_mask_len,
-									struct rte_ether_addr *dst, size_t nr_dst_mask_len,
-									rte_be16_t type);
-
-int insert_ipv6_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_ipv6 *ipv6_spec,
-								struct rte_flow_item_ipv6 *ipv6_mask,
-								uint8_t *src, size_t nr_src_mask_len,
-								uint8_t *dst, size_t nr_dst_mask_len,
-								uint8_t proto);
-
-int insert_ipv4_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_ipv4 *ipv4_spec,
-								struct rte_flow_item_ipv4 *ipv4_mask,
-								rte_be32_t *src, size_t nr_src_mask_len,
-								rte_be32_t *dst, size_t nr_dst_mask_len,
-								uint8_t proto);
-
-int insert_udp_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_udp *udp_spec,
-								struct rte_flow_item_udp *udp_mask,
-								rte_be16_t src_port, rte_be16_t dst_port);
-
-int insert_tcp_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_tcp *tcp_spec,
-								struct rte_flow_item_tcp *tcp_mask,
-								rte_be16_t src_port, rte_be16_t dst_port,
-								uint8_t tcp_flags);
-
-int insert_icmp_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_icmp *icmp_spec,
-								struct rte_flow_item_icmp *icmp_mask,
-								uint8_t type);
-
-int insert_icmpv6_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_icmp6 *icmp6_spec,
-								struct rte_flow_item_icmp6 *icmp6_mask,
-								uint8_t type);
-
-int insert_packet_mark_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-									struct rte_flow_item_mark *mark_spec,
-									struct rte_flow_item_mark *mark_mask,
-									uint32_t marked_id);
-
-int insert_tag_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-									struct rte_flow_item_tag *tag_spec,
-									struct rte_flow_item_tag *tag_mask,
-									uint32_t tag_value, uint8_t tag_index);
-
-int insert_meta_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-							struct rte_flow_item_meta *meta_spec,
-							struct rte_flow_item_meta *meta_mask,
-							uint32_t meta_value);
-
-int insert_end_match_pattern(struct rte_flow_item *pattern, int pattern_cnt);
-
-
-int create_raw_decap_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_raw_decap *raw_decap_action,
-							uint8_t *data_to_decap, size_t data_len);
-
-int create_raw_encap_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_raw_encap *raw_encap_action,
-							uint8_t *data_to_encap, size_t data_len);
-
-int create_dst_mac_set_action(struct rte_flow_action *action, int action_cnt,
-							  struct rte_flow_action_set_mac *dst_mac_set_action,
-							  struct rte_ether_addr *dst_mac);
-
-int create_src_mac_set_action(struct rte_flow_action *action, int action_cnt,
-							  struct rte_flow_action_set_mac *src_mac_set_action,
-							  struct rte_ether_addr *src_mac);
-
-int create_ipv4_set_action(struct rte_flow_action *action, int action_cnt,
-						   struct rte_flow_action_set_ipv4 *ipv4_action,
-						   rte_be32_t ipv4, bool dir);
-
-int create_ipv6_set_action(struct rte_flow_action *action, int action_cnt,
-						   struct rte_flow_action_set_ipv6 *ipv6_action,
-						   uint8_t *ipv6, bool dir);
-
-int create_trans_proto_set_action(struct rte_flow_action *action, int action_cnt,
-									struct rte_flow_action_set_tp *tp_action,
-									uint16_t port, bool dir);
-
-int create_send_to_port_action(struct rte_flow_action *action, int action_cnt,
-								struct rte_flow_action_port_id *send_to_port_action,
-								uint32_t port_id);
-
-int create_flow_age_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_age *flow_age_action,
-							uint32_t timeout, void *age_context);
-
-void free_allocated_agectx(struct flow_age_ctx *agectx);
-
-void config_allocated_agectx(struct flow_age_ctx *agectx, uint16_t port_id,
-								struct dp_flow *df, struct rte_flow *flow);
-
-int create_redirect_queue_action(struct rte_flow_action *action, int action_cnt,
-									struct rte_flow_action_queue *queue_action,
-									uint16_t queue_index);
-
-int create_packet_mark_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_mark *mark_action,
-							uint32_t marked_value);
-
-int create_set_tag_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_set_tag *set_tag_action,
-							uint32_t tag_value, uint8_t index);
-
-int create_set_meta_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_set_meta *meta_action,
-							uint32_t meta_value);
-
-int create_end_action(struct rte_flow_action *action, int action_cnt);
-
-int dp_destroy_rte_action_handle(uint16_t port_id, struct rte_flow_action_handle *handle, struct rte_flow_error *error);
-
-struct rte_flow *validate_and_install_rte_flow(uint16_t port_id,
-												const struct rte_flow_attr *attr,
-												const struct rte_flow_item pattern[],
-												const struct rte_flow_action action[]);
-
-int dp_create_age_indirect_action(struct rte_flow_attr *attr, uint16_t port_id,
-							struct dp_flow *df, struct rte_flow_action *age_action, struct flow_age_ctx *agectx);
+struct rte_flow *dp_install_rte_flow(uint16_t port_id,
+									 const struct rte_flow_attr *attr,
+									 const struct rte_flow_item pattern[],
+									 const struct rte_flow_action actions[]);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __INCLUDE_DP_RTE_FLOW_H */
+#endif

--- a/include/rte_flow/dp_rte_flow_helpers.h
+++ b/include/rte_flow/dp_rte_flow_helpers.h
@@ -1,0 +1,547 @@
+#ifndef __INCLUDE_DP_RTE_FLOW_HELPERS_H__
+#define __INCLUDE_DP_RTE_FLOW_HELPERS_H__
+
+#include <rte_flow.h>
+#include "dp_error.h"
+#include "dp_mbuf_dyn.h"
+#include "nodes/ipv6_nd_node.h"
+#include "rte_flow/dp_rte_flow.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define DP_TCP_CONTROL_FLAGS \
+	(RTE_TCP_FIN_FLAG|RTE_TCP_SYN_FLAG|RTE_TCP_RST_FLAG)
+
+union dp_flow_item_l3 {
+	struct rte_flow_item_ipv4 ipv4;
+	struct rte_flow_item_ipv6 ipv6;
+};
+
+union dp_flow_item_l4 {
+	struct rte_flow_item_tcp tcp;
+	struct rte_flow_item_udp udp;
+	struct rte_flow_item_icmp icmp;
+	struct rte_flow_item_icmp6 icmp6;
+};
+
+static const struct rte_flow_item_eth dp_flow_item_eth_mask = {
+	.hdr.ether_type = 0xffff,
+};
+static const struct rte_flow_item_eth dp_flow_item_eth_dst_mask = {
+	.hdr.dst_addr.addr_bytes = "\xff\xff\xff\xff\xff\xff",
+	.hdr.ether_type = 0xffff,
+};
+static const struct rte_flow_item_eth dp_flow_item_eth_src_dst_mask = {
+	.hdr.src_addr.addr_bytes = "\xff\xff\xff\xff\xff\xff",
+	.hdr.dst_addr.addr_bytes = "\xff\xff\xff\xff\xff\xff",
+	.hdr.ether_type = 0xffff,
+};
+
+static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_mask = {
+	.hdr.proto = 0xff,
+};
+static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_src_mask = {
+	.hdr.src_addr = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+	.hdr.proto = 0xff,
+};
+static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_dst_mask = {
+	.hdr.dst_addr = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+	.hdr.proto = 0xff,
+};
+
+static const struct rte_flow_item_ipv4 dp_flow_item_ipv4_dst_mask = {
+	.hdr.dst_addr = 0xffffffff,
+	.hdr.next_proto_id = 0xff,
+};
+static const struct rte_flow_item_ipv4 dp_flow_item_ipv4_src_dst_mask = {
+	.hdr.src_addr = 0xffffffff,
+	.hdr.dst_addr = 0xffffffff,
+	.hdr.next_proto_id = 0xff,
+};
+
+static const struct rte_flow_item_udp dp_flow_item_udp_src_mask = {
+	.hdr.src_port = 0xffff,
+};
+static const struct rte_flow_item_udp dp_flow_item_udp_src_dst_mask = {
+	.hdr.src_port = 0xffff,
+	.hdr.dst_port = 0xffff,
+};
+
+static const struct rte_flow_item_tcp dp_flow_item_tcp_src_mask = {
+	.hdr.src_port = 0xffff,
+};
+static const struct rte_flow_item_tcp dp_flow_item_tcp_src_dst_mask = {
+	.hdr.src_port = 0xffff,
+	.hdr.dst_port = 0xffff,
+};
+static const struct rte_flow_item_tcp dp_flow_item_tcp_src_dst_noctrl_mask = {
+	.hdr.src_port = 0xffff,
+	.hdr.dst_port = 0xffff,
+	.hdr.tcp_flags = DP_TCP_CONTROL_FLAGS,
+};
+
+static const struct rte_flow_item_icmp dp_flow_item_icmp_mask = {
+	.hdr.icmp_type = 0xff,
+};
+
+static const struct rte_flow_item_icmp6 dp_flow_item_icmp6_mask = {
+	.type = 0xff,
+};
+
+static __rte_always_inline
+void dp_set_eth_flow_item(struct rte_flow_item *item,
+						  struct rte_flow_item_eth *eth_spec,
+						  rte_be16_t type)
+{
+	eth_spec->hdr.ether_type = type;
+	item->type = RTE_FLOW_ITEM_TYPE_ETH;
+	item->spec = eth_spec;
+	item->mask = &dp_flow_item_eth_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_eth_dst_flow_item(struct rte_flow_item *item,
+							  struct rte_flow_item_eth *eth_spec,
+							  const struct rte_ether_addr *dst,
+							  rte_be16_t type)
+{
+	memcpy(&(eth_spec->hdr.dst_addr), dst, sizeof(struct rte_ether_addr));
+	eth_spec->hdr.ether_type = type;
+	item->type = RTE_FLOW_ITEM_TYPE_ETH;
+	item->spec = eth_spec;
+	item->mask = &dp_flow_item_eth_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_eth_src_dst_flow_item(struct rte_flow_item *item,
+								  struct rte_flow_item_eth *eth_spec,
+								  const struct rte_ether_addr *src,
+								  const struct rte_ether_addr *dst,
+								  rte_be16_t type)
+{
+	memcpy(&(eth_spec->hdr.src_addr), src, sizeof(struct rte_ether_addr));
+	memcpy(&(eth_spec->hdr.dst_addr), dst, sizeof(struct rte_ether_addr));
+	eth_spec->hdr.ether_type = type;
+	item->type = RTE_FLOW_ITEM_TYPE_ETH;
+	item->spec = eth_spec;
+	item->mask = &dp_flow_item_eth_src_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_ipv6_flow_item(struct rte_flow_item *item,
+						   struct rte_flow_item_ipv6 *ipv6_spec,
+						   uint8_t proto)
+{
+	ipv6_spec->hdr.proto = proto;
+	item->type = RTE_FLOW_ITEM_TYPE_IPV6;
+	item->spec = ipv6_spec;
+	item->mask = &dp_flow_item_ipv6_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_ipv6_src_flow_item(struct rte_flow_item *item,
+							   struct rte_flow_item_ipv6 *ipv6_spec,
+							   const uint8_t *src,
+							   uint8_t proto)
+{
+	memcpy(ipv6_spec->hdr.src_addr, src, 16);
+	ipv6_spec->hdr.proto = proto;
+	item->type = RTE_FLOW_ITEM_TYPE_IPV6;
+	item->spec = ipv6_spec;
+	item->mask = &dp_flow_item_ipv6_src_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_ipv6_dst_flow_item(struct rte_flow_item *item,
+							   struct rte_flow_item_ipv6 *ipv6_spec,
+							   const uint8_t *dst,
+							   uint8_t proto)
+{
+	memcpy(ipv6_spec->hdr.dst_addr, dst, 16);
+	ipv6_spec->hdr.proto = proto;
+	item->type = RTE_FLOW_ITEM_TYPE_IPV6;
+	item->spec = ipv6_spec;
+	item->mask = &dp_flow_item_ipv6_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_ipv4_dst_flow_item(struct rte_flow_item *item,
+							   struct rte_flow_item_ipv4 *ipv4_spec,
+							   rte_be32_t dst,
+							   uint8_t proto)
+{
+	ipv4_spec->hdr.dst_addr = dst;
+	ipv4_spec->hdr.next_proto_id = proto;
+	item->type = RTE_FLOW_ITEM_TYPE_IPV4;
+	item->spec = ipv4_spec;
+	item->mask = &dp_flow_item_ipv4_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_ipv4_src_dst_flow_item(struct rte_flow_item *item,
+								   struct rte_flow_item_ipv4 *ipv4_spec,
+								   rte_be32_t src,
+								   rte_be32_t dst,
+								   uint8_t proto)
+{
+	ipv4_spec->hdr.src_addr = src;
+	ipv4_spec->hdr.dst_addr = dst;
+	ipv4_spec->hdr.next_proto_id = proto;
+	item->type = RTE_FLOW_ITEM_TYPE_IPV4;
+	item->spec = ipv4_spec;
+	item->mask = &dp_flow_item_ipv4_src_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_udp_src_flow_item(struct rte_flow_item *item,
+							  struct rte_flow_item_udp *udp_spec,
+							  rte_be16_t src_port)
+{
+	udp_spec->hdr.src_port = src_port;
+	item->type = RTE_FLOW_ITEM_TYPE_UDP;
+	item->spec = udp_spec;
+	item->mask = &dp_flow_item_udp_src_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_udp_src_dst_flow_item(struct rte_flow_item *item,
+								  struct rte_flow_item_udp *udp_spec,
+								  rte_be16_t src_port,
+								  rte_be16_t dst_port)
+{
+	udp_spec->hdr.src_port = src_port;
+	udp_spec->hdr.dst_port = dst_port;
+	item->type = RTE_FLOW_ITEM_TYPE_UDP;
+	item->spec = udp_spec;
+	item->mask = &dp_flow_item_udp_src_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_tcp_src_flow_item(struct rte_flow_item *item,
+							  struct rte_flow_item_tcp *tcp_spec,
+							  rte_be16_t src_port)
+{
+	tcp_spec->hdr.src_port = src_port;
+	item->type = RTE_FLOW_ITEM_TYPE_TCP;
+	item->spec = tcp_spec;
+	item->mask = &dp_flow_item_tcp_src_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_tcp_src_dst_flow_item(struct rte_flow_item *item,
+								  struct rte_flow_item_tcp *tcp_spec,
+								  rte_be16_t src_port,
+								  rte_be16_t dst_port)
+{
+	tcp_spec->hdr.src_port = src_port;
+	tcp_spec->hdr.dst_port = dst_port;
+	item->type = RTE_FLOW_ITEM_TYPE_TCP;
+	item->spec = tcp_spec;
+	item->mask = &dp_flow_item_tcp_src_dst_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_tcp_src_dst_noctrl_flow_item(struct rte_flow_item *item,
+										 struct rte_flow_item_tcp *tcp_spec,
+										 rte_be16_t src_port,
+										 rte_be16_t dst_port)
+{
+	tcp_spec->hdr.src_port = src_port;
+	tcp_spec->hdr.dst_port = dst_port;
+	tcp_spec->hdr.tcp_flags = ~DP_TCP_CONTROL_FLAGS;
+	item->type = RTE_FLOW_ITEM_TYPE_TCP;
+	item->spec = tcp_spec;
+	item->mask = &dp_flow_item_tcp_src_dst_noctrl_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_icmp_flow_item(struct rte_flow_item *item,
+						   struct rte_flow_item_icmp *icmp_spec,
+						   uint8_t type)
+{
+	icmp_spec->hdr.icmp_type = type;
+	item->type = RTE_FLOW_ITEM_TYPE_ICMP;
+	item->spec = icmp_spec;
+	item->mask = &dp_flow_item_icmp_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_icmp6_flow_item(struct rte_flow_item *item,
+						    struct rte_flow_item_icmp6 *icmp6_spec,
+						    uint8_t type)
+{
+	icmp6_spec->type = type;
+	item->type = RTE_FLOW_ITEM_TYPE_ICMP6;
+	item->spec = icmp6_spec;
+	item->mask = &dp_flow_item_icmp6_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_mark_flow_item(struct rte_flow_item *item,
+						   struct rte_flow_item_mark *mark_spec,
+						   uint32_t marked_id)
+{
+	mark_spec->id = marked_id;
+	item->type = RTE_FLOW_ITEM_TYPE_MARK;
+	item->spec = mark_spec;
+	item->mask = &rte_flow_item_mark_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_tag_flow_item(struct rte_flow_item *item,
+						  struct rte_flow_item_tag *tag_spec,
+						  uint32_t tag_value,
+						  uint8_t tag_index)
+{
+	tag_spec->data = tag_value;
+	tag_spec->index = tag_index;
+	item->type = RTE_FLOW_ITEM_TYPE_TAG;
+	item->spec = tag_spec;
+	item->mask = &rte_flow_item_tag_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_meta_flow_item(struct rte_flow_item *item,
+						   struct rte_flow_item_meta *meta_spec,
+						   uint32_t meta_value)
+{
+	meta_spec->data = meta_value;
+	item->type = RTE_FLOW_ITEM_TYPE_META;
+	item->spec = meta_spec;
+	item->mask = &rte_flow_item_meta_mask;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+void dp_set_end_flow_item(struct rte_flow_item *item)
+{
+	item->type = RTE_FLOW_ITEM_TYPE_END;
+	item->spec = NULL;
+	item->mask = NULL;
+	item->last = NULL;
+}
+
+static __rte_always_inline
+int dp_set_l4_flow_item(struct rte_flow_item *item,
+						union dp_flow_item_l4 *l4_spec,
+						const struct dp_flow *df)
+{
+	if (df->l4_type == DP_IP_PROTO_TCP)
+		dp_set_tcp_src_dst_noctrl_flow_item(item, &l4_spec->tcp,
+											df->l4_info.trans_port.src_port, df->l4_info.trans_port.dst_port);
+	else if (df->l4_type == DP_IP_PROTO_UDP)
+		dp_set_udp_src_dst_flow_item(item, &l4_spec->udp,
+									 df->l4_info.trans_port.src_port, df->l4_info.trans_port.dst_port);
+	else if (df->l4_type == DP_IP_PROTO_ICMP)
+		dp_set_icmp_flow_item(item, &l4_spec->icmp, df->l4_info.icmp_field.icmp_type);
+	else if (df->l4_type == DP_IP_PROTO_ICMPV6)
+		dp_set_icmp6_flow_item(item, &l4_spec->icmp6, df->l4_info.icmp_field.icmp_type);
+	else {
+		DPS_LOG_ERR("Invalid L4 protocol", DP_LOG_PROTO(df->l4_type));
+		return DP_ERROR;
+	}
+	return DP_OK;
+}
+
+
+static __rte_always_inline
+void dp_set_raw_decap_action(struct rte_flow_action *action,
+							 struct rte_flow_action_raw_decap *raw_decap_action,
+							 uint8_t *data_to_decap, size_t data_len)
+{
+	raw_decap_action->data = data_to_decap;
+	raw_decap_action->size = data_len;
+	action->type = RTE_FLOW_ACTION_TYPE_RAW_DECAP;
+	action->conf = raw_decap_action;
+}
+
+static __rte_always_inline
+void dp_set_raw_encap_action(struct rte_flow_action *action,
+							 struct rte_flow_action_raw_encap *raw_encap_action,
+							 uint8_t *data_to_encap, size_t data_len)
+{
+	raw_encap_action->data = data_to_encap;
+	raw_encap_action->size = data_len;
+	action->type = RTE_FLOW_ACTION_TYPE_RAW_ENCAP;
+	action->conf = raw_encap_action;
+}
+
+static __rte_always_inline
+void dp_set_dst_mac_set_action(struct rte_flow_action *action,
+							   struct rte_flow_action_set_mac *dst_mac_set_action,
+							   const struct rte_ether_addr *dst_mac)
+{
+	rte_ether_addr_copy(dst_mac, (struct rte_ether_addr *)(dst_mac_set_action->mac_addr));
+	action->type = RTE_FLOW_ACTION_TYPE_SET_MAC_DST;
+	action->conf = dst_mac_set_action;
+}
+
+static __rte_always_inline
+void dp_set_src_mac_set_action(struct rte_flow_action *action,
+							   struct rte_flow_action_set_mac *src_mac_set_action,
+							   const struct rte_ether_addr *src_mac)
+{
+	rte_ether_addr_copy(src_mac, (struct rte_ether_addr *)src_mac_set_action->mac_addr);
+	action->type = RTE_FLOW_ACTION_TYPE_SET_MAC_SRC;
+	action->conf = src_mac_set_action;
+}
+
+static __rte_always_inline
+void dp_set_ipv4_set_src_action(struct rte_flow_action *action,
+								struct rte_flow_action_set_ipv4 *ipv4_action,
+								rte_be32_t ipv4)
+{
+	ipv4_action->ipv4_addr = ipv4;
+	action->type = RTE_FLOW_ACTION_TYPE_SET_IPV4_SRC;
+	action->conf = ipv4_action;
+}
+
+static __rte_always_inline
+void dp_set_ipv4_set_dst_action(struct rte_flow_action *action,
+								struct rte_flow_action_set_ipv4 *ipv4_action,
+								rte_be32_t ipv4)
+{
+	ipv4_action->ipv4_addr = ipv4;
+	action->type = RTE_FLOW_ACTION_TYPE_SET_IPV4_DST;
+	action->conf = ipv4_action;
+}
+
+static __rte_always_inline
+void dp_set_ipv6_set_src_action(struct rte_flow_action *action,
+								struct rte_flow_action_set_ipv6 *ipv6_action,
+								const uint8_t *ipv6)
+{
+	memcpy(ipv6_action->ipv6_addr, ipv6, sizeof(ipv6_action->ipv6_addr));
+	action->type = RTE_FLOW_ACTION_TYPE_SET_IPV6_SRC;
+	action->conf = ipv6_action;
+}
+
+static __rte_always_inline
+void dp_set_ipv6_set_dst_action(struct rte_flow_action *action,
+								struct rte_flow_action_set_ipv6 *ipv6_action,
+								const uint8_t *ipv6)
+{
+	memcpy(ipv6_action->ipv6_addr, ipv6, sizeof(ipv6_action->ipv6_addr));
+	action->type = RTE_FLOW_ACTION_TYPE_SET_IPV6_DST;
+	action->conf = ipv6_action;
+}
+
+static __rte_always_inline
+void dp_set_trans_proto_set_src_action(struct rte_flow_action *action,
+									   struct rte_flow_action_set_tp *tp_action,
+									   rte_be16_t port)
+{
+	tp_action->port = port;
+	action->type = RTE_FLOW_ACTION_TYPE_SET_TP_SRC;
+	action->conf = tp_action;
+}
+
+static __rte_always_inline
+void dp_set_trans_proto_set_dst_action(struct rte_flow_action *action,
+									   struct rte_flow_action_set_tp *tp_action,
+									   rte_be16_t port)
+{
+	tp_action->port = port;
+	action->type = RTE_FLOW_ACTION_TYPE_SET_TP_DST;
+	action->conf = tp_action;
+}
+
+static __rte_always_inline
+void dp_set_send_to_port_action(struct rte_flow_action *action,
+								struct rte_flow_action_port_id *send_to_port_action,
+								uint32_t port_id)
+{
+	send_to_port_action->original = 0; // original???
+	send_to_port_action->reserved = 0;
+	send_to_port_action->id = port_id;
+	action->type = RTE_FLOW_ACTION_TYPE_PORT_ID;
+	action->conf = send_to_port_action;
+}
+
+static __rte_always_inline
+void dp_set_flow_age_action(struct rte_flow_action *action,
+							struct rte_flow_action_age *flow_age_action,
+							uint32_t timeout, void *age_context)
+{
+	flow_age_action->timeout = timeout;
+	flow_age_action->reserved = 0;
+	flow_age_action->context = age_context;
+	action->type = RTE_FLOW_ACTION_TYPE_AGE;
+	action->conf = flow_age_action;
+}
+
+static __rte_always_inline
+void dp_set_redirect_queue_action(struct rte_flow_action *action,
+								  struct rte_flow_action_queue *queue_action,
+								  uint16_t queue_index)
+{
+	queue_action->index = queue_index;
+	action->type = RTE_FLOW_ACTION_TYPE_QUEUE;
+	action->conf = queue_action;
+}
+
+static __rte_always_inline
+void dp_set_packet_mark_action(struct rte_flow_action *action,
+							   struct rte_flow_action_mark *mark_action,
+							   uint32_t marked_value)
+{
+	mark_action->id = marked_value;
+	action->type = RTE_FLOW_ACTION_TYPE_MARK;
+	action->conf = mark_action;
+}
+
+static __rte_always_inline
+void dp_set_set_tag_action(struct rte_flow_action *action,
+						   struct rte_flow_action_set_tag *set_tag_action,
+						   uint32_t tag_value)
+{
+	set_tag_action->data = tag_value;
+	set_tag_action->mask = 0xffffffff;
+	set_tag_action->index = 0;  // This function currently only supports one tag per packet
+	action->type = RTE_FLOW_ACTION_TYPE_SET_TAG;
+	action->conf = set_tag_action;
+}
+
+static __rte_always_inline
+void dp_set_set_meta_action(struct rte_flow_action *action,
+							struct rte_flow_action_set_meta *meta_action,
+							uint32_t meta_value)
+{
+	meta_action->data = meta_value;
+	meta_action->mask = 0xffffffff;
+	action->type = RTE_FLOW_ACTION_TYPE_SET_META;
+	action->conf = meta_action;
+}
+
+static __rte_always_inline
+void dp_set_end_action(struct rte_flow_action *action)
+{
+	action->type = RTE_FLOW_ACTION_TYPE_END;
+	action->conf = NULL;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/rte_flow/dp_rte_flow_init.h
+++ b/include/rte_flow/dp_rte_flow_init.h
@@ -1,5 +1,5 @@
-#ifndef __INCLUDE_DP_RTE_FLOW_INIT_H
-#define __INCLUDE_DP_RTE_FLOW_INIT_H
+#ifndef __INCLUDE_DP_RTE_FLOW_INIT_H__
+#define __INCLUDE_DP_RTE_FLOW_INIT_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,4 +16,4 @@ int dp_install_isolated_mode_virtsvc(int port_id, uint8_t proto_id, uint8_t svc_
 }
 #endif
 
-#endif /* __INCLUDE_DP_RTE_FLOW_INIT_H */
+#endif

--- a/include/rte_flow/dp_rte_flow_traffic_forward.h
+++ b/include/rte_flow/dp_rte_flow_traffic_forward.h
@@ -1,21 +1,12 @@
-#ifndef __INCLUDE_DP_RTE_FLOW_TRAFFIC_FORWARD_H
-#define __INCLUDE_DP_RTE_FLOW_TRAFFIC_FORWARD_H
+#ifndef __INCLUDE_DP_RTE_FLOW_TRAFFIC_FORWARD_H__
+#define __INCLUDE_DP_RTE_FLOW_TRAFFIC_FORWARD_H__
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-
-#include <unistd.h>
-#include "rte_malloc.h"
-#include "dp_rte_flow.h"
-#include "nodes/ipv6_nd_node.h"
-
-#define DP_TUNN_OPS_OFFLOAD_MAX_PATTERN 7
-#define DP_TUNN_OPS_OFFLOAD_MAX_ACTION 8
-
-#define DP_TUNN_IPIP_ENCAP_SIZE sizeof(struct rte_ether_hdr)+sizeof(struct rte_ipv6_hdr)
+#include "dp_mbuf_dyn.h"
 
 int dp_offload_handler(struct rte_mbuf *m, struct dp_flow *df);
 
@@ -23,6 +14,4 @@ int dp_offload_handler(struct rte_mbuf *m, struct dp_flow *df);
 }
 #endif
 
-
-
-#endif /* __INCLUDE_DP_RTE_FLOW_TRAFFIC_FORWARD_H */
+#endif

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -54,10 +54,10 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	df = dp_get_flow_ptr(m);
 	ipv4_hdr = dp_get_ipv4_hdr(m);
 
-	if (extract_inner_l3_header(m, ipv4_hdr, 0) < 0)
+	if (DP_FAILED(extract_inner_l3_header(m, ipv4_hdr, 0)))
 		return CONNTRACK_NEXT_DROP;
 
-	if (extract_inner_l4_header(m, ipv4_hdr + 1, 0) < 0)
+	if (DP_FAILED(extract_inner_l4_header(m, ipv4_hdr + 1, 0)))
 		return CONNTRACK_NEXT_DROP;
 
 	if (df->l4_type == DP_IP_PROTO_UDP && df->l4_info.trans_port.dst_port == htons(DP_BOOTP_SRV_PORT))
@@ -70,10 +70,8 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 		|| df->l4_type == IPPROTO_UDP
 		|| df->l4_type == IPPROTO_ICMP
 	) {
-
 		if (DP_FAILED(dp_cntrack_handle(node, m, df)))
 			return CONNTRACK_NEXT_DROP;
-
 	} else {
 		return CONNTRACK_NEXT_DROP;
 	}

--- a/src/nodes/ipv6_lookup_node.c
+++ b/src/nodes/ipv6_lookup_node.c
@@ -32,10 +32,10 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 										   sizeof(struct rte_ether_hdr));
 	}
 
-	if (extract_inner_l3_header(m, ipv6_hdr, 0) < 0)
+	if (DP_FAILED(extract_inner_l3_header(m, ipv6_hdr, 0)))
 		return IPV6_LOOKUP_NEXT_DROP;
 
-	if (extract_inner_l4_header(m, ipv6_hdr + 1, 0) < 0)
+	if (DP_FAILED(extract_inner_l4_header(m, ipv6_hdr + 1, 0)))
 		return IPV6_LOOKUP_NEXT_DROP;
 
 	// TODO: add broadcast routes when machine is added

--- a/src/nodes/tx_node.c
+++ b/src/nodes/tx_node.c
@@ -111,7 +111,8 @@ static uint16_t tx_node_process(struct rte_graph *graph,
 				df->conntrack->flow_status |= DP_FLOW_STATUS_FLAG_DEFAULT;
 
 			if (df->flags.offload_decision == DP_FLOW_OFFLOAD_INSTALL || df->flags.offload_ipv6)
-				dp_offload_handler(pkt, df);
+				if (DP_FAILED(dp_offload_handler(pkt, df)))
+					DPNODE_LOG_WARNING(node, "Offloading handler failed");
 		}
 	}
 

--- a/src/rte_flow/dp_rte_flow.c
+++ b/src/rte_flow/dp_rte_flow.c
@@ -2,19 +2,13 @@
 #include "dp_error.h"
 #include "dp_flow.h"
 #include "dp_lpm.h"
+#include "dp_mbuf_dyn.h"
 #include "dp_nat.h"
 #include "nodes/dhcp_node.h"
-#include "dp_mbuf_dyn.h"
 #include "nodes/ipv6_nd_node.h"
-
-static const uint8_t ether_addr_mask[RTE_ETHER_ADDR_LEN] = "\xff\xff\xff\xff\xff\xff";
-static const uint8_t ipv6_addr_mask[16] = "\xff\xff\xff\xff\xff\xff\xff\xff"
-										  "\xff\xff\xff\xff\xff\xff\xff\xff";
-static const uint8_t ipv4_addr_mask[4] = "\xff\xff\xff\xff";
 
 uint16_t extract_inner_ethernet_header(struct rte_mbuf *pkt)
 {
-
 	struct rte_ether_hdr *eth_hdr;
 	struct dp_flow *df;
 
@@ -29,7 +23,6 @@ uint16_t extract_inner_ethernet_header(struct rte_mbuf *pkt)
 
 uint16_t extract_outer_ethernet_header(struct rte_mbuf *pkt)
 {
-
 	struct rte_ether_hdr *eth_hdr;
 	struct dp_flow *df;
 
@@ -72,12 +65,11 @@ int extract_inner_l3_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 		return df->l4_type;
 	}
 
-	return -1;
+	return DP_ERROR;
 }
 
 int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 {
-
 	struct dp_flow *df;
 	struct rte_tcp_hdr *tcp_hdr;
 	struct rte_udp_hdr *udp_hdr;
@@ -94,7 +86,7 @@ int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 
 		df->l4_info.trans_port.dst_port = tcp_hdr->dst_port;
 		df->l4_info.trans_port.src_port = tcp_hdr->src_port;
-		return 0;
+		return DP_OK;
 	} else if (df->l4_type == DP_IP_PROTO_UDP) {
 		if (hdr != NULL)
 			udp_hdr = (struct rte_udp_hdr *)hdr;
@@ -103,7 +95,7 @@ int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 
 		df->l4_info.trans_port.dst_port = udp_hdr->dst_port;
 		df->l4_info.trans_port.src_port = udp_hdr->src_port;
-		return 0;
+		return DP_OK;
 	} else if (df->l4_type == DP_IP_PROTO_ICMP) {
 		if (hdr != NULL)
 			icmp_hdr = (struct rte_icmp_hdr *)hdr;
@@ -113,7 +105,7 @@ int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 		df->l4_info.icmp_field.icmp_type = icmp_hdr->icmp_type;
 		df->l4_info.icmp_field.icmp_code = icmp_hdr->icmp_code;
 		df->l4_info.icmp_field.icmp_identifier = icmp_hdr->icmp_ident;
-		return 0;
+		return DP_OK;
 	} else if (df->l4_type == DP_IP_PROTO_ICMPV6) {
 		if (hdr != NULL)
 			icmp6_hdr = (struct icmp6hdr *)hdr;
@@ -121,15 +113,14 @@ int extract_inner_l4_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 			icmp6_hdr = rte_pktmbuf_mtod_offset(pkt, struct icmp6hdr *, offset);
 
 		df->l4_info.icmp_field.icmp_type = icmp6_hdr->icmp6_type;
-		return 0;
+		return DP_OK;
 	}
 
-	return -1;
+	return DP_ERROR;
 }
 
 int extract_outer_ipv6_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 {
-
 	struct dp_flow *df = dp_get_flow_ptr(pkt);
 	struct rte_ipv6_hdr *ipv6_hdr = NULL;
 
@@ -144,9 +135,6 @@ int extract_outer_ipv6_header(struct rte_mbuf *pkt, void *hdr, uint16_t offset)
 	rte_memcpy(df->tun_info.ul_src_addr6, ipv6_hdr->src_addr, sizeof(df->tun_info.ul_src_addr6));
 	rte_memcpy(df->tun_info.ul_dst_addr6, ipv6_hdr->dst_addr, sizeof(df->tun_info.ul_dst_addr6));
 	df->tun_info.proto_id = ipv6_hdr->proto;
-	// printf("ipv6->proto %#x\n",ipv6_hdr->proto);
-	// printf("ipv6->hop_limits %#x\n",ipv6_hdr->hop_limits);
-	// printf("payload length in arriving ipv6 hdr %#x\n",ipv6_hdr->payload_len);
 	return ipv6_hdr->proto;
 }
 
@@ -298,557 +286,26 @@ void dp_change_icmp_identifier(struct rte_mbuf *m, uint16_t new_val)
 	icmp_hdr->icmp_cksum = (~cksum) & 0xffff;
 }
 
-void create_rte_flow_rule_attr(struct rte_flow_attr *attr, uint32_t group, uint32_t priority, uint32_t ingress, uint32_t egress, uint32_t transfer)
-{
 
-	memset(attr, 0, sizeof(struct rte_flow_attr));
-
-	attr->group = group;
-	attr->ingress = ingress;
-	attr->egress = egress;
-	attr->priority = priority;
-	attr->transfer = transfer;
-}
-
-int insert_ethernet_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								  struct rte_flow_item_eth *eth_spec,
-								  struct rte_flow_item_eth *eth_mask,
-								  struct rte_ether_addr *src, size_t nr_src_mask_len,
-								  struct rte_ether_addr *dst, size_t nr_dst_mask_len,
-								  rte_be16_t type)
-{
-
-	memset(eth_spec, 0, sizeof(struct rte_flow_item_eth));
-	memset(eth_mask, 0, sizeof(struct rte_flow_item_eth));
-
-	if (src) {
-		memcpy(&(eth_spec->src), src, nr_src_mask_len);
-		memcpy(&(eth_mask->src), ether_addr_mask, nr_src_mask_len);
-	}
-
-	if (dst) {
-		memcpy(&(eth_spec->dst), dst, nr_dst_mask_len);
-		memcpy(&(eth_mask->dst), ether_addr_mask, nr_dst_mask_len);
-	}
-
-	eth_spec->type = type;
-	eth_mask->type = htons(0xffff);
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_ETH;
-	pattern[pattern_cnt].spec = eth_spec;
-	pattern[pattern_cnt].mask = eth_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_ipv6_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-							  struct rte_flow_item_ipv6 *ipv6_spec,
-							  struct rte_flow_item_ipv6 *ipv6_mask,
-							  uint8_t *src, size_t nr_src_mask_len,
-							  uint8_t *dst, size_t nr_dst_mask_len,
-							  uint8_t proto)
-{
-
-	memset(ipv6_spec, 0, sizeof(struct rte_flow_item_ipv6));
-	memset(ipv6_mask, 0, sizeof(struct rte_flow_item_ipv6));
-
-	if (src) {
-		memcpy(ipv6_spec->hdr.src_addr, src, nr_src_mask_len);
-		memcpy(ipv6_mask->hdr.src_addr, ipv6_addr_mask, nr_src_mask_len);
-	}
-
-	if (dst) {
-		memcpy(ipv6_spec->hdr.dst_addr, dst, nr_dst_mask_len);
-		memcpy(ipv6_mask->hdr.dst_addr, ipv6_addr_mask, nr_dst_mask_len);
-	}
-
-	ipv6_spec->hdr.proto = proto;
-	ipv6_mask->hdr.proto = 0xff;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_IPV6;
-	pattern[pattern_cnt].spec = ipv6_spec;
-	pattern[pattern_cnt].mask = ipv6_mask;
-
-	return ++pattern_cnt;
-}
-
-// this is a pure function that only take primitive information
-int insert_ipv4_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_ipv4 *ipv4_spec,
-								struct rte_flow_item_ipv4 *ipv4_mask,
-								rte_be32_t *src, size_t nr_src_mask_len,
-								rte_be32_t *dst, size_t nr_dst_mask_len,
-								uint8_t proto)
-{
-
-	memset(ipv4_spec, 0, sizeof(struct rte_flow_item_ipv4));
-	memset(ipv4_mask, 0, sizeof(struct rte_flow_item_ipv4));
-
-
-	if (src) {
-		ipv4_spec->hdr.src_addr = *src;
-		memcpy(&ipv4_mask->hdr.src_addr, ipv4_addr_mask, nr_src_mask_len);
-	}
-
-	if (dst) {
-		ipv4_spec->hdr.dst_addr = *dst;
-		memcpy(&ipv4_mask->hdr.dst_addr, ipv4_addr_mask, nr_dst_mask_len);
-	}
-
-	ipv4_spec->hdr.next_proto_id = proto;
-	ipv4_mask->hdr.next_proto_id = 0xff;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_IPV4;
-	pattern[pattern_cnt].spec = ipv4_spec;
-	pattern[pattern_cnt].mask = ipv4_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_udp_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-							 struct rte_flow_item_udp *udp_spec,
-							 struct rte_flow_item_udp *udp_mask,
-							 rte_be16_t src_port, rte_be16_t dst_port)
-{
-
-	memset(udp_spec, 0, sizeof(struct rte_flow_item_udp));
-	memset(udp_mask, 0, sizeof(struct rte_flow_item_udp));
-
-	// Who is going to match a port that is 0? Let's assume that port>0 is a valid one.
-	if (src_port) {
-		udp_spec->hdr.src_port = src_port;
-		udp_mask->hdr.src_port = 0xffff;
-	}
-
-	if (dst_port) {
-		udp_spec->hdr.dst_port = dst_port;
-		udp_mask->hdr.dst_port = 0xffff;
-	}
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_UDP;
-	pattern[pattern_cnt].spec = udp_spec;
-	pattern[pattern_cnt].mask = udp_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_tcp_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-							 struct rte_flow_item_tcp *tcp_spec,
-							 struct rte_flow_item_tcp *tcp_mask,
-							 rte_be16_t src_port, rte_be16_t dst_port,
-							 uint8_t tcp_flags)
-{
-
-	memset(tcp_spec, 0, sizeof(struct rte_flow_item_tcp));
-	memset(tcp_mask, 0, sizeof(struct rte_flow_item_tcp));
-
-	// Who is going to match a port that is 0? Let's assume that port>0 is a valid one.
-	if (src_port) {
-		tcp_spec->hdr.src_port = src_port;
-		tcp_mask->hdr.src_port = 0xffff;
-	}
-
-	if (dst_port) {
-		tcp_spec->hdr.dst_port = dst_port;
-		tcp_mask->hdr.dst_port = 0xffff;
-	}
-
-	if (tcp_flags) {
-		tcp_spec->hdr.tcp_flags = ~tcp_flags;
-		tcp_mask->hdr.tcp_flags = tcp_flags;
-	}
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_TCP;
-	pattern[pattern_cnt].spec = tcp_spec;
-	pattern[pattern_cnt].mask = tcp_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_icmp_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-							  struct rte_flow_item_icmp *icmp_spec,
-							  struct rte_flow_item_icmp *icmp_mask,
-							  uint8_t type)
-{
-
-	memset(icmp_spec, 0, sizeof(struct rte_flow_item_icmp));
-	memset(icmp_mask, 0, sizeof(struct rte_flow_item_icmp));
-
-	icmp_spec->hdr.icmp_type = type;
-	icmp_spec->hdr.icmp_type = 0xff;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_ICMP;
-	pattern[pattern_cnt].spec = icmp_spec;
-	pattern[pattern_cnt].mask = icmp_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_icmpv6_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-								struct rte_flow_item_icmp6 *icmp6_spec,
-								struct rte_flow_item_icmp6 *icmp6_mask,
-								uint8_t type)
-{
-
-	memset(icmp6_spec, 0, sizeof(struct rte_flow_item_icmp6));
-	memset(icmp6_mask, 0, sizeof(struct rte_flow_item_icmp6));
-
-	icmp6_spec->type = type;
-	icmp6_mask->type = 0xff;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_ICMP6;
-	pattern[pattern_cnt].spec = icmp6_spec;
-	pattern[pattern_cnt].mask = icmp6_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_packet_mark_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-									struct rte_flow_item_mark *mark_spec,
-									struct rte_flow_item_mark *mark_mask,
-									uint32_t marked_id)
-{
-
-	memset(mark_spec, 0, sizeof(struct rte_flow_item_mark));
-	memset(mark_mask, 0, sizeof(struct rte_flow_item_mark));
-
-	mark_spec->id = marked_id;
-	mark_mask->id = rte_flow_item_mark_mask.id;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_MARK;
-	pattern[pattern_cnt].spec = mark_spec;
-	pattern[pattern_cnt].mask = mark_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_tag_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-									struct rte_flow_item_tag *tag_spec,
-									struct rte_flow_item_tag *tag_mask,
-									uint32_t tag_value, uint8_t tag_index)
-{
-
-	memset(tag_spec, 0, sizeof(struct rte_flow_item_tag));
-	memset(tag_mask, 0, sizeof(struct rte_flow_item_tag));
-
-	tag_spec->data = tag_value;
-	tag_spec->index = tag_index;
-
-	tag_mask->data = rte_flow_item_tag_mask.data;
-	tag_mask->index = rte_flow_item_tag_mask.index;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_TAG;
-	pattern[pattern_cnt].spec = tag_spec;
-	pattern[pattern_cnt].mask = tag_mask;
-
-	return ++pattern_cnt;
-}
-
-int insert_meta_match_pattern(struct rte_flow_item *pattern, int pattern_cnt,
-							struct rte_flow_item_meta *meta_spec,
-							struct rte_flow_item_meta *meta_mask,
-							uint32_t meta_value)
-{
-
-	memset(meta_spec, 0, sizeof(struct rte_flow_item_meta));
-	memset(meta_mask, 0, sizeof(struct rte_flow_item_meta));
-
-	meta_spec->data = meta_value;
-
-	meta_mask->data = 0xffffffff;
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_META;
-	pattern[pattern_cnt].spec = meta_spec;
-	pattern[pattern_cnt].mask = meta_mask;
-
-	return ++pattern_cnt;
-}
-
-
-int insert_end_match_pattern(struct rte_flow_item *pattern, int pattern_cnt)
-{
-
-	pattern[pattern_cnt].type = RTE_FLOW_ITEM_TYPE_END;
-
-	return ++pattern_cnt;
-}
-
-int create_raw_decap_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_raw_decap *raw_decap_action,
-							uint8_t *data_to_decap, size_t data_len)
-{
-
-	raw_decap_action->data = data_to_decap;
-	raw_decap_action->size = data_len;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_RAW_DECAP;
-	action[action_cnt].conf = raw_decap_action;
-	return ++action_cnt;
-}
-
-int create_raw_encap_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_raw_encap *raw_encap_action,
-							uint8_t *data_to_encap, size_t data_len)
-{
-
-	raw_encap_action->data = data_to_encap;
-	raw_encap_action->size = data_len;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_RAW_ENCAP;
-	action[action_cnt].conf = raw_encap_action;
-
-	return ++action_cnt;
-}
-
-int create_dst_mac_set_action(struct rte_flow_action *action, int action_cnt,
-							  struct rte_flow_action_set_mac *dst_mac_set_action,
-							  struct rte_ether_addr *dst_mac)
-{
-
-	rte_ether_addr_copy(dst_mac, (struct rte_ether_addr *)(dst_mac_set_action->mac_addr));
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_MAC_DST;
-	action[action_cnt].conf = dst_mac_set_action;
-
-	return ++action_cnt;
-}
-
-int create_src_mac_set_action(struct rte_flow_action *action, int action_cnt,
-							  struct rte_flow_action_set_mac *src_mac_set_action,
-							  struct rte_ether_addr *src_mac)
-{
-
-	rte_ether_addr_copy(src_mac, (struct rte_ether_addr *)src_mac_set_action->mac_addr);
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_MAC_SRC;
-	action[action_cnt].conf = src_mac_set_action;
-
-	return ++action_cnt;
-}
-
-int create_ipv4_set_action(struct rte_flow_action *action, int action_cnt,
-						   struct rte_flow_action_set_ipv4 *ipv4_action,
-						   rte_be32_t ipv4, bool dir)
-{
-	ipv4_action->ipv4_addr = ipv4;
-
-	if (dir == DP_IS_DST)
-		action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_IPV4_DST;
-	else
-		action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_IPV4_SRC;
-
-	action[action_cnt].conf = ipv4_action;
-
-	return ++action_cnt;
-}
-
-int create_ipv6_set_action(struct rte_flow_action *action, int action_cnt,
-						   struct rte_flow_action_set_ipv6 *ipv6_action,
-						   uint8_t *ipv6, bool dir)
-{
-	memcpy(ipv6_action->ipv6_addr, ipv6, sizeof(ipv6_action->ipv6_addr));
-
-	if (dir == DP_IS_DST)
-		action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_IPV6_DST;
-	else
-		action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_IPV6_SRC;
-
-	action[action_cnt].conf = ipv6_action;
-
-	return ++action_cnt;
-}
-
-int create_trans_proto_set_action(struct rte_flow_action *action, int action_cnt,
-									struct rte_flow_action_set_tp *tp_action,
-									uint16_t port, bool dir)
-{
-
-	tp_action->port = htons(port);
-
-	if (dir == DP_IS_DST)
-		action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_TP_DST;
-	else
-		action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_TP_SRC;
-
-	action[action_cnt].conf = tp_action;
-
-	return ++action_cnt;
-}
-
-int create_send_to_port_action(struct rte_flow_action *action, int action_cnt,
-							   struct rte_flow_action_port_id *send_to_port_action,
-							   uint32_t port_id)
-{
-
-	send_to_port_action->original = 0; // original???
-	send_to_port_action->reserved = 0;
-	send_to_port_action->id = port_id;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_PORT_ID;
-	action[action_cnt].conf = send_to_port_action;
-
-	return ++action_cnt;
-}
-
-int create_flow_age_action(struct rte_flow_action *action, int action_cnt,
-						   struct rte_flow_action_age *flow_age_action,
-						   uint32_t timeout, void *age_context)
-{
-
-	flow_age_action->timeout = timeout;
-	flow_age_action->reserved = 0;
-	flow_age_action->context = age_context;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_AGE;
-	action[action_cnt].conf = flow_age_action;
-
-	return ++action_cnt;
-}
-
-int create_redirect_queue_action(struct rte_flow_action *action, int action_cnt,
-								 struct rte_flow_action_queue *queue_action,
-								 uint16_t queue_index)
-{
-
-	queue_action->index = queue_index;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_QUEUE;
-	action[action_cnt].conf = queue_action;
-
-	return ++action_cnt;
-}
-
-int create_packet_mark_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_mark *mark_action,
-							uint32_t marked_value)
-{
-
-	mark_action->id =  marked_value;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_MARK;
-	action[action_cnt].conf = mark_action;
-
-	return ++action_cnt;
-}
-
-int create_set_tag_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_set_tag *set_tag_action,
-							uint32_t tag_value, __rte_unused uint8_t index)
-{
-
-	set_tag_action->data =  tag_value;
-	set_tag_action->mask =  0xffffffff;
-	set_tag_action->index = 0;  // This function currently only supports one tag per packet
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_TAG;
-	action[action_cnt].conf = set_tag_action;
-
-	return ++action_cnt;
-}
-
-
-int create_set_meta_action(struct rte_flow_action *action, int action_cnt,
-							struct rte_flow_action_set_meta *meta_action,
-							uint32_t meta_value)
-{
-
-	meta_action->data =  meta_value;
-	meta_action->mask = 0xffffffff;
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_SET_META;
-	action[action_cnt].conf = meta_action;
-
-	return ++action_cnt;
-}
-
-int create_end_action(struct rte_flow_action *action, int action_cnt)
-{
-
-	action[action_cnt].type = RTE_FLOW_ACTION_TYPE_END;
-	return ++action_cnt;
-}
-
-// flow aging related config is highly customized, thus put them into a function in case different agectx needs
-// to be configured
-void free_allocated_agectx(struct flow_age_ctx *agectx)
-{
-	struct rte_flow_error error;
-
-	if (agectx) {
-		if (agectx->handle) {
-			if (DP_FAILED(dp_destroy_rte_action_handle(agectx->port_id, agectx->handle, &error)))
-				DPS_LOG_ERR("Failed to remove an indirect action", DP_LOG_PORTID(agectx->port_id));
-		}
-		rte_free(agectx);
-	}
-}
-
-void config_allocated_agectx(struct flow_age_ctx *agectx, uint16_t port_id,
-							struct dp_flow *df, struct rte_flow *flow)
-{
-	agectx->cntrack = df->conntrack;
-	agectx->rte_flow = flow;
-	agectx->port_id = port_id;
-	dp_ref_inc(&agectx->cntrack->ref_count);
-}
-
-
-
-struct rte_flow *validate_and_install_rte_flow(uint16_t port_id,
-												const struct rte_flow_attr *attr,
-												const struct rte_flow_item pattern[],
-												const struct rte_flow_action action[])
+struct rte_flow *dp_install_rte_flow(uint16_t port_id,
+									 const struct rte_flow_attr *attr,
+									 const struct rte_flow_item pattern[],
+									 const struct rte_flow_action actions[])
 {
 	int ret;
-	struct rte_flow *flow = NULL;
-	struct rte_flow_error error = {
-		.message = "(no stated reason)",
-	};
+	struct rte_flow *flow;
+	struct rte_flow_error error;
 
-	ret = rte_flow_validate(port_id, attr, pattern, action, &error);
-	if (ret) {
-		DPS_LOG_ERR("Flow cannot be validated", DP_LOG_FLOW_ERROR(error.message), DP_LOG_PORTID(port_id), DP_LOG_RET(ret));
+	ret = rte_flow_validate(port_id, attr, pattern, actions, &error);
+	if (DP_FAILED(ret)) {
+		DPS_LOG_ERR("Flow cannot be validated", DP_LOG_PORTID(port_id),  DP_LOG_FLOW_ERROR(error.message), DP_LOG_RET(ret));
 		return NULL;
-	} else {
-		flow = rte_flow_create(port_id, attr, pattern, action, &error);
-		if (!flow) {
-			DPS_LOG_ERR("Flow cannot be created", DP_LOG_PORTID(port_id), DP_LOG_FLOW_ERROR(error.message));
-			return NULL;
-		}
-		DPS_LOG_DEBUG("Installed a flow rule", DP_LOG_PORTID(port_id));
-		return flow;
-	}
-}
-
-int dp_create_age_indirect_action(struct rte_flow_attr *attr, uint16_t port_id,
-							struct dp_flow *df, struct rte_flow_action *age_action, struct flow_age_ctx *agectx)
-{
-
-	if (df->l4_type != IPPROTO_TCP)
-		return DP_OK;
-
-	struct rte_flow_indir_action_conf age_indirect_conf;
-	struct rte_flow_error error = {
-		.message = "(no stated reason)",
-	};
-	struct rte_flow_action_handle *result = NULL;
-
-	age_indirect_conf.ingress = attr->ingress;
-	age_indirect_conf.egress = attr->egress;
-	age_indirect_conf.transfer = attr->transfer;
-
-	result = rte_flow_action_handle_create(port_id, &age_indirect_conf, age_action, &error);
-	if (!result) {
-		DPS_LOG_ERR("Flow's age cannot be configured as indirect", DP_LOG_FLOW_ERROR(error.message));
-		return DP_ERROR;
 	}
 
-	if (DP_FAILED(dp_add_rte_age_ctx(df->conntrack, agectx))) {
-		if (DP_FAILED(dp_destroy_rte_action_handle(port_id, result, &error)))
-			DPS_LOG_ERR("Failed to remove an indirect action", DP_LOG_PORTID(port_id));
-		DPS_LOG_ERR("Failed to store agectx in conntrack object");
-		result = NULL;
-		return DP_ERROR;
+	flow = rte_flow_create(port_id, attr, pattern, actions, &error);
+	if (!flow) {
+		DPS_LOG_ERR("Flow cannot be created", DP_LOG_PORTID(port_id), DP_LOG_FLOW_ERROR(error.message));
+		return NULL;
 	}
-
-	agectx->handle = result;
-	return DP_OK;
+	return flow;
 }

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -2,154 +2,76 @@
 
 #include "dp_error.h"
 #include "dp_log.h"
-#include "rte_flow/dp_rte_flow.h"
+#include "rte_flow/dp_rte_flow_helpers.h"
 
+static const struct rte_flow_attr dp_flow_attr_prio_ingress = {
+	.group = 0,
+	.priority = 1,
+	.ingress = 1,
+	.egress = 0,
+	.transfer = 0,
+};
 
-static int create_flow(int port_id,
-					   struct rte_flow_attr *attr,
-					   struct rte_flow_item *pattern,
-					   struct rte_flow_action *action)
-{
-	int ret;
-	struct rte_flow *flow;
-	struct rte_flow_error error = {
-		.message = "(no stated reason)",
-	};
-
-	ret = rte_flow_validate(port_id, attr, pattern, action, &error);
-	if (DP_FAILED(ret)) {
-		DPS_LOG_ERR("Flow isolation cannot be validated",
-					DP_LOG_PORTID(port_id), DP_LOG_FLOW_ERROR(error.message), DP_LOG_RET(ret));
-		return ret;
-	}
-
-	flow = rte_flow_create(port_id, attr, pattern, action, &error);
-	if (!flow) {
-		DPS_LOG_ERR("Flow isolation cannot be created",
-					DP_LOG_PORTID(port_id), DP_LOG_FLOW_ERROR(error.message), DP_LOG_RET(rte_errno));
-		return DP_ERROR;
-	}
-
-	return DP_OK;
-}
-
-// TODO(plague): retval checking is not finished here, just bare minimum done
 int dp_install_isolated_mode_ipip(int port_id, uint8_t proto_id)
 {
-
-	// create flow attributes
-	struct rte_flow_attr attr;
-
-	create_rte_flow_rule_attr(&attr, 0, 1, 1, 0, 0);
-
-	struct rte_flow_item pattern[3];
+	struct rte_flow_item_eth eth_spec;   // #1
+	struct rte_flow_item_ipv6 ipv6_spec; // #2
+	struct rte_flow_item pattern[3];     // + end
 	int pattern_cnt = 0;
-	struct rte_flow_action action[2];
+	struct rte_flow_action_queue queue_action; // #1
+	struct rte_flow_action action[2];          // + end
 	int action_cnt = 0;
 
-	memset(pattern, 0, sizeof(pattern));
-	memset(action, 0, sizeof(action));
+	// create match pattern: IP in IPv6 tunnel packets
+	dp_set_eth_flow_item(&pattern[pattern_cnt++], &eth_spec, htons(RTE_ETHER_TYPE_IPV6));
+	dp_set_ipv6_flow_item(&pattern[pattern_cnt++], &ipv6_spec, proto_id);
+	dp_set_end_flow_item(&pattern[pattern_cnt++]);
 
-	// create flow match patterns -- eth
-	struct rte_flow_item_eth eth_spec;
-	struct rte_flow_item_eth eth_mask;
+	// create flow action: allow packets to enter dp-service packet queue
+	dp_set_redirect_queue_action(&action[action_cnt++], &queue_action, 0);
+	dp_set_end_action(&action[action_cnt++]);
 
-	pattern_cnt = insert_ethernet_match_pattern(pattern, pattern_cnt,
-												&eth_spec, &eth_mask,
-												NULL, 0, NULL, 0,
-												htons(RTE_ETHER_TYPE_IPV6));
+	if (!dp_install_rte_flow(port_id, &dp_flow_attr_prio_ingress, pattern, action))
+		return DP_ERROR;
 
-	// create flow match patterns -- ipv6
-	struct rte_flow_item_ipv6 ipv6_spec;
-	struct rte_flow_item_ipv6 ipv6_mask;
-
-	pattern_cnt = insert_ipv6_match_pattern(pattern, pattern_cnt,
-											&ipv6_spec, &ipv6_mask,
-											NULL, 0, NULL, 0,
-											proto_id);
-
-	// create flow match patterns -- end
-	pattern_cnt = insert_end_match_pattern(pattern, pattern_cnt);
-
-	// create flow action -- queue
-	struct rte_flow_action_queue queue_action;
-
-	action_cnt = create_redirect_queue_action(action, action_cnt,
-											  &queue_action, 0);
-
-	// create flow action -- end
-	action_cnt = create_end_action(action, action_cnt);
-
-	return create_flow(port_id, &attr, pattern, action);
+	DPS_LOG_DEBUG("Installed IPIP isolation flow rule", DP_LOG_PORTID(port_id));
+	return DP_OK;
 }
 
 #ifdef ENABLE_VIRTSVC
 int dp_install_isolated_mode_virtsvc(int port_id, uint8_t proto_id, uint8_t svc_ipv6[16], rte_be16_t svc_port)
 {
-
-	// create flow attributes
-	struct rte_flow_attr attr;
-
-	create_rte_flow_rule_attr(&attr, 0, 1, 1, 0, 0);
-
-	struct rte_flow_item pattern[4];
+	struct rte_flow_item_eth eth_spec;   // #1
+	struct rte_flow_item_ipv6 ipv6_spec; // #2
+	struct rte_flow_item_tcp tcp_spec;   // #3 (choose one)
+	struct rte_flow_item_udp udp_spec;   // #3 (choose one)
+	struct rte_flow_item pattern[4];     // + end
 	int pattern_cnt = 0;
-	struct rte_flow_action action[2];
+	struct rte_flow_action_queue queue_action; // #1
+	struct rte_flow_action actions[2];         // + end
 	int action_cnt = 0;
 
-	memset(pattern, 0, sizeof(pattern));
-	memset(action, 0, sizeof(action));
-
-	// create flow match patterns -- eth
-	struct rte_flow_item_eth eth_spec;
-	struct rte_flow_item_eth eth_mask;
-
-	pattern_cnt = insert_ethernet_match_pattern(pattern, pattern_cnt,
-												&eth_spec, &eth_mask,
-												NULL, 0, NULL, 0,
-												htons(RTE_ETHER_TYPE_IPV6));
-
-	// create flow match patterns -- ipv6
-	struct rte_flow_item_ipv6 ipv6_spec;
-	struct rte_flow_item_ipv6 ipv6_mask;
-
-	pattern_cnt = insert_ipv6_match_pattern(pattern, pattern_cnt,
-											&ipv6_spec, &ipv6_mask,
-											svc_ipv6, 16, NULL, 0,
-											proto_id);
-
-	// create flow match patterns -- L4
-	struct rte_flow_item_tcp tcp_spec;
-	struct rte_flow_item_tcp tcp_mask;
-	struct rte_flow_item_udp udp_spec;
-	struct rte_flow_item_udp udp_mask;
-
+	// create match pattern: IPv6 packets from selected addresses
+	dp_set_eth_flow_item(&pattern[pattern_cnt++], &eth_spec, htons(RTE_ETHER_TYPE_IPV6));
+	dp_set_ipv6_src_flow_item(&pattern[pattern_cnt++], &ipv6_spec, svc_ipv6, proto_id);
 	if (proto_id == DP_IP_PROTO_TCP) {
-		pattern_cnt = insert_tcp_match_pattern(pattern, pattern_cnt,
-											   &tcp_spec, &tcp_mask,
-											   svc_port, 0,
-											   0);
+		dp_set_tcp_src_flow_item(&pattern[pattern_cnt++], &tcp_spec, svc_port);
 	} else if (proto_id == DP_IP_PROTO_UDP) {
-		pattern_cnt = insert_udp_match_pattern(pattern, pattern_cnt,
-											   &udp_spec, &udp_mask,
-											   svc_port, 0);
+		dp_set_udp_src_flow_item(&pattern[pattern_cnt++], &udp_spec, svc_port);
 	} else {
 		DPS_LOG_ERR("Invalid virtsvc protocol for isolation", DP_LOG_PROTO(proto_id));
 		return DP_ERROR;
 	}
+	dp_set_end_flow_item(&pattern[pattern_cnt++]);
 
-	// create flow match patterns -- end
-	pattern_cnt = insert_end_match_pattern(pattern, pattern_cnt);
+	// create flow action: allow packets to enter dp-service packet queue
+	dp_set_redirect_queue_action(&actions[action_cnt++], &queue_action, 0);
+	dp_set_end_action(&actions[action_cnt++]);
 
-	// create flow action -- queue
-	struct rte_flow_action_queue queue_action;
+	if (!dp_install_rte_flow(port_id, &dp_flow_attr_prio_ingress, pattern, actions))
+		return DP_ERROR;
 
-	action_cnt = create_redirect_queue_action(action, action_cnt,
-											  &queue_action, 0);
-
-	// create flow action -- end
-	action_cnt = create_end_action(action, action_cnt);
-
-	return create_flow(port_id, &attr, pattern, action);
+	DPS_LOG_DEBUG("Installed virtsvc isolation flow rule", DP_LOG_PORTID(port_id));
+	return DP_OK;
 }
 #endif


### PR DESCRIPTION
I was looking for places where return value handling is still not refactored, so I entered the rte_flow subdir.

Most of the changes is just moving stuff around and creating wrappers. The overall architecture of each flow creation is till the same, i.e. all steps are still repeated for similar flows to be easier to read. 

I tried to create small commits due to the fact that I cannot properly test on a cluster, but I do finally have two real machines connected. These commits should make it easier to review and (hopefully not needed) bisect on errors.

I would rather squash them at the end as the history does not really need that many I think.

I put this as a draft so we can discuss the changes first and also address a few leftover problems/misunderstandings by me.

Maybe just take a look first, test if this is totally broken and then we can sync using this draft PR as a visual guide.