### PR TITLE
Make VNI always use uint32_t

### DIFF
--- a/include/dp_iface.h
+++ b/include/dp_iface.h
@@ -14,7 +14,7 @@ int dp_map_iface_id(const char iface_id[DP_IFACE_ID_MAX_LEN], struct dp_port *po
 void dp_unmap_iface_id(const char iface_id[DP_IFACE_ID_MAX_LEN]);
 struct dp_port *dp_get_port_with_iface_id(const char iface_id[DP_IFACE_ID_MAX_LEN]);
 
-int dp_setup_iface(struct dp_port *port, int vni);
+int dp_setup_iface(struct dp_port *port, uint32_t vni);
 void dp_delete_iface(struct dp_port *port);
 
 

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -38,18 +38,18 @@ extern "C" {
 #define DP_LIST_INT_ROUTES false
 
 struct dp_iface_route {
-	int		vni;
-	uint8_t	nh_ipv6[16];
+	uint32_t vni;
+	uint8_t  nh_ipv6[16];
 };
 
 const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
-										  int t_vni,
+										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
 										  uint32_t *route_key);
 
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
-										  int t_vni,
+										  uint32_t t_vni,
 										  const struct rte_ipv6_hdr *ipv6_hdr,
 										  struct dp_iface_route *route);
 
@@ -62,10 +62,10 @@ int dp_del_route(const struct dp_port *port, uint32_t vni, uint32_t ip, uint8_t 
 int dp_add_route6(const struct dp_port *port, uint32_t vni, uint32_t t_vni, const uint8_t *ipv6,
 				  const uint8_t *ext_ip6, uint8_t depth);
 int dp_del_route6(const struct dp_port *port, uint32_t vni, const uint8_t *ipv6, uint8_t depth);
-int dp_list_routes(const struct dp_port *port, int vni, bool ext_routes, struct dp_grpc_responder *responder);
+int dp_list_routes(const struct dp_port *port, uint32_t vni, bool ext_routes, struct dp_grpc_responder *responder);
 
 int dp_lpm_reset_all_route_tables(void);
-int dp_lpm_reset_route_tables(int vni);
+int dp_lpm_reset_route_tables(uint32_t vni);
 
 #ifdef __cplusplus
 }

