### PR TITLE
Add packing for structures used as hash keys

### DIFF
--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -18,7 +18,7 @@ extern "C" {
 struct lb_key {
 	uint32_t	ip;
 	uint32_t	vni;
-};
+} __rte_packed;
 
 struct lb_port {
 	uint8_t			protocol;

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -26,11 +26,10 @@ enum {
 	DP_LB_RECIRC,
 };
 
-// TODO: key packing?
 struct nat_key {
 	uint32_t	ip;
 	uint32_t	vni;
-};
+} __rte_packed;
 
 typedef struct network_nat_entry {
 	union {
@@ -60,7 +59,7 @@ struct netnat_portmap_key {
 	uint32_t	vm_src_ip;
 	uint32_t	vni;
 	uint16_t	vm_src_port;
-};
+} __rte_packed;
 
 struct netnat_portmap_data {
 	uint32_t	nat_ip;
@@ -74,7 +73,7 @@ struct netnat_portoverload_tbl_key {
 	uint32_t dst_ip;
 	uint16_t dst_port;
 	uint8_t	l4_type;
-};
+} __rte_packed;
 
 struct nat_check_result {
 	bool	is_vip_natted;

--- a/include/dp_vni.h
+++ b/include/dp_vni.h
@@ -25,10 +25,9 @@ extern struct rte_hash *vni_handle_tbl;
 // Also, when NUMA is not available, DPDK uses SOCKET_ID_ANY (-1)
 #define DP_SOCKETID(SOCKETID) (unlikely((unsigned int)(SOCKETID) >= DP_NB_SOCKETS) ? 0 : (SOCKETID))
 
-// TODO: packing?
 struct dp_vni_key {
 	int vni;
-};
+} __rte_packed;
 
 struct dp_vni_data {
 	struct rte_rib	*ipv4[DP_NB_SOCKETS];

--- a/src/dp_virtsvc.c
+++ b/src/dp_virtsvc.c
@@ -27,13 +27,11 @@
 	_DP_LOG_UINT("service_port", ntohs((SERVICE)->service_port)), \
 	DP_LOG_PROTO((SERVICE)->proto)
 
-#pragma pack(push, 1)
 // packed, because hashing would include padding otherwise
 struct dp_virtsvc_conn_key {
 	uint16_t vf_port_id;
 	rte_be16_t vf_l4_port;
-};
-#pragma pack(pop)
+} __rte_packed;
 
 static struct dp_virtsvc *dp_virtservices;
 static struct dp_virtsvc *dp_virtservices_end;


### PR DESCRIPTION
The reason recent GitHub tests failed was the fact that hash-table keys were not being packed, thus containing random padding.

The other solution would be to use `memset()` instead of structure intialization, but it is not only never faster, but also longer keys take longer to hash, so I added packing. (Although some architectures - non-x86 - are slower to access unaligned memory).

I tried to find all instances by 
1. Looking at variables passed to `dp_create_jhash_table()`
2. Searching for `struct xxx_key {` definitions

If there is something used as a key and not used as above, I would have missed it.