### PR TITLE
Docker image improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:11-slim as builder
 
 ARG DPDK_VER=21.11
+ARG DPSERVICE_FEATURES=""
 
 WORKDIR /workspace
 
@@ -90,11 +91,11 @@ COPY tools/ tools/
 # Needed for version extraction by meson
 COPY .git/ .git/
 
-RUN meson setup build && cd ./build && ninja
+RUN meson setup build $DPSERVICE_FEATURES && cd ./build && ninja
 
 FROM builder AS testbuilder
-RUN rm -rf build && meson setup build --buildtype=release && cd ./build && ninja
-RUN rm -rf build && CC=clang CXX=clang++ meson setup build && cd ./build && ninja
+RUN rm -rf build && meson setup build $DPSERVICE_FEATURES --buildtype=release && cd ./build && ninja
+RUN rm -rf build && CC=clang CXX=clang++ meson setup build $DPSERVICE_FEATURES && cd ./build && ninja
 
 FROM debian:11-slim as tester
 


### PR DESCRIPTION
As we now have a tester container and GitHub action, previously used test buildruns (release and clang) can now be only done by the tester image and not the main builder.

I also added a docker build argument `DPSERVICE_FEATURES` which is by default empty, so no change for the `main` branch.

But in TSi this will enable the build system to create an image with `-Denable_virtual_services=true` and thus remove the need of a custom branch, which would be highly appreciated.