--- a/include/dp_vni.h
+++ b/include/dp_vni.h
@@ -26,7 +26,7 @@ extern struct rte_hash *vni_handle_tbl;
 #define DP_SOCKETID(SOCKETID) (unlikely((unsigned int)(SOCKETID) >= DP_NB_SOCKETS) ? 0 : (SOCKETID))
 
 struct dp_vni_key {
-	int vni;
+	uint32_t vni;
 } __rte_packed;
 
 struct dp_vni_data {
@@ -34,11 +34,11 @@ struct dp_vni_data {
 	struct rte_rib6	*ipv6[DP_NB_SOCKETS];
 	struct dp_ref	ref_count;
 	int				socket_id;
-	int				vni;
+	uint32_t		vni;
 };
 
 static __rte_always_inline
-struct rte_rib *dp_get_vni_route4_table(int vni)
+struct rte_rib *dp_get_vni_route4_table(uint32_t vni)
 {
 	struct dp_vni_data *vni_data;
 	struct dp_vni_key vni_key = {
@@ -57,7 +57,7 @@ struct rte_rib *dp_get_vni_route4_table(int vni)
 }
 
 static __rte_always_inline
-struct rte_rib6 *dp_get_vni_route6_table(int vni)
+struct rte_rib6 *dp_get_vni_route6_table(uint32_t vni)
 {
 	struct dp_vni_data *vni_data;
 	struct dp_vni_key vni_key = {
@@ -77,10 +77,10 @@ struct rte_rib6 *dp_get_vni_route6_table(int vni)
 
 int dp_vni_init(int socket_id);
 void dp_vni_free(void);
-bool dp_is_vni_route_table_available(int vni, int type);
-int dp_create_vni_route_tables(int vni, int socket_id);
-int dp_delete_vni_route_tables(int vni);
-int dp_reset_vni_route_tables(int vni);
+bool dp_is_vni_route_table_available(uint32_t vni, int type);
+int dp_create_vni_route_tables(uint32_t vni, int socket_id);
+int dp_delete_vni_route_tables(uint32_t vni);
+int dp_reset_vni_route_tables(uint32_t vni);
 int dp_reset_all_vni_route_tables(void);
 
 #ifdef __cplusplus

--- a/src/dp_iface.c
+++ b/src/dp_iface.c
@@ -65,7 +65,7 @@ struct dp_port *dp_get_port_with_iface_id(const char iface_id[DP_IFACE_ID_MAX_LE
 }
 
 
-int dp_setup_iface(struct dp_port *port, int vni)
+int dp_setup_iface(struct dp_port *port, uint32_t vni)
 {
 	if (DP_FAILED(dp_create_vni_route_tables(vni, port->socket_id)))
 		return DP_ERROR;

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -47,7 +47,7 @@ int dp_lpm_reset_all_route_tables(void)
 	return DP_GRPC_OK;
 }
 
-int dp_lpm_reset_route_tables(int vni)
+int dp_lpm_reset_route_tables(uint32_t vni)
 {
 	const struct dp_ports *ports = dp_get_ports();
 	int ret;
@@ -58,8 +58,7 @@ int dp_lpm_reset_route_tables(int vni)
 	}
 
 	DP_FOREACH_PORT(ports, port) {
-		// TODO(plague?): the cast does not seem nice, define a type for VNIs?
-		if (!port->iface.ready || (int)port->iface.vni != vni)
+		if (!port->iface.ready || port->iface.vni != vni)
 			continue;
 		ret = dp_lpm_fill_route_tables(port);
 		if (DP_FAILED(ret))
@@ -188,7 +187,7 @@ static int dp_list_route_entry(struct rte_rib_node *node,
 	return DP_GRPC_OK;
 }
 
-int dp_list_routes(const struct dp_port *port, int vni, bool ext_routes,
+int dp_list_routes(const struct dp_port *port, uint32_t vni, bool ext_routes,
 				   struct dp_grpc_responder *responder)
 {
 	struct rte_rib_node *node = NULL;
@@ -273,7 +272,7 @@ int dp_del_route6(const struct dp_port *port, uint32_t vni, const uint8_t *ipv6,
 }
 
 const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
-										  int t_vni,
+										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
 										  uint32_t *route_key)
@@ -312,7 +311,7 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 }
 
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
-										  int t_vni,
+										  uint32_t t_vni,
 										  const struct rte_ipv6_hdr *ipv6_hdr,
 										  struct dp_iface_route *route)
 {

--- a/src/dp_vni.c
+++ b/src/dp_vni.c
@@ -20,7 +20,7 @@ void dp_vni_free(void)
 	dp_free_jhash_table(vni_handle_tbl);
 }
 
-bool dp_is_vni_route_table_available(int vni, int type)
+bool dp_is_vni_route_table_available(uint32_t vni, int type)
 {
 	struct dp_vni_data *vni_data;
 	struct dp_vni_key vni_key = {
@@ -143,7 +143,7 @@ err_alloc:
 	return DP_ERROR;
 }
 
-int dp_create_vni_route_tables(int vni, int socket_id)
+int dp_create_vni_route_tables(uint32_t vni, int socket_id)
 {
 	struct dp_vni_data *vni_data;
 	struct dp_vni_key vni_key = {
@@ -165,7 +165,7 @@ int dp_create_vni_route_tables(int vni, int socket_id)
 
 }
 
-int dp_delete_vni_route_tables(int vni)
+int dp_delete_vni_route_tables(uint32_t vni)
 {
 	struct dp_vni_data *vni_data;
 	struct dp_vni_key vni_key = {
@@ -190,7 +190,7 @@ int dp_delete_vni_route_tables(int vni)
 	return DP_OK;
 }
 
-static int dp_reset_vni_data(int vni, struct dp_vni_data *vni_data)
+static int dp_reset_vni_data(uint32_t vni, struct dp_vni_data *vni_data)
 {
 	int socket_id = DP_SOCKETID(vni_data->socket_id);
 
@@ -209,7 +209,7 @@ static int dp_reset_vni_data(int vni, struct dp_vni_data *vni_data)
 	return DP_OK;
 }
 
-int dp_reset_vni_route_tables(int vni)
+int dp_reset_vni_route_tables(uint32_t vni)
 {
 	struct dp_vni_data *vni_data;
 	struct dp_vni_key vni_key = {

--- a/tools/dp_grpc_client.cpp
+++ b/tools/dp_grpc_client.cpp
@@ -113,7 +113,7 @@ static char get_nat_info_type_str[10]={0};
 
 static int command;
 static int debug_mode;
-static int vni;
+static uint32_t vni;
 static int t_vni;
 static int length, src_length, dst_length;
 static bool pfx_lb_enabled = false;


### PR DESCRIPTION
There were some instances where VNI was using `int`, so I unified the type to `uint32` (hopefully) everywhere.