### PR TITLE
Remove packet path from rx_periodic to cls node

### DIFF
--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-enum dp_periodic_type {
-	DP_PER_TYPE_ZERO,
-	DP_PER_TYPE_ND_RA,
-	DP_PER_TYPE_DIRECT_TX,
-} __rte_packed;
-
 struct dp_flow {
 	struct {
 		uint16_t	flow_type : 2;		// local,outgoing,incoming
@@ -70,7 +64,6 @@ struct dp_flow {
 	} tun_info;
 	uint8_t					vnf_type;
 	uint8_t					nxt_hop;
-	enum dp_periodic_type	periodic_type;
 	struct flow_value	*conntrack;
 #ifdef ENABLE_VIRTSVC
 	struct dp_virtsvc	*virtsvc;
@@ -88,8 +81,6 @@ struct dp_pkt_mark {
 
 static_assert(sizeof(struct dp_flow) + sizeof(struct dp_pkt_mark) <= DP_MBUF_PRIV_DATA_SIZE,
 			  "packet private data is too big to fit in packet");
-static_assert(sizeof(((struct dp_flow *)0)->periodic_type) == 1,
-			  "enum dp_periodic_type is unnecessarily big");
 static_assert((1 << (sizeof(((struct dp_flow *)0)->nxt_hop) * 8)) >= DP_MAX_PORTS,
 			  "struct dp_flow::nxt_hop cannot hold all possible port_ids");
 

--- a/include/dp_periodic_msg.h
+++ b/include/dp_periodic_msg.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-void send_to_all_vfs(const struct rte_mbuf *pkt, enum dp_periodic_type per_type, uint16_t eth_type);
+void send_to_all_vfs(const struct rte_mbuf *pkt, uint16_t eth_type);
 void trigger_garp(void);
 void trigger_nd_unsol_adv(void);
 void trigger_nd_ra(void);

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -11,7 +11,7 @@ static uint8_t dp_mc_ipv6[16] = {0xff,0x02,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01};
 static uint8_t dp_mc_mac[6] = {0x33,0x33,0x00,0x00,0x00,0x01};
 
 
-void send_to_all_vfs(const struct rte_mbuf *pkt, enum dp_periodic_type per_type, uint16_t eth_type)
+void send_to_all_vfs(const struct rte_mbuf *pkt, uint16_t eth_type)
 {
 	struct dp_flow *df;
 	struct rte_ether_hdr *eth_hdr;
@@ -47,7 +47,6 @@ void send_to_all_vfs(const struct rte_mbuf *pkt, enum dp_periodic_type per_type,
 
 		dp_init_pkt_mark(clone_buf);
 		df = dp_init_flow_ptr(clone_buf);
-		df->periodic_type = per_type;
 		df->l3_type = eth_type;
 				
 		ret = rte_ring_sp_enqueue(dp_layer->periodic_msg_queue, clone_buf);
@@ -88,7 +87,7 @@ void trigger_garp(void)
 	pkt->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
 	pkt->pkt_len = pkt->data_len;
 
-	send_to_all_vfs(pkt, DP_PER_TYPE_DIRECT_TX, RTE_ETHER_TYPE_ARP);
+	send_to_all_vfs(pkt, RTE_ETHER_TYPE_ARP);
 	rte_pktmbuf_free(pkt);
 }
 
@@ -141,7 +140,7 @@ void trigger_nd_unsol_adv(void)
 	icmp6_hdr->icmp6_cksum = 0;
 	icmp6_hdr->icmp6_cksum = rte_ipv6_udptcp_cksum(ipv6_hdr, icmp6_hdr);
 
-	send_to_all_vfs(pkt, DP_PER_TYPE_DIRECT_TX,RTE_ETHER_TYPE_IPV6);
+	send_to_all_vfs(pkt, RTE_ETHER_TYPE_IPV6);
 	rte_pktmbuf_free(pkt);
 }
 
@@ -195,6 +194,6 @@ void trigger_nd_ra(void)
 	icmp6_hdr->icmp6_cksum = 0;
 	icmp6_hdr->icmp6_cksum = rte_ipv6_udptcp_cksum(ipv6_hdr, icmp6_hdr);
 
-	send_to_all_vfs(pkt, DP_PER_TYPE_DIRECT_TX, RTE_ETHER_TYPE_IPV6);
+	send_to_all_vfs(pkt, RTE_ETHER_TYPE_IPV6);
 	rte_pktmbuf_free(pkt);
 }

--- a/src/nodes/rx_periodic_node.c
+++ b/src/nodes/rx_periodic_node.c
@@ -10,9 +10,7 @@
 #include "monitoring/dp_monitoring.h"
 #include "nodes/common_node.h"
 
-#define NEXT_NODES(NEXT) \
-	NEXT(RX_PERIODIC_NEXT_CLS, "cls")
-DP_NODE_REGISTER_SOURCE(RX_PERIODIC, rx_periodic, NEXT_NODES);
+DP_NODE_REGISTER_SOURCE(RX_PERIODIC, rx_periodic, DP_NODE_DEFAULT_NEXT_ONLY);
 
 static uint16_t next_tx_index[DP_MAX_PORTS];
 
@@ -53,12 +51,7 @@ static __rte_always_inline void handle_nongraph_queues(void)
 
 static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_node *node, struct rte_mbuf *m)
 {
-	struct dp_flow *df = dp_get_flow_ptr(m);
-
-	if (df->periodic_type == DP_PER_TYPE_DIRECT_TX)
-		return next_tx_index[m->port];
-
-	return RX_PERIODIC_NEXT_CLS;
+	return next_tx_index[m->port];
 }
 
 static uint16_t rx_periodic_node_process(struct rte_graph *graph,


### PR DESCRIPTION
When re-doing the graph documentation I found a connection between `rx_periodic` and `cls` nodes which upon discussing it seems to not be wanted anymore.

I removed it along with the periodic type that was used to send packets to `cls` previously.