### PR TITLE
Fix (backport) bug in DPDK in graph allocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ COPY hack/*.patch hack/
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_21_11_clang.patch
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_21_11_log.patch
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_21_11_xstats_mem_leak.patch
+RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_21_11_graph_alloc.patch
 
 # Compile DPDK
 RUN cd $DPDK_DIR && meson -Dmax_ethports=132 -Dplatform=generic -Ddisable_drivers=common/dpaax,\

--- a/hack/dpdk_21_11_graph_alloc.patch
+++ b/hack/dpdk_21_11_graph_alloc.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/graph/rte_graph_worker.h b/lib/graph/rte_graph_worker.h
+index 0c0b9c095ad..6dc74616597 100644
+--- a/lib/graph/rte_graph_worker.h
++++ b/lib/graph/rte_graph_worker.h
+@@ -224,7 +224,7 @@ __rte_node_enqueue_prologue(struct rte_graph *graph, struct rte_node *node,
+ 		__rte_node_enqueue_tail_update(graph, node);
+
+ 	if (unlikely(node->size < (idx + space)))
+-		__rte_node_stream_alloc(graph, node);
++		__rte_node_stream_alloc_size(graph, node, node->size + space);
+ }
+
+ /**
+@@ -432,7 +432,7 @@ rte_node_next_stream_get(struct rte_graph *graph, struct rte_node *node,
+ 	uint16_t free_space = node->size - idx;
+
+ 	if (unlikely(free_space < nb_objs))
+-		__rte_node_stream_alloc_size(graph, node, nb_objs);
++		__rte_node_stream_alloc_size(graph, node, node->size + nb_objs);
+
+ 	return &node->objs[idx];
+ }


### PR DESCRIPTION
I implemented the DPDK solution to a bug in graph burst (re)allocation to alleviate a problem in production.

See the issue for more details.

Fixes #376 