### PR TITLE
Fixed VF offloaded dump (output and DPDK 22 compatibility)

### DIFF
--- a/include/monitoring/dp_graphtrace.h
+++ b/include/monitoring/dp_graphtrace.h
@@ -41,6 +41,7 @@ void _dp_graphtrace_send(enum dp_graphtrace_pkt_type type, struct rte_node *node
 #define dp_graphtrace_node_burst(NODE, OBJS, NUM) _dp_graphtrace_log_node_burst(NODE, OBJS, NUM)
 
 extern bool _dp_graphtrace_enabled;
+extern bool _dp_graphtrace_hw_enabled;
 
 static __rte_always_inline void dp_graphtrace_next(struct rte_node *node, void *obj, rte_edge_t next_index)
 {
@@ -66,17 +67,8 @@ static __rte_always_inline void dp_graphtrace_tx_burst(struct rte_node *node, vo
 
 static __rte_always_inline void dp_graphtrace_capture_offload_pkt(void *obj)
 {
-	_dp_graphtrace_send(DP_GRAPHTRACE_PKT_TYPE_OFFLOAD, NULL, NULL, &obj, 1);
-}
-
-static __rte_always_inline void dp_graphtrace_enable(void)
-{
-	_dp_graphtrace_enabled = true;
-}
-
-static __rte_always_inline void dp_graphtrace_disable(void)
-{
-	_dp_graphtrace_enabled = false;
+	if (_dp_graphtrace_hw_enabled)
+		_dp_graphtrace_send(DP_GRAPHTRACE_PKT_TYPE_OFFLOAD, NULL, NULL, &obj, 1);
 }
 
 static __rte_always_inline bool dp_graphtrace_is_enabled(void)

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -15,7 +15,11 @@ static const struct rte_flow_attr dp_flow_attr_prio_ingress = {
 static const struct rte_flow_attr dp_flow_attr_default_jump_ingress = {
 	.group = DP_RTE_FLOW_DEFAULT_GROUP,
 	.priority = 1,
+#ifdef ENABLE_DPDK_22_11
+	.ingress = 0,
+#else
 	.ingress = 1,
+#endif
 	.egress = 0,
 	.transfer = 1,
 };
@@ -23,7 +27,11 @@ static const struct rte_flow_attr dp_flow_attr_default_jump_ingress = {
 static const struct rte_flow_attr dp_flow_attr_default_monitoring_ingress = {
 	.group = DP_RTE_FLOW_MONITORING_GROUP,
 	.priority = 3,
+#ifdef ENABLE_DPDK_22_11
+	.ingress = 0,
+#else
 	.ingress = 1,
+#endif
 	.egress = 0,
 	.transfer = 1,
 };

--- a/tools/dp_graphtrace.c
+++ b/tools/dp_graphtrace.c
@@ -156,6 +156,7 @@ static void print_packet(struct rte_mbuf *pkt)
 			printbuf);
 		break;
 	}
+	fflush(stdout);
 }
 
 static int dp_graphtrace_dump(struct dp_graphtrace *graphtrace)


### PR DESCRIPTION
Even though there is a DPDK 22 update incoming, current main will not start in offloaded mode after VF dunping has been added.

Also, the offloaded packets will always get traced even when tracing was never enabled, which is a performance hit.

The rest is just small improvements found along the way.