### PR TITLE
Add check for empty string values in gRPC

### DIFF
--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -19,7 +19,7 @@
 
 // Prevent errors and large inputs (negative values/errors will be converted to huge size by uint)
 #define SNPRINTF_FAILED(DEST, SRC) \
-	((uint)snprintf(DEST, sizeof(DEST), "%s", SRC.c_str()) >= sizeof(DEST))
+	((SRC).empty() || (uint)snprintf((DEST), sizeof(DEST), "%s", (SRC).c_str()) >= sizeof(DEST))
 
 
 CallState BaseCall::HandleRpc()


### PR DESCRIPTION
As previously discussed, all string values passed by gRPC are not checked for emptiness.

Tested by @vlorinc in metalnet tests