### PR TITLE
Fix actions scheduling

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -13,7 +13,9 @@ on:
 
 jobs:
   checkpatch:
-    runs-on: self-hosted
+    runs-on:
+      labels: self-hosted
+      group: organization/default
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -19,7 +19,9 @@ on:
 
 jobs:
   buildAndPushTester:
-    runs-on: self-hosted
+    runs-on:
+      labels: self-hosted
+      group: organization/default
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -19,7 +19,9 @@ on:
 
 jobs:
   buildAndPush:
-    runs-on: self-hosted
+    runs-on:
+      labels: self-hosted
+      group: organization/default
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: self-hosted
+    runs-on:
+      labels: self-hosted
+      group: organization/default
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   size-label:
-    runs-on: self-hosted
+    runs-on:
+      labels: self-hosted
+      group: organization/default
     steps:
       - name: size-label
         uses: pascalgn/size-label-action@v0.5.0


### PR DESCRIPTION
All actions not requiring the "special" DPDK runner should be scheduled on the general-purposed `onmetal` runners. Otherwise they can block the DPDK runner, so the test action could stall.

