### PR TITLE
Fixed fast flow aging for tests

### DIFF
--- a/include/dp_timers.h
+++ b/include/dp_timers.h
@@ -14,7 +14,7 @@ void dp_timers_free(void);
 int dp_timers_add_stats(rte_timer_cb_t stats_cb);
 
 uint64_t dp_timers_get_manage_interval_cycles(void);
-uint8_t dp_timers_get_flow_aging_interval(void);
+int dp_timers_get_flow_aging_interval(void);
 void dp_timers_signal_initialization(void);
 
 #ifdef __cplusplus

--- a/src/dp_timers.c
+++ b/src/dp_timers.c
@@ -77,7 +77,7 @@ uint64_t dp_timers_get_manage_interval_cycles(void)
 	return dp_timer_manage_interval_cycles;
 }
 
-uint8_t dp_timers_get_flow_aging_interval(void)
+int dp_timers_get_flow_aging_interval(void)
 {
 	return TIMER_FLOW_AGING_INTERVAL;
 }


### PR DESCRIPTION
The new change in conntrack code is not compatible with `--fast-flow-timeout` in pytest, so I propose this fix.

I am not 100% sure on the conntrack fast_path functionality, so please check my change thoroughly.