### PR TITLE
Reworked cntrack flow cache, added invalidation

### DIFF
--- a/include/dp_cntrack.h
+++ b/include/dp_cntrack.h
@@ -1,8 +1,6 @@
 #ifndef __INCLUDE_DP_CNTRACK_H__
 #define __INCLUDE_DP_CNTRACK_H__
 
-#include <rte_common.h>
-#include <rte_graph.h>
 #include <rte_graph_worker.h>
 #include <rte_mbuf.h>
 
@@ -13,8 +11,10 @@ extern "C" {
 #endif
 
 void dp_cntrack_init(void);
+
 int dp_cntrack_handle(struct rte_node *node, struct rte_mbuf *m, struct dp_flow *df);
 
+void dp_cntrack_flush_cache(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a required change for #357 to be addressed properly and this also fixes #356 

I have moved the cntrack flow value caching from time-based invalidation (that somewhat duplicates flow table aging code) to a direct flush.
The main reason in that the upcoming flow-table flushing by NAT/VIP/neigh/... removal will need to trigger this.

During implementation I noticed that there are also some edge cases that were not covered by the time-based cache invalidation in `dp_cntrack.c`, namely all calls to `dp_delete_flow_key()`.

So I now invalidate the `prev_key` caching in `dp_cntrack.c` every time `dp_delete_flow_key()` gets called (i.e. flow table gets a removal). This will automatically get called by flow aging via the reference counting hook. And it should then also automatically work for the upcoming flow-table invalidation for NAT, etc.