### PR TITLE
Better dpservice-dump MTU

### DIFF
--- a/src/monitoring/dp_pcap.c
+++ b/src/monitoring/dp_pcap.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include "dp_error.h"
 
-#define DP_PCAP_MTU 1500
+#define DP_PCAP_MTU 9100
 
 int dp_pcap_init(struct dp_pcap *dp_pcap, const char *dump_path)
 {


### PR DESCRIPTION
To make dp_pcap support more types of traffic, I increased it's MTU to 9000. As this does not increase the PCAP output size (it's just a limit) and allocation is done on the stack (with no stack problems detected on my machine).

(prepared as a followup to #411 for easy merge)