### PR TITLE
Fixed invalid logging call in virtual services

### DIFF
--- a/src/dp_virtsvc.c
+++ b/src/dp_virtsvc.c
@@ -290,7 +290,8 @@ static __rte_always_inline int dp_virtsvc_create_connection(struct dp_virtsvc *v
 		delete_key.vf_l4_port = conn->vf_l4_port;
 		ret = rte_hash_del_key(virtsvc->open_ports, &delete_key);
 		if (DP_FAILED(ret))
-			DPS_LOG_WARNING("Cannot delete virtual service NAT entry %s", DP_LOG_RET(ret));
+			DPS_LOG_WARNING("Cannot delete virtual service NAT entry", DP_LOG_RET(ret),
+							DP_LOG_PORTID(conn->vf_port_id), DP_LOG_PORT(conn->vf_l4_port));
 	}
 
 	ret = rte_hash_add_key_with_hash_data(virtsvc->open_ports, key, sig, (void *)(intptr_t)free_port);
@@ -362,7 +363,7 @@ void dp_virtsvc_del_vm(uint16_t port_id)
 		// But in practice, the port table is always full anyway
 		// as timed-out connections get replaced with new ones on-demand
 		// (i.e. the table is constantly full after the first 64k connections)
-		for (uint i = 0; i < RTE_DIM(service->connections); ++i) {
+		for (size_t i = 0; i < RTE_DIM(service->connections); ++i) {
 			conn = &service->connections[i];
 			if (conn->vf_port_id == port_id && conn->last_pkt_timestamp) {
 				conn->last_pkt_timestamp = 0;
@@ -370,7 +371,8 @@ void dp_virtsvc_del_vm(uint16_t port_id)
 				delete_key.vf_l4_port = conn->vf_l4_port;
 				ret = rte_hash_del_key(service->open_ports, &delete_key);
 				if (DP_FAILED(ret))
-					DPS_LOG_WARNING("Cannot delete virtual service NAT entry", DP_LOG_PORTID(port_id), DP_LOG_RET(ret));
+					DPS_LOG_WARNING("Cannot delete virtual service NAT entry", DP_LOG_RET(ret),
+							DP_LOG_PORTID(conn->vf_port_id), DP_LOG_PORT(conn->vf_l4_port));
 			}
 		}
 	}


### PR DESCRIPTION
Crash-inducing assertion by using the wrong logging format.

I also unified those similar calls.