### PR TITLE
Add GCC conversion warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY hack/*.patch hack/
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_22_11_gcc12.patch
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_22_11_log.patch
 RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_22_11_telemetry_key.patch
+RUN cd $DPDK_DIR && patch -p1 < ../hack/dpdk_22_11_ethdev_conversion.patch
 
 # Compile DPDK
 RUN cd $DPDK_DIR && meson setup -Dmax_ethports=132 -Dplatform=generic -Ddisable_drivers=common/dpaax,\

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -35,6 +35,7 @@ cd dpdk-stable-22.11.3
 patch -p1 < ../net-dpservice/hack/dpdk_22_11_gcc12.patch
 patch -p1 < ../net-dpservice/hack/dpdk_22_11_log.patch
 patch -p1 < ../net-dpservice/hack/dpdk_22_11_telemetry_key.patch
+patch -p1 < ../net-dpservice/hack/dpdk_22_11_ethdev_conversion.patch
 meson setup build
 ninja -C build
 sudo ninja -C build install

--- a/hack/dpdk_22_11_ethdev_conversion.patch
+++ b/hack/dpdk_22_11_ethdev_conversion.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/ethdev/rte_ethdev.c b/lib/ethdev/rte_ethdev.c
+index 5d5e18db1e..d8908b722a 100644
+--- a/lib/ethdev/rte_ethdev.c
++++ b/lib/ethdev/rte_ethdev.c
+@@ -387,7 +387,7 @@ eth_is_valid_owner_id(uint64_t owner_id)
+ 	return 1;
+ }
+ 
+-uint64_t
++uint16_t
+ rte_eth_find_next_owned_by(uint16_t port_id, const uint64_t owner_id)
+ {
+ 	port_id = rte_eth_find_next(port_id);
+diff --git a/lib/ethdev/rte_ethdev.h b/lib/ethdev/rte_ethdev.h
+index c129ca1eaf..a92fe1259e 100644
+--- a/lib/ethdev/rte_ethdev.h
++++ b/lib/ethdev/rte_ethdev.h
+@@ -2059,7 +2059,7 @@ struct rte_eth_dev_owner {
+  * @return
+  *   Next valid port ID owned by owner_id, RTE_MAX_ETHPORTS if there is none.
+  */
+-uint64_t rte_eth_find_next_owned_by(uint16_t port_id,
++uint16_t rte_eth_find_next_owned_by(uint16_t port_id,
+ 		const uint64_t owner_id);
+ 
+ /**

--- a/include/dp_conf.h
+++ b/include/dp_conf.h
@@ -25,7 +25,7 @@ struct dp_conf_virtual_services {
 #endif
 
 struct dp_conf_dhcp_dns {
-	int len;
+	uint8_t len;
 	uint8_t *array;
 };
 

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -127,7 +127,7 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 void dp_invert_flow_key(const struct flow_key *key /* in */, struct flow_key *inv_key /* out */);
 int dp_flow_init(int socket_id);
 void dp_flow_free(void);
-void dp_process_aged_flows(int port_id);
+void dp_process_aged_flows(uint16_t port_id);
 void dp_process_aged_flows_non_offload(void);
 void dp_free_flow(struct dp_ref *ref);
 void dp_free_network_nat_port(const struct flow_value *cntrack);

--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -63,8 +63,6 @@ struct dp_flow {
 	rte_be32_t	nat_addr;
 	uint16_t	nat_port;
 
-	uint8_t		nxt_hop;
-
 	uint8_t					l4_type;
 	union {
 		struct {
@@ -87,6 +85,8 @@ struct dp_flow {
 		uint8_t		proto_id;	//proto_id in outer ipv6 header
 		uint32_t	dst_vni;
 	} tun_info;
+
+	uint16_t		nxt_hop;  // this can be brought down to only one byte (low DP_MAX_PORTS)
 
 	struct flow_value	*conntrack;
 #ifdef ENABLE_VIRTSVC

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -28,7 +28,7 @@ enum dp_vnf_type {
 
 struct dp_vnf_prefix {
 	uint32_t	ip;
-	uint16_t	length;
+	uint8_t		length;
 };
 
 struct dp_vnf {
@@ -42,13 +42,13 @@ int dp_vnf_init(int socket_id);
 void dp_vnf_free(void);
 
 int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type type,
-			   uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint16_t prefix_len);
+			   uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len);
 const struct dp_vnf *dp_get_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 
-bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint16_t prefix_len);
+bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len);
 
-int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint16_t prefix_len);
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len);
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder);
 

