### PR TITLE
Improve IPv4 prefix length check in gRPC thread

### DIFF
--- a/include/grpc/dp_grpc_conv.h
+++ b/include/grpc/dp_grpc_conv.h
@@ -29,7 +29,7 @@ namespace GrpcConv
 
 	const char *Ipv4ToStr(uint32_t ipv4);
 
-	uint32_t Ipv4PrefixLenToMask(uint32_t prefix_length);
+	bool Ipv4PrefixLenToMask(uint32_t prefix_length, uint32_t *mask);
 
 	void DpToGrpcInterface(const struct dpgrpc_iface *dp_iface, Interface *grpc_iface);
 

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -925,16 +925,14 @@ const char* CreateFirewallRuleCall::FillRequest(struct dpgrpc_request* request)
 		return "Invalid source_prefix.ip.ipver";
 	if (!GrpcConv::StrToIpv4(grpc_rule.source_prefix().ip().address(), &dp_rule->src_ip))
 		return "Invalid source_prefix.ip";
-	if (grpc_rule.source_prefix().length() > 32)
+	if (!GrpcConv::Ipv4PrefixLenToMask(grpc_rule.source_prefix().length(), &dp_rule->src_ip_mask))
 		return "Invalid source_prefix.length";
-	dp_rule->src_ip_mask = GrpcConv::Ipv4PrefixLenToMask(grpc_rule.source_prefix().length());
 	if (grpc_rule.destination_prefix().ip().ipver() != IpVersion::IPV4)
 		return "Invalid destination_prefix.ip.ipver";
 	if (!GrpcConv::StrToIpv4(grpc_rule.destination_prefix().ip().address(), &dp_rule->dest_ip))
 		return "Invalid destination_prefix.ip";
-	if (grpc_rule.destination_prefix().length() > 32)
+	if (!GrpcConv::Ipv4PrefixLenToMask(grpc_rule.destination_prefix().length(), &dp_rule->dest_ip_mask))
 		return "Invalid destination_prefix.length";
-	dp_rule->dest_ip_mask = GrpcConv::Ipv4PrefixLenToMask(grpc_rule.destination_prefix().length());
 	if (!GrpcConv::GrpcToDpFwallDirection(grpc_rule.direction(), &dp_rule->dir))
 		return "Invalid direction";
 	if (!GrpcConv::GrpcToDpFwallAction(grpc_rule.action(), &dp_rule->action))
@@ -995,8 +993,8 @@ const char* CreateFirewallRuleCall::FillRequest(struct dpgrpc_request* request)
 						DP_LOG_FWICMPTYPE(grpc_filter.icmp().icmp_type()),
 						DP_LOG_FWICMPCODE(grpc_filter.icmp().icmp_code()));
 		dp_rule->protocol = IPPROTO_ICMP;
-		dp_rule->filter.icmp.icmp_type = grpc_filter.icmp().icmp_type();
-		dp_rule->filter.icmp.icmp_code = grpc_filter.icmp().icmp_code();
+		dp_rule->filter.icmp.icmp_type = (uint32_t)grpc_filter.icmp().icmp_type();
+		dp_rule->filter.icmp.icmp_code = (uint32_t)grpc_filter.icmp().icmp_code();
 		if (dp_rule->filter.icmp.icmp_type != DP_FWALL_MATCH_ANY_ICMP_TYPE && dp_rule->filter.icmp.icmp_type > UINT8_MAX)
 			return "Invalid icmp.icmp_type";
 		if (dp_rule->filter.icmp.icmp_code != DP_FWALL_MATCH_ANY_ICMP_CODE && dp_rule->filter.icmp.icmp_code > UINT8_MAX)

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -148,11 +148,17 @@ const char *Ipv4ToStr(uint32_t ipv4)
 	return inet_ntoa(addr);
 }
 
-uint32_t Ipv4PrefixLenToMask(uint32_t prefix_length)
+bool Ipv4PrefixLenToMask(uint32_t prefix_length, uint32_t *mask)
 {
-	return prefix_length == DP_FWALL_MATCH_ANY_LENGTH
-		? DP_FWALL_MATCH_ANY_LENGTH
-		: ~((1 << (32 - prefix_length)) - 1);
+	if (prefix_length > 32)
+		return false;
+
+	if (prefix_length == DP_FWALL_MATCH_ANY_LENGTH)
+		*mask = DP_FWALL_MATCH_ANY_LENGTH;
+	else
+		*mask = ~((1 << (32 - prefix_length)) - 1);
+
+	return true;
 }
 
 


### PR DESCRIPTION
This is only a small improvement that came from me trying to compile with `-Wsign-compare`. 

It is not feasible to compile with it currently, but it does point out places that could be done better. However I don't have the time to properly make the whole codebase work with it.