### PR TITLE
Added regex-based node filter to dpservice-dump

### DIFF
--- a/docs/deployment/help_dpservice-dump.md
+++ b/docs/deployment/help_dpservice-dump.md
@@ -6,6 +6,7 @@
 | -v, --version | None | display version and exit |  |
 | --drops | None | show dropped packets |  |
 | --nodes | None | show graph node traversal |  |
+| --node-filter | REGEX | show only nodes with name matching REGEX |  |
 | --hw | None | capture offloaded packets (only outgoing VF->PF packets supported) |  |
 | --pcap | FILE | write packets into a PCAP file |  |
 | --stop | None | do nothing, only make sure tracing is disabled in dp-service |  |

--- a/include/monitoring/dp_graphtrace_shared.h
+++ b/include/monitoring/dp_graphtrace_shared.h
@@ -16,6 +16,8 @@
 
 #define DP_MP_ACTION_GRAPHTRACE "dp_mp_graphtrace"
 
+#define DP_GRAPHTRACE_NODE_FILTER_SIZE 64
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,6 +48,7 @@ struct dp_graphtrace_pktinfo {
 struct dp_graphtrace_params_start {
 	bool drops;
 	bool nodes;
+	char node_filter[DP_GRAPHTRACE_NODE_FILTER_SIZE];
 	bool hw;
 };
 

--- a/tools/dump/dp_conf.json
+++ b/tools/dump/dp_conf.json
@@ -18,6 +18,11 @@
       "default": "false"
     },
     {
+      "lgopt": "node-filter",
+      "help": "show only nodes with name matching REGEX",
+      "arg": "REGEX"
+    },
+    {
       "lgopt": "hw",
       "help": "capture offloaded packets (only outgoing VF->PF packets supported)",
       "var": "offload_enabled",

--- a/tools/dump/opts.c
+++ b/tools/dump/opts.c
@@ -17,6 +17,7 @@ enum {
 _OPT_SHOPT_MAX = 255,
 	OPT_DROPS,
 	OPT_NODES,
+	OPT_NODE_FILTER,
 	OPT_HW,
 	OPT_PCAP,
 	OPT_STOP,
@@ -29,6 +30,7 @@ static const struct option dp_conf_longopts[] = {
 	{ "version", 0, 0, OPT_VERSION },
 	{ "drops", 0, 0, OPT_DROPS },
 	{ "nodes", 0, 0, OPT_NODES },
+	{ "node-filter", 1, 0, OPT_NODE_FILTER },
 	{ "hw", 0, 0, OPT_HW },
 	{ "pcap", 1, 0, OPT_PCAP },
 	{ "stop", 0, 0, OPT_STOP },
@@ -64,19 +66,21 @@ bool dp_conf_is_stop_mode(void)
 
 /* These functions need to be implemented by the user of this generated code */
 static void dp_argparse_version(void);
+static int dp_argparse_opt_node_filter(const char *arg);
 static int dp_argparse_opt_pcap(const char *arg);
 
 
 static inline void dp_argparse_help(const char *progname, FILE *outfile)
 {
 	fprintf(outfile, "Usage: %s [options]\n"
-		" -h, --help       display this help and exit\n"
-		" -v, --version    display version and exit\n"
-		"     --drops      show dropped packets\n"
-		"     --nodes      show graph node traversal\n"
-		"     --hw         capture offloaded packets (only outgoing VF->PF packets supported)\n"
-		"     --pcap=FILE  write packets into a PCAP file\n"
-		"     --stop       do nothing, only make sure tracing is disabled in dp-service\n"
+		" -h, --help               display this help and exit\n"
+		" -v, --version            display version and exit\n"
+		"     --drops              show dropped packets\n"
+		"     --nodes              show graph node traversal\n"
+		"     --node-filter=REGEX  show only nodes with name matching REGEX\n"
+		"     --hw                 capture offloaded packets (only outgoing VF->PF packets supported)\n"
+		"     --pcap=FILE          write packets into a PCAP file\n"
+		"     --stop               do nothing, only make sure tracing is disabled in dp-service\n"
 	, progname);
 }
 
@@ -88,6 +92,8 @@ static int dp_conf_parse_arg(int opt, const char *arg)
 		return dp_argparse_store_true(&showing_drops);
 	case OPT_NODES:
 		return dp_argparse_store_true(&showing_nodes);
+	case OPT_NODE_FILTER:
+		return dp_argparse_opt_node_filter(arg);
 	case OPT_HW:
 		return dp_argparse_store_true(&offload_enabled);
 	case OPT_PCAP:


### PR DESCRIPTION
As proposed I added a filter to dpservice-dump to filter only some of the graph nodes. 

Filtering is done in service for performance (the client has trouble pulling the packets fast enough).

I chose to use libc regex to do this to support multiple node matching. It was easier to implement (and possibly more performant) than to send over an array of node names and match them in a loop for every packet.

Although there is a drawback of the library not matching the whole name by default, thus needing to specify `^xxx$` archors in some cases (though in practice it's not really needed to do.

Leaving this as a draft to discuss this implementation choice.