### PR TITLE
Removed log noise for ICMP packets of unused type.

### DIFF
--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -276,17 +276,15 @@ static __rte_always_inline int dp_get_flow_val(struct rte_mbuf *m, struct dp_flo
 	return DP_OK;
 }
 
-int dp_cntrack_handle(struct rte_node *node, struct rte_mbuf *m, struct dp_flow *df)
+int dp_cntrack_handle(__rte_unused struct rte_node *node, struct rte_mbuf *m, struct dp_flow *df)
 {
 	struct flow_value *flow_val;
 	struct rte_tcp_hdr *tcp_hdr;
 	int ret;
 
 	ret = dp_get_flow_val(m, df, &flow_val);
-	if (DP_FAILED(ret)) {
-		DPNODE_LOG_WARNING(node, "Cannot establish flow value", DP_LOG_RET(ret));
+	if (DP_FAILED(ret))
 		return ret;
-	}
 
 	flow_val->timestamp = rte_rdtsc();
 

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -47,7 +47,7 @@ void dp_flow_free(void)
 	dp_free_jhash_table(ipv4_flow_tbl);
 }
 
-static int dp_build_icmp_flow_key(struct dp_flow *df, struct flow_key *key /* out */, struct rte_mbuf *m /* in */)
+static __rte_always_inline int dp_build_icmp_flow_key(struct dp_flow *df, struct flow_key *key /* out */, struct rte_mbuf *m /* in */)
 {
 	struct dp_icmp_err_ip_info icmp_err_ip_info = {0};
 


### PR DESCRIPTION
My recent refactoring and adding a log caused a regression, where unimplemented ICMP type packets cause log flooding.

@byteocean @guvenc Even though I removed the log in the caller (as all errors are already logged in the callee), are these DEBUG logs actually needed? I.e. will there be an implementation of such packets in the future, Because if not, I think we should remove them since they are a potential DDoS/log spam vector if someone would enable debug logging.

The function containing the debug logs is `dp_build_icmp_flow_key()`
(I also inlined it since it is only ever called in one place in the hot path).