### PR TITLE
Added retval checks and simplified dp_add_flow()

### DIFF
--- a/include/dp_cntrack.h
+++ b/include/dp_cntrack.h
@@ -4,7 +4,7 @@
 #include <rte_graph_worker.h>
 #include <rte_mbuf.h>
 
-#include "dp_flow.h"
+#include "dp_mbuf_dyn.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,6 +21,5 @@ void dp_cntrack_flush_cache(void);
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // __INCLUDE_DP_CNTRACK_H__

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -141,12 +141,9 @@ struct flow_age_ctx {
 };
 
 bool dp_are_flows_identical(struct flow_key *key1, struct flow_key *key2);
-int dp_get_flow_data(struct flow_key *key, void **data);
-// TODO(plague): followup PR to actually check this value
-int dp_add_flow_data(struct flow_key *key, void *data);
-// TODO(plague): followup PR to actually check this value (and maybe rename to _key to match delete)
-int dp_add_flow(struct flow_key *key);
-void dp_delete_flow_key(struct flow_key *key);
+int dp_get_flow(struct flow_key *key, struct flow_value **p_flow_val);
+int dp_add_flow(struct flow_key *key, struct flow_value *flow_val);
+void dp_delete_flow(struct flow_key *key);
 int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(struct flow_key *key /* in */, struct flow_key *inv_key /* out */);
 int dp_flow_init(int socket_id);

--- a/src/nodes/lb_node.c
+++ b/src/nodes/lb_node.c
@@ -63,7 +63,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 		if (df->flags.nat != DP_LB_RECIRC) {
 			cntrack->nf_info.nat_type = DP_FLOW_LB_TYPE_FORWARD;
-			dp_delete_flow_key(&cntrack->flow_key[DP_FLOW_DIR_REPLY]); // no reverse traffic for relaying pkts
+			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]); // no reverse traffic for relaying pkts
 		} else
 			cntrack->nf_info.nat_type = DP_FLOW_LB_TYPE_RECIRC;
 

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -72,13 +72,13 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 			/* Expect the new destination in this conntrack object */
 			cntrack->flow_status |= DP_FLOW_STATUS_FLAG_SRC_NAT;
-			dp_delete_flow_key(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].ip_dst = ntohl(ipv4_hdr->src_addr);
 			if (snat_data->network_nat_ip != 0)
 				cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 
-			dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-			dp_add_flow_data(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
+			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
+				return SNAT_NEXT_DROP;
 		}
 		// it is deleted due the case where an init packet/request is sent twice, and no action is done if it is returned here
 		// it has to continue to the follow-up code


### PR DESCRIPTION
> best to merge this after the graphtrace for offloaded VFs, I'll be rebasing this then

I had a pending TODO for missing return value checks for `dp_add_flow*()`, so I added them. This also caused a need for some rollback in `dp_cntrack.c`, which I added.

Doing that I noticed that there was always a `dp_add_flow()` and a subsequent `dp_add_flow_data()` which effectively doubles the amount of hash table access, but I do not believe this is ever needed, so I actually merged these functions (and renamed appropriately).

Since I was tracing the call path, I also changed some style details and removed the need to set `inverted_key` to zero before overwriting it via `dp_invert_flow_key()`.

I am not sure about the DROP in `dnat_node` and `snat_node`, i.e. whether to rollback or do something else besides dropping, but I did not think up anything better.
