### PR TITLE
Added TCP flags to graphtrace output

### DIFF
--- a/src/monitoring/dp_graphtrace_shared.c
+++ b/src/monitoring/dp_graphtrace_shared.c
@@ -10,6 +10,41 @@
 					##__VA_ARGS__); \
 } while (0)
 
+static const char *tcp_strflags[256] = {
+	"",       "F",      "S",      "FS",      "R",      "FR",      "SR",      "FSR",
+	"P",      "FP",     "SP",     "FSP",     "RP",     "FRP",     "SRP",     "FSRP",
+	"A",      "FA",     "SA",     "FSA",     "RA",     "FRA",     "SRA",     "FSRA",
+	"PA",     "FPA",    "SPA",    "FSPA",    "RPA",    "FRPA",    "SRPA",    "APRSF",
+	"U",      "FU",     "SU",     "FSU",     "RU",     "FRU",     "SRU",     "FSRU",
+	"PU",     "FPU",    "SPU",    "FSPU",    "RPU",    "FRPU",    "SRPU",    "UPRSF",
+	"AU",     "FAU",    "SAU",    "FSAU",    "RAU",    "FRAU",    "SRAU",    "UARSF",
+	"PAU",    "FPAU",   "SPAU",   "FSPAU",   "UAPR",   "FRPAU",   "SRPAU",   "FSRPAU",
+	"E",      "FE",     "SE",     "FSE",     "RE",     "FRE",     "SRE",     "FSRE",
+	"PE",     "FPE",    "SPE",    "FSPE",    "RPE",    "FRPE",    "SRPE",    "EPRSF",
+	"AE",     "FAE",    "SAE",    "FSAE",    "RAE",    "FRAE",    "SRAE",    "EARSF",
+	"PAE",    "FPAE",   "SPAE",   "FSPAE",   "EAPR",   "FRPAE",   "SRPAE",   "FSRPAE",
+	"UE",     "FUE",    "SUE",    "FSUE",    "RUE",    "FRUE",    "SRUE",    "EURSF",
+	"PUE",    "FPUE",   "SPUE",   "FSPUE",   "EUPR",   "FRPUE",   "SRPUE",   "FSRPUE",
+	"AUE",    "FAUE",   "SAUE",   "FSAUE",   "EUAR",   "FRAUE",   "SRAUE",   "FSRAUE",
+	"PAUE",   "FPAUE",  "SPAUE",  "FSPAUE",  "RPAUE",  "FRPAUE",  "SRPAUE",  "FSRPAUE",
+	"C",      "FC",     "SC",     "FSC",     "RC",     "FRC",     "SRC",     "FSRC",
+	"PC",     "FPC",    "SPC",    "FSPC",    "RPC",    "FRPC",    "SRPC",    "CPRSF",
+	"AC",     "FAC",    "SAC",    "FSAC",    "RAC",    "FRAC",    "SRAC",    "CARSF",
+	"PAC",    "FPAC",   "SPAC",   "FSPAC",   "CAPR",   "FRPAC",   "SRPAC",   "FSRPAC",
+	"UC",     "FUC",    "SUC",    "FSUC",    "RUC",    "FRUC",    "SRUC",    "CURSF",
+	"PUC",    "FPUC",   "SPUC",   "FSPUC",   "CUPR",   "FRPUC",   "SRPUC",   "FSRPUC",
+	"AUC",    "FAUC",   "SAUC",   "FSAUC",   "CUAR",   "FRAUC",   "SRAUC",   "FSRAUC",
+	"PAUC",   "FPAUC",  "SPAUC",  "FSPAUC",  "RPAUC",  "FRPAUC",  "SRPAUC",  "FSRPAUC",
+	"EC",     "FEC",    "SEC",    "FSEC",    "REC",    "FREC",    "SREC",    "CERSF",
+	"PEC",    "FPEC",   "SPEC",   "FSPEC",   "CEPR",   "FRPEC",   "SRPEC",   "FSRPEC",
+	"AEC",    "FAEC",   "SAEC",   "FSAEC",   "CEAR",   "FRAEC",   "SRAEC",   "FSRAEC",
+	"PAEC",   "FPAEC",  "SPAEC",  "FSPAEC",  "RPAEC",  "FRPAEC",  "SRPAEC",  "FSRPAEC",
+	"UEC",    "FUEC",   "SUEC",   "FSUEC",   "CEUR",   "FRUEC",   "SRUEC",   "FSRUEC",
+	"PUEC",   "FPUEC",  "SPUEC",  "FSPUEC",  "RPUEC",  "FRPUEC",  "SRPUEC",  "FSRPUEC",
+	"AUEC",   "FAUEC",  "SAUEC",  "FSAUEC",  "RAUEC",  "FRAUEC",  "SRAUEC",  "FSRAUEC",
+	"PAUEC",  "FPAUEC", "SPAUEC", "FSPAUEC", "RPAUEC", "FRPAUEC", "SRPAUEC", "FSRPAUEC",
+};
+
 static void dp_graphtrace_sprint_ether(void **p_pkt_data, size_t *p_pos, char *buf, size_t bufsize)
 {
 	struct rte_ether_hdr *ether_hdr = (struct rte_ether_hdr *)*p_pkt_data;
@@ -61,8 +96,10 @@ static void dp_graphtrace_sprint_tcp(void **p_pkt_data, size_t *p_pos, char *buf
 	struct rte_tcp_hdr *tcp_hdr = (struct rte_tcp_hdr *)*p_pkt_data;
 
 	PRINT_LAYER(p_pos, buf, bufsize,
-		"TCP %u -> %u seq %u ack %u",
-		ntohs(tcp_hdr->src_port), ntohs(tcp_hdr->dst_port), ntohl(tcp_hdr->sent_seq), ntohl(tcp_hdr->recv_ack));
+		"TCP %u -> %u [%s] seq %u ack %u",
+		ntohs(tcp_hdr->src_port), ntohs(tcp_hdr->dst_port),
+		tcp_strflags[tcp_hdr->tcp_flags],
+		ntohl(tcp_hdr->sent_seq), ntohl(tcp_hdr->recv_ack));
 
 	*p_pkt_data = tcp_hdr + 1;
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,6 +34,9 @@ def pytest_addoption(parser):
 	parser.addoption(
 		"--dpgrpc", action="store_true", help="Use C++ gRPC client"
 	)
+	parser.addoption(
+		"--graphtrace", action="store_true", help="Log graph tracing messages"
+	)
 
 @pytest.fixture(scope="package")
 def build_path(request):
@@ -61,7 +64,8 @@ def dp_service(request, build_path, port_redundancy, fast_flow_timeout):
 	dp_service = DpService(build_path, port_redundancy, fast_flow_timeout,
 						   test_virtsvc = request.config.getoption("--virtsvc"),
 						   hardware = request.config.getoption("--hw"),
-						   offloading = request.config.getoption("--offloading"))
+						   offloading = request.config.getoption("--offloading"),
+						   graphtrace = request.config.getoption("--graphtrace"))
 
 	if request.config.getoption("--attach"):
 		print("Attaching to an already running service")

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -14,7 +14,8 @@ class DpService:
 
 	DP_SERVICE_CONF = "/tmp/dp_service.conf"
 
