### PR TITLE
Added safety margin to hash table sizes

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -13,7 +13,8 @@
 extern "C" {
 #endif
 
-#define FLOW_MAX						(1*1024*1024UL)
+// arbitrary big number
+#define FLOW_MAX						850000
 
 #define DP_FLOW_VAL_AGE_CTX_CAPACITY	5
 
@@ -32,11 +33,11 @@ extern "C" {
 #define DP_IS_FLOW_STATUS_FLAG_NONE(flag)		(!(flag))
 #define DP_IS_FLOW_STATUS_FLAG_SRC_NAT(flag)	((flag) & DP_FLOW_STATUS_FLAG_SRC_NAT)
 #define DP_IS_FLOW_STATUS_FLAG_DST_NAT(flag)	((flag) & DP_FLOW_STATUS_FLAG_DST_NAT)
-#define DP_IS_FLOW_STATUS_FLAG_DST_LB(flag)	((flag) & DP_FLOW_STATUS_FLAG_DST_LB)
+#define DP_IS_FLOW_STATUS_FLAG_DST_LB(flag)		((flag) & DP_FLOW_STATUS_FLAG_DST_LB)
 #define DP_IS_FLOW_STATUS_FLAG_FIREWALL(flag)	((flag) & DP_FLOW_STATUS_FLAG_FIREWALL)
 #define DP_IS_FLOW_STATUS_FLAG_DEFAULT(flag)	((flag) & DP_FLOW_STATUS_FLAG_DEFAULT)
 
- #define DP_IS_FLOW_STATUS_FLAG_NF(flag)		((flag) & DP_FLOW_STATUS_FLAG_NF)
+#define DP_IS_FLOW_STATUS_FLAG_NF(flag)		((flag) & DP_FLOW_STATUS_FLAG_NF)
 
 
 enum {

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -10,6 +10,9 @@
 #define DP_SYSFS_SUFFIX_MLX_VF_COUNT	"/device/sriov_numvfs"
 #define DP_SYSFS_MAX_PATH 256
 
+// makes sure there is enough space to prevent collisions
+#define DP_JHASH_MARGIN_COEF(ENTRIES) ((ENTRIES)*1.20)
+
 int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IFNAMSIZ])
 {
 	int ret;
@@ -148,7 +151,7 @@ struct rte_hash *dp_create_jhash_table(int entries, size_t key_len, const char *
 
 	struct rte_hash_parameters params = {
 		.name = full_name,
-		.entries = entries,
+		.entries = DP_JHASH_MARGIN_COEF(entries),
 		.key_len = key_len,
 		.hash_func = hash_func,
 		.hash_func_init_val = 0xfee1900d,  // "random" IV


### PR DESCRIPTION
As discussed, this increases all hash table sizes by a factor of 20%. Since flow table is big and the size seems arbitrary, that single one has been adjusted to stay relatively the same.

(Also naming is hard, so if the macro seems opaque, please suggest a better name)