--- a/include/grpc/dp_grpc_api.h
+++ b/include/grpc/dp_grpc_api.h
@@ -99,13 +99,13 @@ struct dpgrpc_address {
 
 struct dpgrpc_prefix {
 	struct dpgrpc_address	addr;
-	uint32_t				length;
+	uint8_t					length;
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
 };
 
 struct dpgrpc_route {
 	struct dpgrpc_address	pfx_addr;
-	uint32_t				pfx_length;
+	uint8_t					pfx_length;
 	uint32_t				vni;
 	struct dpgrpc_address	trgt_addr;
 	uint32_t				trgt_vni;
@@ -181,8 +181,8 @@ struct dpgrpc_capture_interface {
 struct dpgrpc_capture {
 	uint8_t			dst_addr6[DP_VNF_IPV6_ADDR_SIZE];
 	uint8_t			interface_count;
-	uint32_t		udp_src_port;
-	uint32_t		udp_dst_port;
+	uint16_t		udp_src_port;
+	uint16_t		udp_dst_port;
 	struct dpgrpc_capture_interface interfaces[DP_CAPTURE_MAX_PORT_NUM];
 	bool			is_active;
 };
@@ -192,7 +192,7 @@ struct dpgrpc_capture_stop {
 };
 
 struct dpgrpc_request {
-	uint16_t 					type;  // enum dpgrpc_request_type
+	enum dpgrpc_request_type	type;
 	union {
 		struct dpgrpc_iface		add_iface;
 		struct dpgrpc_iface_id	del_iface;
@@ -251,12 +251,12 @@ struct dpgrpc_vni_in_use {
 };
 
 struct dpgrpc_reply {
-	uint8_t		type;  // copied enum dpgrpc_request_type
-	uint8_t		is_chained;
-	uint16_t	msg_count;
-	uint32_t	err_code;
+	enum dpgrpc_request_type		type;			// copied enum dpgrpc_request_type
+	bool							is_chained;
+	uint16_t						msg_count;
+	uint32_t						err_code;
 	union {
-		uint8_t						messages[0];  // used for multiresponse mode
+		uint8_t						messages[0];	// used for multiresponse mode
 		struct dpgrpc_ul_addr		ul_addr;
 		struct dpgrpc_iface			iface;
 		struct dpgrpc_vf_pci		vf_pci;

--- a/include/grpc/dp_grpc_responder.h
+++ b/include/grpc/dp_grpc_responder.h
@@ -20,12 +20,11 @@ struct dp_grpc_responder {
 	struct dpgrpc_reply *rep;
 	size_t rep_max_size;
 	size_t msg_size;
-	int rep_capacity;
-	int rep_msgcount;
+	size_t rep_capacity;
+	uint16_t rep_msgcount;
 };
 
-// returns request's type
-uint16_t dp_grpc_init_responder(struct dp_grpc_responder *responder, struct rte_mbuf *req_mbuf);
+enum dpgrpc_request_type dp_grpc_init_responder(struct dp_grpc_responder *responder, struct rte_mbuf *req_mbuf);
 
 static inline void *dp_grpc_single_reply(struct dp_grpc_responder *responder)
 {

--- a/include/monitoring/dp_monitoring.h
+++ b/include/monitoring/dp_monitoring.h
@@ -33,14 +33,14 @@ struct dp_event_msg {
 
 struct dp_capture_hdr_config {
 	uint8_t capture_node_ipv6_addr[16];
-	uint32_t capture_udp_src_port;
-	uint32_t capture_udp_dst_port;
+	uint16_t capture_udp_src_port;
+	uint16_t capture_udp_dst_port;
 };
 
 void dp_process_event_msg(struct rte_mbuf *m);
 
 
-void dp_set_capture_hdr_config(uint8_t *addr, uint32_t udp_src_port, uint32_t udp_dst_port);
+void dp_set_capture_hdr_config(uint8_t *addr, uint16_t udp_src_port, uint16_t udp_dst_port);
 const struct dp_capture_hdr_config *dp_get_capture_hdr_config(void);
 
 void dp_set_capture_enabled(bool enabled);

--- a/include/rte_flow/dp_rte_flow_helpers.h
+++ b/include/rte_flow/dp_rte_flow_helpers.h
@@ -17,6 +17,8 @@ extern "C"
 #define DP_TCP_CONTROL_FLAGS \
 	(RTE_TCP_FIN_FLAG|RTE_TCP_SYN_FLAG|RTE_TCP_RST_FLAG)
 
+#define DP_AGE_TIMEOUT_24BIT_MASK 0x00FFFFFF
+
 union dp_flow_item_l3 {
 	struct rte_flow_item_ipv4 ipv4;
 	struct rte_flow_item_ipv6 ipv6;
@@ -509,7 +511,9 @@ void dp_set_flow_age_action(struct rte_flow_action *action,
 							struct rte_flow_action_age *flow_age_action,
 							uint32_t timeout, void *age_context)
 {
-	flow_age_action->timeout = timeout;
+	// timeout has only 24 bits
+	// should always fit, the value is just a #define'd constant (unless in testing mode)
+	flow_age_action->timeout = timeout & DP_AGE_TIMEOUT_24BIT_MASK;
 	flow_age_action->reserved = 0;
 	flow_age_action->context = age_context;
 	action->type = RTE_FLOW_ACTION_TYPE_AGE;

--- a/include/rte_flow/dp_rte_flow_init.h
+++ b/include/rte_flow/dp_rte_flow_init.h
@@ -10,10 +10,10 @@ extern "C" {
 #include <rte_flow.h>
 #include "dp_port.h"
 
-int dp_install_isolated_mode_ipip(int port_id, uint8_t proto_id);
+int dp_install_isolated_mode_ipip(uint16_t port_id, uint8_t proto_id);
 
 #ifdef ENABLE_VIRTSVC
-int dp_install_isolated_mode_virtsvc(int port_id, uint8_t proto_id, const uint8_t svc_ipv6[16], uint16_t svc_port);
+int dp_install_isolated_mode_virtsvc(uint16_t port_id, uint8_t proto_id, const uint8_t svc_ipv6[16], uint16_t svc_port);
 #endif
 
 #ifdef __cplusplus

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,8 @@ if get_option('warning_level').to_int() >= 2
   common_flags = [
     # -Werror provided by 'werror=true' in default project options
     # -Wall -Wextra provided by 'warning_level=2' in default project options
-     '-Wunused', '-Wshadow', '-Wundef', '-Wcast-qual', '-Wwrite-strings', '-Wpointer-arith',
+    '-Wunused', '-Wshadow', '-Wundef', '-Wcast-qual', '-Wwrite-strings', '-Wpointer-arith',
+    '-Wconversion', '-Wno-sign-conversion'
   ]
   cflags += common_flags + [
     '-Wbad-function-cast', '-Wmissing-declarations', '-Wstrict-prototypes', '-Wmissing-prototypes',

--- a/src/dp_argparse.c
+++ b/src/dp_argparse.c
@@ -42,7 +42,7 @@ int dp_argparse_enum(const char *arg, int *dst, const char *choices[], size_t ch
 {
 	for (size_t i = 0; i < choice_count; ++i) {
 		if (!strcmp(choices[i], arg)) {
-			*dst = i;
+			*dst = (int)i;
 			return DP_OK;
 		}
 	}

--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -136,7 +136,7 @@ static int add_virtsvc(uint8_t proto, const char *str)
 		DP_EARLY_ERR("Invalid virtual service IPv4 port '%s'", tok);
 		return DP_ERROR;
 	}
-	from_port = htons(longport);
+	from_port = htons((uint16_t)longport);
 
 	tok = strtok(NULL, ",");
 	if (!tok) {
@@ -158,7 +158,7 @@ static int add_virtsvc(uint8_t proto, const char *str)
 		DP_EARLY_ERR("Invalid virtual service IPv6 port '%s'", tok);
 		return DP_ERROR;
 	}
-	to_port = htons(longport);
+	to_port = htons((uint16_t)longport);
 
 	// prevent virtual/service address duplicates
 	for (int i = 0; i < virtual_services.nb_entries; ++i) {

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -305,7 +305,7 @@ int dp_destroy_rte_flow_agectx(struct flow_age_ctx *agectx)
 	return DP_OK;
 }
 
-void dp_process_aged_flows(int port_id)
+void dp_process_aged_flows(uint16_t port_id)
 {
 	int total, fetched;
 	struct flow_age_ctx *agectx;
@@ -485,10 +485,11 @@ hash_sig_t dp_get_conntrack_flow_hash_value(const struct flow_key *key)
 
 int dp_add_rte_age_ctx(struct flow_value *cntrack, struct flow_age_ctx *ctx)
 {
-	for (size_t i = 0; i < sizeof(cntrack->rte_age_ctxs); ++i) {
+	static_assert(RTE_DIM(cntrack->rte_age_ctxs) <= UINT8_MAX, "Conntrack age context storage is too large");
+	for (size_t i = 0; i < RTE_DIM(cntrack->rte_age_ctxs); ++i) {
 		if (!cntrack->rte_age_ctxs[i]) {
 			cntrack->rte_age_ctxs[i] = ctx;
-			ctx->ref_index_in_cntrack = i;
+			ctx->ref_index_in_cntrack = (uint8_t)i;
 			return DP_OK;
 		}
 	}

--- a/src/dp_hairpin.c
+++ b/src/dp_hairpin.c
@@ -8,8 +8,8 @@
 
 static int setup_hairpin_rx_tx_queues(uint16_t port_id,
 									  uint16_t peer_port_id,
-									  uint8_t hairpin_queue_id,
-									  uint8_t peer_hairpin_queue_id)
+									  uint16_t hairpin_queue_id,
+									  uint16_t peer_hairpin_queue_id)
 {
 	int ret;
 

--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -246,7 +246,7 @@ uint8_t *dp_lb_get_backend_ip(uint32_t ol_ip, uint32_t vni, rte_be16_t port, uin
 	if (pos < 0)
 		return NULL;
 
-	lb_val->last_sel_pos = pos;
+	lb_val->last_sel_pos = (uint16_t)pos;
 	return (uint8_t *)&lb_val->back_end_ips[pos][0];
 }
 

--- a/src/dp_log.c
+++ b/src/dp_log.c
@@ -182,8 +182,8 @@ static const char *json_escape(const char *message, char *buf, size_t bufsize)
 			buf[bufpos++] = 'u';
 			buf[bufpos++] = '0';
 			buf[bufpos++] = '0';
-			buf[bufpos++] = '0' + hi;
-			buf[bufpos++] = lo >= 10 ? 'a' + (lo-10) : '0' + lo;
+			buf[bufpos++] = (char)('0' + hi);
+			buf[bufpos++] = (char)(lo >= 10 ? 'a' + (lo-10) : '0' + lo);
 		} else if (c == '\\' || c == '\"') {
 			if (bufpos + 2 >= bufsize)
 				break;

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -159,7 +159,7 @@ static int dp_list_route_entry(struct rte_rib_node *node,
 	// can only fail when any argument is NULL
 	rte_rib_get_nh(node, &next_hop);
 
-	dst_port = dp_get_port_by_id(next_hop);
+	dst_port = dp_get_port_by_id((uint16_t)next_hop);
 	if (unlikely(!dst_port))
 		return DP_GRPC_ERR_NO_VM;
 
@@ -297,7 +297,7 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 	if (DP_FAILED(rte_rib_get_nh(node, &next_hop)))
 		return NULL;
 
-	dst_port = dp_get_port_by_id(next_hop);
+	dst_port = dp_get_port_by_id((uint16_t)next_hop);
 	if (!dst_port)
 		return NULL;
 
@@ -334,7 +334,7 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 	if (DP_FAILED(rte_rib6_get_nh(node, &next_hop)))
 		return NULL;
 
-	dst_port = dp_get_port_by_id(next_hop);
+	dst_port = dp_get_port_by_id((uint16_t)next_hop);
 	if (!dst_port)
 		return NULL;
 

--- a/src/dp_netlink.c
+++ b/src/dp_netlink.c
@@ -16,7 +16,7 @@ static int dp_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *
 {
 	struct rtattr *rt_attr;
 	struct ndmsg *rt_msg;
-	int rtl, ndm_family;
+	size_t rtl, ndm_family;
 
 	for (; NLMSG_OK(nh, nll); nh = NLMSG_NEXT(nh, nll)) {
 		rt_msg = (struct ndmsg *)NLMSG_DATA(nh);
@@ -40,13 +40,13 @@ static int dp_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *
 static int dp_recv_msg(struct sockaddr_nl sock_addr, int sock, char *buf, int bufsize)
 {
 	struct nlmsghdr *nh;
-	int recv_len;
-	int msg_len = 0;
+	ssize_t recv_len;
+	ssize_t msg_len = 0;
 
 	for (;;) {
 		recv_len = recv(sock, buf, bufsize - msg_len, 0);
 		if (recv_len < 0)
-			return recv_len;
+			return (int)recv_len;
 
 		nh = (struct nlmsghdr *)buf;
 		if (nh->nlmsg_type == NLMSG_DONE)
@@ -60,7 +60,7 @@ static int dp_recv_msg(struct sockaddr_nl sock_addr, int sock, char *buf, int bu
 		if ((sock_addr.nl_groups & RTMGRP_IPV6_ROUTE) == RTMGRP_IPV6_ROUTE)
 			break;
 	}
-	return msg_len;
+	return (int)msg_len;
 }
 
 int dp_get_pf_neigh_mac(int if_idx, struct rte_ether_addr *neigh, const struct rte_ether_addr *own_mac)

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -88,7 +88,7 @@ static int dp_port_init_ethdev(struct dp_port *port, struct rte_eth_dev_info *de
 	port_conf.txmode.offloads &= dev_info->tx_offload_capa;
 
 	nr_hairpin_queues = port->is_pf
-		? (DP_NR_PF_HAIRPIN_RX_TX_QUEUES + DP_NR_VF_HAIRPIN_RX_TX_QUEUES * dp_layer->num_of_vfs)
+		? (uint16_t)(DP_NR_PF_HAIRPIN_RX_TX_QUEUES + DP_NR_VF_HAIRPIN_RX_TX_QUEUES * dp_layer->num_of_vfs)
 		: DP_NR_VF_HAIRPIN_RX_TX_QUEUES;
 
 	ret = rte_eth_dev_configure(port->port_id,
@@ -104,7 +104,7 @@ static int dp_port_init_ethdev(struct dp_port *port, struct rte_eth_dev_info *de
 	rxq_conf.offloads = port_conf.rxmode.offloads;
 
 	/* RX and TX queues config */
-	for (int i = 0; i < DP_NR_STD_RX_QUEUES; ++i) {
+	for (uint16_t i = 0; i < DP_NR_STD_RX_QUEUES; ++i) {
 		ret = rte_eth_rx_queue_setup(port->port_id, i, 1024,
 									 port->socket_id,
 									 &rxq_conf,
@@ -118,7 +118,7 @@ static int dp_port_init_ethdev(struct dp_port *port, struct rte_eth_dev_info *de
 	txq_conf = dev_info->default_txconf;
 	txq_conf.offloads = port_conf.txmode.offloads;
 
-	for (int i = 0; i < DP_NR_STD_TX_QUEUES; ++i) {
+	for (uint16_t i = 0; i < DP_NR_STD_TX_QUEUES; ++i) {
 		ret = rte_eth_tx_queue_setup(port->port_id, i, 2048,
 									 port->socket_id,
 									 &txq_conf);
@@ -223,7 +223,7 @@ static struct dp_port *dp_port_init_interface(uint16_t port_id, struct rte_eth_d
 		// All VFs belong to pf0, assign a tx queue from pf1 for it
 		if (dp_conf_is_offload_enabled()) {
 			port->peer_pf_port_id = dp_get_pf1()->port_id;
-			port->peer_pf_hairpin_tx_rx_queue_offset = last_pf1_hairpin_tx_rx_queue_offset++;
+			port->peer_pf_hairpin_tx_rx_queue_offset = (uint8_t)last_pf1_hairpin_tx_rx_queue_offset++;
 			if (last_pf1_hairpin_tx_rx_queue_offset > UINT8_MAX) {
 				DPS_LOG_ERR("Too many VFs, cannot create more hairpins");
 				return NULL;
@@ -357,7 +357,7 @@ void dp_ports_free(void)
 }
 
 
-static int dp_port_install_isolated_mode(int port_id)
+static int dp_port_install_isolated_mode(uint16_t port_id)
 {
 	DPS_LOG_INFO("Init isolation flow rule for IPinIP tunnels");
 	if (DP_FAILED(dp_install_isolated_mode_ipip(port_id, DP_IP_PROTO_IPv4_ENCAP))

--- a/src/dp_service.c
+++ b/src/dp_service.c
@@ -216,7 +216,8 @@ static int run_service(void)
 {
 	int result;
 
-	srand(rte_rdtsc());
+	// the lower 32 bits are the ones that are actually changing all the time, cast is fine
+	srand((unsigned int)rte_rdtsc());
 
 	// pre-init sanity checks
 	if (!dp_conf_is_conntrack_enabled() && dp_conf_is_offload_enabled()) {

--- a/src/dp_telemetry.c
+++ b/src/dp_telemetry.c
@@ -43,7 +43,7 @@ static int tel_stat_value_offset = 0;
 //
 // Graph introduces another layer of callbacks due to DPDK stats API
 //
-static __rte_always_inline int get_stat_value(const struct rte_graph_cluster_node_stats *st)
+static __rte_always_inline uint64_t get_stat_value(const struct rte_graph_cluster_node_stats *st)
 {
 	return *(const uint64_t *)((const uint8_t *)(st) + tel_stat_value_offset);
 }

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -12,7 +12,7 @@
 #define DP_SYSFS_MAX_PATH 256
 
 // makes sure there is enough space to prevent collisions
-#define DP_JHASH_MARGIN_COEF(ENTRIES) ((ENTRIES)*1.20)
+#define DP_JHASH_MARGIN_COEF(ENTRIES) ((uint32_t)((ENTRIES)*1.20))
 
 int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IF_NAMESIZE])
 {
@@ -138,7 +138,7 @@ struct rte_hash *dp_create_jhash_table(int entries, size_t key_len, const char *
 	struct rte_hash_parameters params = {
 		.name = full_name,
 		.entries = DP_JHASH_MARGIN_COEF(entries),
-		.key_len = key_len,
+		.key_len = (uint32_t)key_len,  // no way this will get bigger than 32b
 		.hash_func = hash_func,
 		.hash_func_init_val = 0xfee1900d,  // "random" IV
 		.socket_id = socket_id,

--- a/src/dp_virtsvc.c
+++ b/src/dp_virtsvc.c
@@ -214,7 +214,8 @@ void dp_virtsvc_free(void)
 
 int dp_virtsvc_get_count(void)
 {
-	return dp_virtservices_end - dp_virtservices;
+	// conversion is fine, will never get that far
+	return (int)(dp_virtservices_end - dp_virtservices);
 }
 
 
@@ -255,11 +256,11 @@ static __rte_always_inline int dp_virtsvc_get_free_port(struct dp_virtsvc *virts
 		virtsvc->last_assigned_port = 0;
 #endif
 
-	for (int port = virtsvc->last_assigned_port+1; port < DP_VIRTSVC_PORTCOUNT; ++port)
+	for (uint16_t port = virtsvc->last_assigned_port+1; port < DP_VIRTSVC_PORTCOUNT; ++port)
 		if (dp_virtsvc_is_connection_old(&virtsvc->connections[port], current_tsc))
 			return virtsvc->last_assigned_port = port;
 
-	for (int port = 0; port <= virtsvc->last_assigned_port; ++port)
+	for (uint16_t port = 0; port <= virtsvc->last_assigned_port; ++port)
 		if (dp_virtsvc_is_connection_old(&virtsvc->connections[port], current_tsc))
 			return virtsvc->last_assigned_port = port;
 
@@ -317,7 +318,7 @@ static __rte_always_inline int dp_virstvc_get_connection(struct dp_virtsvc *virt
 		return ret;
 
 	assert((intptr_t)data >= 0 && (intptr_t)data < DP_VIRTSVC_PORTCOUNT);
-	return (intptr_t)data;
+	return (int)(intptr_t)data;
 }
 
 int dp_virtsvc_get_pf_route(struct dp_virtsvc *virtsvc,

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -25,7 +25,7 @@ void dp_vnf_free(void)
 }
 
 int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type type,
-			   uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint16_t prefix_len)
+			   uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len)
 {
 	struct dp_vnf *vnf;
 	int ret;
@@ -91,7 +91,7 @@ int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE])
 
 static __rte_always_inline bool dp_vnf_match(const struct dp_vnf *vnf, enum dp_vnf_type type,
 											 uint16_t port_id, uint32_t vni,
-											 uint32_t prefix_ip, uint16_t prefix_len)
+											 uint32_t prefix_ip, uint8_t prefix_len)
 {
 	return (port_id == DP_VNF_MATCH_ALL_PORT_IDS || vnf->port_id == port_id)
 		&& vnf->vni == vni
@@ -100,7 +100,7 @@ static __rte_always_inline bool dp_vnf_match(const struct dp_vnf *vnf, enum dp_v
 		&& vnf->type == type;
 }
 
-bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint16_t prefix_len)
+bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len)
 {
 	struct dp_vnf *vnf;
 	uint32_t iter = 0;
@@ -119,7 +119,7 @@ bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, uint32_t prefix_ip, 
 	return false;
 }
 
-int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint16_t prefix_len)
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len)
 {
 	struct dp_vnf *vnf;
 	uint32_t iter = 0;

--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -119,7 +119,8 @@ static int main_core_loop(void)
 	uint64_t prev_cycles = 0;
 	uint64_t elapsed_cycles;
 	uint64_t period_cycles = dp_timers_get_manage_interval_cycles();
-	double cycles_per_ns = rte_get_timer_hz() / (double)NS_PER_S;
+	uint64_t timer_hz = rte_get_timer_hz();
+	double cycles_per_ns = (double)timer_hz / (double)NS_PER_S;
 	int ret = DP_OK;
 
 	while (!force_quit) {
@@ -128,7 +129,7 @@ static int main_core_loop(void)
 		if (elapsed_cycles < period_cycles) {
 			// rte_delay_us_sleep() is not interruptible by signals
 			// (and signal is something that should stop this loop)
-			dp_nanosleep((period_cycles - elapsed_cycles) / cycles_per_ns);
+			dp_nanosleep((uint64_t)((double)(period_cycles - elapsed_cycles) / cycles_per_ns));
 			// if wait fails, this effectively becomes busy-wait, which is fine
 			continue;
 		}

--- a/src/monitoring/dp_monitoring.c
+++ b/src/monitoring/dp_monitoring.c
@@ -23,7 +23,7 @@ void dp_process_event_msg(struct rte_mbuf *m)
 	rte_pktmbuf_free(m);
 }
 
-void dp_set_capture_hdr_config(uint8_t *addr, uint32_t udp_src_port, uint32_t udp_dst_port)
+void dp_set_capture_hdr_config(uint8_t *addr, uint16_t udp_src_port, uint16_t udp_dst_port)
 {
 	rte_memcpy(capture_hdr_config.capture_node_ipv6_addr, addr, sizeof(capture_hdr_config.capture_node_ipv6_addr));
 	capture_hdr_config.capture_udp_src_port = udp_src_port;

--- a/src/monitoring/dp_pcap.c
+++ b/src/monitoring/dp_pcap.c
@@ -46,7 +46,7 @@ void dp_pcap_dump(struct dp_pcap *dp_pcap, struct rte_mbuf *m, struct timeval *t
 
 	header.ts = *timestamp;
 	header.len = rte_pktmbuf_pkt_len(m);
-	header.caplen = RTE_MIN(header.len, sizeof(buffer));
+	header.caplen = RTE_MIN(header.len, (uint32_t)sizeof(buffer));
 
 	// rte_pktmbuf_read() can only fail if the buffer is too small, hence RTE_MIN() above
 	pcap_dump((void *)dp_pcap->dumper, &header, rte_pktmbuf_read(m, 0, header.caplen, buffer));
@@ -82,7 +82,7 @@ bool dp_is_bpf_match(struct bpf_program *bpf, struct rte_mbuf *m)
 	uint32_t len = rte_pktmbuf_pkt_len(m);
 	struct pcap_pkthdr header = {
 		.len = len,
-		.caplen = RTE_MIN(len, sizeof(buffer)),
+		.caplen = RTE_MIN(len, (uint32_t)sizeof(buffer)),
 		// timestamp left zero, not needed for filtering
 	};
 

--- a/src/nodes/cls_node.c
+++ b/src/nodes/cls_node.c
@@ -67,7 +67,7 @@ static __rte_always_inline struct dp_virtsvc *get_outgoing_virtsvc(const struct 
 {
 	const struct rte_ipv4_hdr *ipv4_hdr = (const struct rte_ipv4_hdr *)(ether_hdr + 1);
 	rte_be32_t addr = ipv4_hdr->dst_addr;
-	uint16_t proto = ipv4_hdr->next_proto_id;
+	uint8_t proto = ipv4_hdr->next_proto_id;
 	rte_be16_t port;
 	const struct dp_virtsvc_lookup_entry *entry;
 	int diff;
@@ -93,7 +93,7 @@ static __rte_always_inline struct dp_virtsvc *get_outgoing_virtsvc(const struct 
 static __rte_always_inline struct dp_virtsvc *get_incoming_virtsvc(const struct rte_ipv6_hdr *ipv6_hdr)
 {
 	const uint8_t *addr = ipv6_hdr->src_addr;
-	uint16_t proto = ipv6_hdr->proto;
+	uint8_t proto = ipv6_hdr->proto;
 	rte_be16_t port;
 	const struct dp_virtsvc_lookup_entry *entry;
 	int diff;

--- a/src/nodes/packet_relay_node.c
+++ b/src/nodes/packet_relay_node.c
@@ -29,7 +29,7 @@ static __rte_always_inline rte_edge_t lb_nnat_icmp_reply(struct dp_flow *df, str
 	cksum += RTE_BE16(RTE_IP_ICMP_ECHO_REPLY << 8);
 	cksum = (cksum & 0xffff) + (cksum >> 16);
 	cksum = (cksum & 0xffff) + (cksum >> 16);
-	icmp_hdr->icmp_cksum = ~cksum;
+	icmp_hdr->icmp_cksum = (uint16_t)~cksum;
 
 	temp_ip = ipv4_hdr->dst_addr;
 	ipv4_hdr->dst_addr = ipv4_hdr->src_addr;

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -19,7 +19,7 @@ static const struct rte_flow_attr dp_flow_attr_prio_ingress = {
 };
 
 
-int dp_install_isolated_mode_ipip(int port_id, uint8_t proto_id)
+int dp_install_isolated_mode_ipip(uint16_t port_id, uint8_t proto_id)
 {
 	struct rte_flow_item_eth eth_spec;   // #1
 	struct rte_flow_item_ipv6 ipv6_spec; // #2
@@ -46,7 +46,7 @@ int dp_install_isolated_mode_ipip(int port_id, uint8_t proto_id)
 }
 
 #ifdef ENABLE_VIRTSVC
-int dp_install_isolated_mode_virtsvc(int port_id, uint8_t proto_id, const uint8_t svc_ipv6[16], rte_be16_t svc_port)
+int dp_install_isolated_mode_virtsvc(uint16_t port_id, uint8_t proto_id, const uint8_t svc_ipv6[16], rte_be16_t svc_port)
 {
 	struct rte_flow_item_eth eth_spec;   // #1
 	struct rte_flow_item_ipv6 ipv6_spec; // #2

--- a/src/rte_flow/dp_rte_flow_traffic_forward.c
+++ b/src/rte_flow/dp_rte_flow_traffic_forward.c
@@ -92,7 +92,8 @@ static __rte_always_inline int dp_install_rte_flow_with_age(uint16_t port_id,
 
 	agectx->cntrack = conntrack;
 	agectx->rte_flow = flow;
-	agectx->port_id = port_id;
+	static_assert(DP_MAX_PORTS <= UINT8_MAX, "Too many ports for offloading");
+	agectx->port_id = (uint8_t)port_id;
 	dp_ref_inc(&conntrack->ref_count);
 	return DP_OK;
 }

--- a/tools/dp_grpc_client.cpp
+++ b/tools/dp_grpc_client.cpp
@@ -1056,7 +1056,7 @@ public:
 			while (pt != NULL) {
 				if (countp == DP_MAX_LB_PORTS)
 					break;
-				ports[countp++] = atoi(pt);
+				ports[countp++] = (uint16_t)atoi(pt);
 				pt = strtok(NULL, ",");
 			}
 


### PR DESCRIPTION
I remember conversion warnings being a problem before all the refactoring, so I tried again. Sign-conversion is a separate problem, but conversion itself, like narrowing `uint32_t` to `uint16_t` was doable and actually found a few bugs.

The warning will force us to use more `static_asserts` before actually doing a hard narrowing cast or re-typing some variables.

There are only a few places (mostly dhcp) that the code looks slightly uglier than before and it's because of the DHCP options parsing and changing them in-place for optimization, so it's to be expected.

I also changed `df->nxt_hop` from `uint8_t` to `uint16_t`. Now that will need one more byte (I left a comment about unused space), but will prevent any checks/masking to be needed when assigning it, which I think is a plus.
Maybe doing the same thing to `struct flow_age_ctx` can be done, but I do not know if that is space-critical.

There is however a bad return-type (seems like a typo) in one RTE function, which I had to patch.

Checkpatch fails due to also checking the patch to DPDK.