### PR TITLE
Remove port's attached flag

### DIFF
--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -53,7 +53,6 @@ struct dp_port {
 	char					dev_name[RTE_ETH_NAME_MAX_LEN];
 	uint8_t					peer_pf_hairpin_tx_rx_queue_offset;
 	uint16_t				peer_pf_port_id;
-	bool					attached;
 	struct vm_entry			vm;
 	struct rte_flow			*default_jump_flow;
 	struct rte_flow			*default_capture_flow;
@@ -73,8 +72,6 @@ extern struct dp_ports _dp_ports;
 
 
 struct dp_port *dp_get_port_by_name(const char *pci_name);
-
-int dp_attach_vf(struct dp_port *port);
 
 int dp_ports_init(void);
 void dp_ports_free(void);

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -71,17 +71,6 @@ struct dp_port *dp_get_port_by_name(const char *pci_name)
 	return _dp_port_table[port_id];
 }
 
-int dp_attach_vf(struct dp_port *port)
-{
-	if (port->port_type != DP_PORT_VF) {
-		DPS_LOG_ERR("VF port not registered in dpservice", DP_LOG_PORT(port));
-		return DP_ERROR;
-	}
-
-	port->attached = true;
-	return DP_OK;
-}
-
 static int dp_port_init_ethdev(struct dp_port *port, struct rte_eth_dev_info *dev_info, enum dp_port_type port_type)
 {
 	struct dp_dpdk_layer *dp_layer = get_dpdk_layer();

--- a/src/nodes/arp_node.c
+++ b/src/nodes/arp_node.c
@@ -62,15 +62,10 @@ static __rte_always_inline bool arp_handled(struct rte_mbuf *m)
 	return true;
 }
 
-static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, struct rte_mbuf *m)
+static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_node *node, struct rte_mbuf *m)
 {
 	if (!arp_handled(m))
 		return ARP_NEXT_DROP;
-
-	if (DP_FAILED(dp_attach_vf(dp_get_port(m)))) {
-		DPNODE_LOG_ERR(node, "Cannot attach port", DP_LOG_PORTID(m->port));
-		return ARP_NEXT_DROP;
-	}
 
 	return next_tx_index[m->port];
 }

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -276,11 +276,6 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 				 + header_size;
 	m->data_len = m->pkt_len;
 
-	if (DP_FAILED(dp_attach_vf(port))) {
-		DPNODE_LOG_ERR(node, "Cannot attach port", DP_LOG_PORT(port));
-		return DHCP_NEXT_DROP;
-	}
-
 	return next_tx_index[m->port];
 }
 

--- a/src/nodes/ipv4_lookup_node.c
+++ b/src/nodes/ipv4_lookup_node.c
@@ -50,11 +50,6 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (!df->flags.flow_type)
 		df->flags.flow_type = DP_FLOW_TYPE_LOCAL;
 
-	if (df->flags.flow_type == DP_FLOW_TYPE_LOCAL || df->flags.flow_type == DP_FLOW_TYPE_INCOMING) {
-		if (dst_port->port_type == DP_PORT_VF && !dst_port->attached)
-			return IPV4_LOOKUP_NEXT_DROP;
-	}
-
 	if (df->flags.flow_type == DP_FLOW_TYPE_OUTGOING)
 		dst_port = dp_multipath_get_pf(df->dp_flow_hash);
 


### PR DESCRIPTION
tests in the lab environment show that, pinging starting from another hypervisor to a newly created VM, which is yet not started, can start receiving replies after VM is actually booted up.  It may be due to upgrading of DPDK. 