### PR TITLE
Various grpc capture status fixes

### DIFF
--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -950,39 +950,47 @@ static int dp_process_capture_stop(struct dp_grpc_responder *responder)
 	return DP_GRPC_OK;
 }
 
-static int dp_process_capture_get_status(struct dp_grpc_responder *responder)
+static int dp_process_capture_status(struct dp_grpc_responder *responder)
 {
 	struct dpgrpc_capture *reply = dp_grpc_single_reply(responder);
 	struct dp_ports *ports = get_dp_ports();
 	const struct dp_capture_hdr_config *capture_hdr_config = dp_get_capture_hdr_config();
 	int count = 0;
 
-	reply->is_active = dp_is_capture_enabled();
-
-	if (reply->is_active) {
-		DP_FOREACH_PORT(ports, port) {
-			if (port->allocated && port->captured) {
-				if (port->port_type == DP_PORT_PF) {
-					reply->interfaces[count].type = DP_CAPTURE_IFACE_TYPE_SINGLE_PF;
-					reply->interfaces[count].spec.pf_index = port->port_id == dp_port_get_pf0_id() ? 0 : 1;
-				} else {
-					reply->interfaces[count].type = DP_CAPTURE_IFACE_TYPE_SINGLE_VF;
-					memcpy(reply->interfaces[count].spec.iface_id, dp_get_vm_machineid(port->port_id), sizeof(port->port_name));
-				}
-				count++;
-			}
-			// it shouldnot never happen, but just in case
-			if (count >= DP_CAPTURE_MAX_PORT_NUM) {
-				DPS_LOG_ERR("Unexpected too many interfaces are captured");
-				return DP_GRPC_ERR_LIMIT_REACHED;
-			}
-		}
+	if (!dp_is_capture_enabled()) {
+		memset(reply, 0, sizeof(*reply));
+		// this includes setting reply->is_active to false
+		return DP_GRPC_OK;
 	}
 
-	memcpy(reply->dst_addr6, capture_hdr_config->capture_node_ipv6_addr, sizeof(reply->dst_addr6));
+	DP_FOREACH_PORT(ports, port) {
+		if (!port->allocated || !port->captured)
+			continue;
+
+		// this should never happen, but just in case
+		if (count >= DP_CAPTURE_MAX_PORT_NUM) {
+			DPS_LOG_ERR("Unexpected number of interfaces are being captured",
+						DP_LOG_VALUE(count), DP_LOG_MAX(DP_CAPTURE_MAX_PORT_NUM));
+			return DP_GRPC_ERR_LIMIT_REACHED;
+		}
+
+		if (port->port_type == DP_PORT_PF) {
+			reply->interfaces[count].type = DP_CAPTURE_IFACE_TYPE_SINGLE_PF;
+			reply->interfaces[count].spec.pf_index = port->port_id == dp_port_get_pf0_id() ? 0 : 1;
+		} else {
+			reply->interfaces[count].type = DP_CAPTURE_IFACE_TYPE_SINGLE_VF;
+			static_assert(sizeof(reply->interfaces[count].spec.iface_id) == VM_IFACE_ID_MAX_LEN,
+						  "Invalid size for captured interface id");
+			rte_memcpy(reply->interfaces[count].spec.iface_id, dp_get_vm_machineid(port->port_id), VM_IFACE_ID_MAX_LEN);
+		}
+		count++;
+	}
+
+	rte_memcpy(reply->dst_addr6, capture_hdr_config->capture_node_ipv6_addr, sizeof(reply->dst_addr6));
 	reply->udp_src_port = capture_hdr_config->capture_udp_src_port;
 	reply->udp_dst_port = capture_hdr_config->capture_udp_dst_port;
 	reply->interface_count = count;
+	reply->is_active = true;
 
 	return DP_GRPC_OK;
 }
@@ -1115,7 +1123,7 @@ void dp_process_request(struct rte_mbuf *m)
 		ret = dp_process_capture_stop(&responder);
 		break;
 	case DP_REQ_TYPE_CaptureStatus:
-		ret = dp_process_capture_get_status(&responder);
+		ret = dp_process_capture_status(&responder);
 		break;
 	// DP_REQ_TYPE_CheckInitialized is handled by the gRPC thread
 	default:


### PR DESCRIPTION
There were a few overlooked problems with the new CaptureStatus code. 
 - If capturing is not active, the UDP address is undefined, so it returns zeroes now.
 - The DP_CAPTURE_MAX_PORT_NUM would complain one entry too early
 - The size of the interface id (name) is not `sizeof(port->port_name)` (there is a better assert in an upcoming PR)

The `dp_async_grpc.cpp` is just me wanting to have everything neat, since the file is grouped by k8s objects and ordered in the way `dp_grpc_api.h` defines the enum, so I reordered the code.