### PR TITLE
Prevent redundant docker build and push on release published

### DIFF
--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -4,9 +4,6 @@ env:
   platforms: linux/amd64
 
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -4,9 +4,6 @@ env:
   platforms: linux/amd64
 
 on:
-  release:
-    types:
-      - published
   push:
     branches:
       - main


### PR DESCRIPTION
Remove trigger `on release`. Upon each release a tag is created, the v-tag criteria will be matched, so a build and push will be performed implicitly

