### PR TITLE
Use less nonstandard types and definitions

### DIFF
--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -30,10 +30,10 @@ enum dp_vf_port_attach_status {
 struct dp_port {
 	enum dp_port_type				port_type;
 	uint16_t						port_id;
-	char							port_name[IFNAMSIZ];
+	char							port_name[IF_NAMESIZE];
 	uint8_t							link_status;
 	bool							allocated;
-	char							vf_name[IFNAMSIZ];
+	char							vf_name[IF_NAMESIZE];
 	uint8_t							peer_pf_hairpin_tx_rx_queue_offset;
 	uint16_t						peer_pf_port_id;
 	enum dp_vf_port_attach_status	attach_status;

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -37,7 +37,7 @@ extern "C" {
 	(((FLAGS) & (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG)) == (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG))
 
 
-int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IFNAMSIZ]);
+int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IF_NAMESIZE]);
 
 int dp_get_num_of_vfs(void);
 

--- a/include/grpc/dp_grpc_responder.h
+++ b/include/grpc/dp_grpc_responder.h
@@ -14,7 +14,7 @@ struct dp_grpc_responder {
 	struct dpgrpc_request request;
 	// reply consists of an array of 'packets' (called replies)
 	struct rte_mbuf *replies[DP_GRPC_REPLY_ARR_SIZE];
-	uint repcount;
+	unsigned int repcount;
 	struct rte_mempool *mempool;
 	// each of which can optinally be divided into 'messages'
 	struct dpgrpc_reply *rep;

--- a/include/nodes/common_node.h
+++ b/include/nodes/common_node.h
@@ -12,7 +12,7 @@ extern "C" {
 #include "dp_port.h"
 #include "monitoring/dp_graphtrace.h"
 
-#define DP_GRAPH_NO_SPECULATED_NODE -1
+#define DP_GRAPH_NO_SPECULATED_NODE (-1)
 
 static __rte_always_inline
 void dp_foreach_graph_packet(struct rte_graph *graph,
@@ -25,7 +25,6 @@ void dp_foreach_graph_packet(struct rte_graph *graph,
 {
 	struct rte_mbuf *pkt;
 	rte_edge_t next_index, speculated_next_node_index;
-	uint i;
 	void **to_next, **from;
 	uint16_t last_spec = 0;
 	uint16_t held = 0;
@@ -36,7 +35,7 @@ void dp_foreach_graph_packet(struct rte_graph *graph,
 		speculated_next_node_index = (rte_edge_t)speculated_node;
 		from = objs;
 		to_next = rte_node_next_stream_get(graph, node, speculated_next_node_index, nb_objs);
-		for (i = 0; i < nb_objs; ++i) {
+		for (uint16_t i = 0; i < nb_objs; ++i) {
 			pkt = (struct rte_mbuf *)objs[i];
 			rte_prefetch0(objs[i+1]);
 			dp_graphtrace_node(node, pkt);
@@ -66,8 +65,7 @@ void dp_foreach_graph_packet(struct rte_graph *graph,
 		rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
 		rte_node_next_stream_put(graph, node, speculated_next_node_index, held);
 	} else {
-
-		for (i = 0; i < nb_objs; ++i) {
+		for (uint16_t i = 0; i < nb_objs; ++i) {
 			pkt = (struct rte_mbuf *)objs[i];
 			// __builtin_prefetch(&objs[i+1]);
 			dp_graphtrace_node(node, pkt);
@@ -75,7 +73,6 @@ void dp_foreach_graph_packet(struct rte_graph *graph,
 			dp_graphtrace_next(node, pkt, next_index);
 			rte_node_enqueue_x1(graph, node, next_index, pkt);
 		}
-
 	}
 }
 

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -324,7 +324,7 @@ static int dp_port_init_pf(const char *pf_name)
 {
 	uint16_t port_id;
 	struct rte_eth_dev_info dev_info;
-	char ifname[IFNAMSIZ] = {0};
+	char ifname[IF_NAMESIZE] = {0};
 	struct dp_port *port;
 
 	RTE_ETH_FOREACH_DEV(port_id) {
@@ -347,7 +347,7 @@ static int dp_port_init_vfs(const char *vf_pattern, int num_of_vfs)
 {
 	uint16_t port_id;
 	struct rte_eth_dev_info dev_info;
-	char ifname[IFNAMSIZ] = {0};
+	char ifname[IF_NAMESIZE] = {0};
 	int vf_count = 0;
 	struct dp_port *port;
 

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -14,7 +14,7 @@
 // makes sure there is enough space to prevent collisions
 #define DP_JHASH_MARGIN_COEF(ENTRIES) ((ENTRIES)*1.20)
 
-int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IFNAMSIZ])
+int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IF_NAMESIZE])
 {
 	int ret;
 
@@ -64,7 +64,7 @@ static int get_num_of_vfs_pattern(void)
 {
 	int count = 0;
 	uint16_t port_id;
-	char ifname[IFNAMSIZ] = {0};
+	char ifname[IF_NAMESIZE] = {0};
 	struct rte_eth_dev_info dev_info;
 	const char *pattern = dp_conf_get_vf_pattern();
 

--- a/src/nodes/rx_periodic_node.c
+++ b/src/nodes/rx_periodic_node.c
@@ -66,7 +66,7 @@ static uint16_t rx_periodic_node_process(struct rte_graph *graph,
 										 void **objs,
 										 uint16_t nb_objs)
 {
-	uint n_pkts;
+	unsigned int n_pkts;
 
 	RTE_SET_USED(nb_objs);  // this is a source node, input data is not present yet
 

--- a/src/nodes/tx_node.c
+++ b/src/nodes/tx_node.c
@@ -81,12 +81,11 @@ static uint16_t tx_node_process(struct rte_graph *graph,
 	uint16_t new_eth_type;
 	struct rte_mbuf *pkt;
 	struct dp_flow *df;
-	uint i;
 
 	// since this node is emitting packets, dp_forward_* wrapper functions cannot be used
 	// this code should colely resemble the one inside those functions
 
-	for (i = 0; i < nb_objs; ++i) {
+	for (uint16_t i = 0; i < nb_objs; ++i) {
 		pkt = (struct rte_mbuf *)objs[i];
 		df = dp_get_flow_ptr(pkt);
 		// Rewrite ethernet header for all packets except:


### PR DESCRIPTION
I was starting my work on the Ethernet header handling and got annoyed by the IDE complaining it not knowing `uint` and `IFNAMSIZ`, although compilation works fine.

`IFNAMSIZ` requires `__USE_MISC` to be defined which is done by using `_BSD_SOURCE` features

`uint` can also be enabled by `__USE_MISC` (but also by some other headers) and the typedef is marked as "old compatibility name" and we are already using the standard `stdint.h`.

(plus there is a small change to a macro to make it safer by adding parentheses)