-	def __init__(self, build_path, port_redundancy, fast_flow_timeout, gdb=False, test_virtsvc=False, hardware=False, offloading=False):
+	def __init__(self, build_path, port_redundancy, fast_flow_timeout,
+				 gdb=False, test_virtsvc=False, hardware=False, offloading=False, graphtrace=False):
 		self.build_path = build_path
 		self.port_redundancy = port_redundancy
 		self.hardware = hardware
@@ -49,6 +50,8 @@ class DpService:
 					 f' --dhcp-dns="{dhcp_dns1}" --dhcp-dns="{dhcp_dns2}"'
 					 f' --grpc-port={grpc_port}'
 					  ' --no-stats')
+		if graphtrace:
+			self.cmd += ' --graphtrace-loglevel=1'
 		if not offloading:
 			self.cmd += ' --no-offload'
 


### PR DESCRIPTION
In operations, TCP flags are actually the most used info from tcpdump, because IP/ports are already in the filter and we are looking at how the TCP connection fails by looking at the flags (often whether or not we finish the handshake).

But this is actually missing in graphtrace, so I added it (inspired by tcpdump output).

I chose to use an array for speed. If you dislike it then I can only think of doing this:
```printf("[%s%s%s%s%s]", tcp_flags&TCP_ACK ? "A" : "", ...(5 times)```

I also added a `--graphtrace` switch to pytest as graphtrace is now a permanent part of the service and not being compiled in, so why not have it as an easy switch (at least I appreciate it being there).