### PR TITLE
Improve randomness for underlay_ip generation

### DIFF
--- a/src/dp_service.c
+++ b/src/dp_service.c
@@ -225,7 +225,7 @@ static int run_service(void)
 {
 	int result;
 
-	srand(time(NULL));
+	srand(rte_rdtsc());
 
 	// pre-init sanity checks
 	if (!dp_conf_is_conntrack_enabled() && dp_conf_is_offload_enabled()) {


### PR DESCRIPTION
I previously noticed that when I test and generate multiple VMs, the all get very similar underlay addresses:
```
$ /home/plague/onmetal/lab/setup_local.sh
 UUID
 C3DBB108-F826-400D-AD98-134C7ECEF1D9
test10 created, underlay route: fe80::a7:0:1
test11 created, underlay route: fe80::a7:0:2
```
I never really looked into it, nut I did once notice this in production even.

Now while doing #392 I saw the culprit: `srand(time(NULL))` is called every time and the resolution of `time(NULL)` is in seconds.

So I moved the `srand()` into initialization:
```
$ /home/plague/onmetal/lab/setup_local.sh
 UUID
 131CF85D-C698-4927-8B89-0EAEF9719FF2
test10 created, underlay route: fe80::8e:0:1
test11 created, underlay route: fe80::3d:0:2
```

(I also simplified the `ENABLE_STATIC_UNDERLAY_IP` code while touching the location)