### PR TITLE
Fixed dp_port refactor for offloading in-network

### DIFF
--- a/src/nodes/virtsvc_node.c
+++ b/src/nodes/virtsvc_node.c
@@ -232,7 +232,7 @@ static __rte_always_inline uint16_t virtsvc_reply_next(struct rte_node *node,
 	vf_port_id = conn->vf_port_id;
 
 	vf_port = dp_get_port_by_id(vf_port_id);
-	if (!vf_port || !vf_port->attached)
+	if (!vf_port)
 		return VIRTSVC_NEXT_DROP;
 
 	dp_fill_ether_hdr(ether_hdr, vf_port, RTE_ETHER_TYPE_IPV4);


### PR DESCRIPTION
Fixes #428 

I have misunderstood the original code, so I now also kept the original comment, which makes sense to me now.

I am unable to test this for offloading, as that requires two ports and that is something the test suite is unable to do at this time (I guess that is the next thing to do by me).

I did try to make a test using 2 PCs and 2 dpservices, but was unable to do it for LB with PF1.