### PR TITLE
Introduce IPv6 overlay support for non-offloading path

### DIFF
--- a/docs/deployment/help_dpservice-bin.md
+++ b/docs/deployment/help_dpservice-bin.md
@@ -10,6 +10,7 @@
 | --vf-pattern | PATTERN | virtual interface name pattern (e.g. 'eth1vf') |  |
 | --dhcp-mtu | SIZE | set the mtu field in DHCP responses (68 - 1500) |  |
 | --dhcp-dns | IPv4 | set the domain name server field in DHCP responses (can be used multiple times) |  |
+| --dhcpv6-dns | ADDR6 | set the domain name server field in DHCPv6 responses (can be used multiple times) |  |
 | --udp-virtsvc | IPv4,port,IPv6,port | map a VM-accessible IPv4 endpoint to an outside IPv6 UDP service |  |
 | --tcp-virtsvc | IPv4,port,IPv6,port | map a VM-accessible IPv4 endpoint to an outside IPv6 TCP service |  |
 | --wcmp | PERCENTAGE | weighted-cost-multipath percentage for pf0 (0 - 100) |  |

--- a/hack/dp_conf.json
+++ b/hack/dp_conf.json
@@ -48,10 +48,10 @@
       "help": "set the domain name server field in DHCP responses (can be used multiple times)"
     },
     {
-		"lgopt": "dhcpv6-dns",
-		"arg": "ADDR6",
-		"help": "set the domain name server field in DHCPv6 responses (can be used multiple times)"
-	},
+      "lgopt": "dhcpv6-dns",
+      "arg": "ADDR6",
+      "help": "set the domain name server field in DHCPv6 responses (can be used multiple times)"
+    },
     {
       "lgopt": "udp-virtsvc",
       "arg": "IPv4,port,IPv6,port",

--- a/hack/dp_conf.json
+++ b/hack/dp_conf.json
@@ -48,6 +48,11 @@
       "help": "set the domain name server field in DHCP responses (can be used multiple times)"
     },
     {
+		"lgopt": "dhcpv6-dns",
+		"arg": "ADDR6",
+		"help": "set the domain name server field in DHCPv6 responses (can be used multiple times)"
+	},
+    {
       "lgopt": "udp-virtsvc",
       "arg": "IPv4,port,IPv6,port",
       "help": "map a VM-accessible IPv4 endpoint to an outside IPv6 UDP service",

--- a/include/dp_conf.h
+++ b/include/dp_conf.h
@@ -45,6 +45,7 @@ const char *dp_conf_get_eal_a_pf0(void);
 const char *dp_conf_get_eal_a_pf1(void);
 const uint8_t *dp_conf_get_underlay_ip(void);
 const struct dp_conf_dhcp_dns *dp_conf_get_dhcp_dns(void);
+const struct dp_conf_dhcp_dns *dp_conf_get_dhcpv6_dns(void);
 #ifdef ENABLE_VIRTSVC
 const struct dp_conf_virtual_services *dp_conf_get_virtual_services(void);
 #endif

--- a/include/dp_firewall.h
+++ b/include/dp_firewall.h
@@ -45,18 +45,19 @@ struct dp_port_filter {
 	struct dp_port_range dst_port;
 };
 
+struct dp_ip_mask {
+	union {
+		uint32_t ip4;
+		uint8_t ip6[DP_IPV6_ADDR_SIZE];
+	};
+};
+
 struct dp_fwall_rule {
 	char					rule_id[DP_FIREWALL_ID_MAX_LEN];
 	struct dp_ip_address	src_ip;
 	struct dp_ip_address	dest_ip;
-	union {
-		uint32_t			ip4;
-		uint8_t				ip6[DP_IPV6_ADDR_SIZE];
-	} src_mask;
-	union {
-		uint32_t			ip4;
-		uint8_t				ip6[DP_IPV6_ADDR_SIZE];
-	} dest_mask;
+	struct dp_ip_mask		src_mask;
+	struct dp_ip_mask		dest_mask;
 	uint16_t				priority;
 	uint8_t					protocol;
 	union {

--- a/include/dp_firewall.h
+++ b/include/dp_firewall.h
@@ -46,13 +46,19 @@ struct dp_port_filter {
 };
 
 struct dp_fwall_rule {
-	char		rule_id[DP_FIREWALL_ID_MAX_LEN];
-	uint32_t	src_ip;
-	uint32_t	src_ip_mask;
-	uint32_t	dest_ip;
-	uint32_t	dest_ip_mask;
-	uint16_t	priority;
-	uint8_t		protocol;
+	char					rule_id[DP_FIREWALL_ID_MAX_LEN];
+	struct dp_ip_address	src_ip;
+	struct dp_ip_address	dest_ip;
+	union {
+		uint32_t			ip4;
+		uint8_t				ip6[DP_IPV6_ADDR_SIZE];
+	} src_mask;
+	union {
+		uint32_t			ip4;
+		uint8_t				ip6[DP_IPV6_ADDR_SIZE];
+	} dest_mask;
+	uint16_t				priority;
+	uint8_t					protocol;
 	union {
 		struct dp_icmp_filter icmp;
 		struct dp_port_filter tcp_udp;

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -66,8 +66,14 @@ enum dp_flow_tcp_state {
 };
 
 struct flow_key {
-	uint32_t ip_dst;
-	uint32_t ip_src;
+	union {
+		uint32_t	ip4;
+		uint8_t		ip6[16];
+	} l3_dst;
+	union {
+		uint32_t	ip4;
+		uint8_t		ip6[16];
+	} l3_src;
 	uint16_t port_dst;
 	union {
 		uint16_t port_src;

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -10,6 +10,7 @@
 #include <rte_malloc.h>
 #include "dpdk_layer.h"
 #include "dp_firewall.h"
+#include "dp_util.h"
 #include "dp_mbuf_dyn.h"
 #include "dp_refcount.h"
 #include "dp_timers.h"
@@ -70,11 +71,11 @@ enum dp_flow_tcp_state {
 struct flow_key {
 	union {
 		uint32_t	ip4;
-		uint8_t		ip6[16];
+		uint8_t		ip6[DP_IPV6_ADDR_SIZE];
 	} l3_dst;
 	union {
 		uint32_t	ip4;
-		uint8_t		ip6[16];
+		uint8_t		ip6[DP_IPV6_ADDR_SIZE];
 	} l3_src;
 	uint16_t port_dst;
 	union {

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -32,16 +32,18 @@ extern "C" {
 #define DP_FLOW_FLAG_DST_NAT			0x02
 #define DP_FLOW_FLAG_DST_LB				0x04
 #define DP_FLOW_FLAG_FIREWALL			0x08
-#define DP_FLOW_FLAG_DEFAULT			0x10
+#define DP_FLOW_FLAG_SRC_NAT64			0x10
+#define DP_FLOW_FLAG_DEFAULT			0x20
 
-#define DP_FLOW_FLAG_NF					(DP_FLOW_FLAG_SRC_NAT | DP_FLOW_FLAG_DST_NAT | DP_FLOW_FLAG_DST_LB)
+#define DP_FLOW_FLAG_NF					(DP_FLOW_FLAG_SRC_NAT64 | DP_FLOW_FLAG_SRC_NAT | DP_FLOW_FLAG_DST_NAT | DP_FLOW_FLAG_DST_LB)
 
-#define DP_FLOW_HAS_NO_FLAGS(flag)		(!(flag))
-#define DP_FLOW_HAS_FLAG_SRC_NAT(flag)	((flag) & DP_FLOW_FLAG_SRC_NAT)
-#define DP_FLOW_HAS_FLAG_DST_NAT(flag)	((flag) & DP_FLOW_FLAG_DST_NAT)
-#define DP_FLOW_HAS_FLAG_DST_LB(flag)	((flag) & DP_FLOW_FLAG_DST_LB)
-#define DP_FLOW_HAS_FLAG_FIREWALL(flag)	((flag) & DP_FLOW_FLAG_FIREWALL)
-#define DP_FLOW_HAS_FLAG_DEFAULT(flag)	((flag) & DP_FLOW_FLAG_DEFAULT)
+#define DP_FLOW_HAS_NO_FLAGS(flag)			(!(flag))
+#define DP_FLOW_HAS_FLAG_SRC_NAT(flag)		((flag) & DP_FLOW_FLAG_SRC_NAT)
+#define DP_FLOW_HAS_FLAG_DST_NAT(flag)		((flag) & DP_FLOW_FLAG_DST_NAT)
+#define DP_FLOW_HAS_FLAG_DST_LB(flag)		((flag) & DP_FLOW_FLAG_DST_LB)
+#define DP_FLOW_HAS_FLAG_FIREWALL(flag)		((flag) & DP_FLOW_FLAG_FIREWALL)
+#define DP_FLOW_HAS_FLAG_SRC_NAT64(flag)	((flag) & DP_FLOW_FLAG_SRC_NAT64)
+#define DP_FLOW_HAS_FLAG_DEFAULT(flag)		((flag) & DP_FLOW_FLAG_DEFAULT)
 
 #define DP_FLOW_HAS_FLAG_NF(flag)		((flag) & DP_FLOW_FLAG_NF)
 

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -80,6 +80,7 @@ struct flow_key {
 		uint16_t type_src; /* ICMP */
 	} src;
 	uint32_t vni;
+	uint16_t l3_type;
 	uint8_t  proto;
 	enum dp_vnf_type vnf_type;
 } __rte_packed;
@@ -133,7 +134,7 @@ int dp_get_flow(const struct flow_key *key, struct flow_value **p_flow_val);
 int dp_add_flow(const struct flow_key *key, struct flow_value *flow_val);
 void dp_delete_flow(const struct flow_key *key);
 int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
-void dp_invert_flow_key(const struct flow_key *key /* in */, struct flow_key *inv_key /* out */);
+void dp_invert_flow_key(const struct flow_key *key /* in */, uint16_t l3_type /* in */, struct flow_key *inv_key /* out */);
 int dp_flow_init(int socket_id);
 void dp_flow_free(void);
 void dp_process_aged_flows(uint16_t port_id);

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -24,7 +24,7 @@ struct lb_key {
 		uint32_t	v4;
 		uint8_t		v6[DP_IPV6_ADDR_SIZE];
 	} ip;
-	uint32_t	ip_type;
+	uint16_t	ip_type;
 	uint32_t	vni;
 } __rte_packed;
 
@@ -45,7 +45,7 @@ struct lb_value {
 int dp_lb_init(int socket_id);
 void dp_lb_free(void);
 bool dp_is_ip_lb(struct dp_flow *df, uint32_t vni);
-uint8_t *dp_lb_get_backend_ip(struct flow_key *fkey, uint32_t vni);
+uint8_t *dp_lb_get_backend_ip(struct flow_key *flow_key, uint32_t vni);
 bool dp_is_lb_enabled(void);
 int dp_del_lb_back_ip(const void *id_key, const uint8_t *back_ip);
 int dp_add_lb_back_ip(const void *id_key, const uint8_t *back_ip, uint8_t ip_size);

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -8,6 +8,7 @@
 extern "C" {
 #endif
 
+#include "dp_flow.h"
 #include "grpc/dp_grpc_responder.h"
 
 #define DP_LB_TABLE_MAX			256
@@ -19,7 +20,11 @@ extern "C" {
 #define DP_LB_DLB	3
 
 struct lb_key {
-	uint32_t	ip;
+	union {
+		uint32_t	v4;
+		uint8_t		v6[16];
+	} ip;
+	uint32_t	ip_type;
 	uint32_t	vni;
 } __rte_packed;
 
@@ -39,9 +44,8 @@ struct lb_value {
 
 int dp_lb_init(int socket_id);
 void dp_lb_free(void);
-bool dp_is_ip_lb(uint32_t ol_ip, uint32_t vni);
-uint32_t dp_get_lb_ip(uint32_t ol_ip, uint32_t vni);
-uint8_t *dp_lb_get_backend_ip(uint32_t ol_ip, uint32_t vni, rte_be16_t port, uint8_t proto);
+bool dp_is_ip_lb(struct dp_flow *df, uint32_t vni);
+uint8_t *dp_lb_get_backend_ip(struct flow_key *fkey, uint32_t vni);
 bool dp_is_lb_enabled(void);
 int dp_del_lb_back_ip(const void *id_key, const uint8_t *back_ip);
 int dp_add_lb_back_ip(const void *id_key, const uint8_t *back_ip, uint8_t ip_size);

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -22,7 +22,7 @@ extern "C" {
 struct lb_key {
 	union {
 		uint32_t	v4;
-		uint8_t		v6[16];
+		uint8_t		v6[DP_IPV6_ADDR_SIZE];
 	} ip;
 	uint32_t	ip_type;
 	uint32_t	vni;

--- a/include/dp_log.h
+++ b/include/dp_log.h
@@ -57,6 +57,8 @@ extern "C" {
 #define DP_LOG_IPV6(VALUE) _DP_LOG_IPV6("ipv6", VALUE)
 #define DP_LOG_SRC_IPV4(VALUE) _DP_LOG_IPV4("src_ipv4", VALUE)
 #define DP_LOG_DST_IPV4(VALUE) _DP_LOG_IPV4("dst_ipv4", VALUE)
+#define DP_LOG_SRC_IPV6(VALUE) _DP_LOG_IPV6("src_ipv6", VALUE)
+#define DP_LOG_DST_IPV6(VALUE) _DP_LOG_IPV6("dst_ipv6", VALUE)
 #define DP_LOG_L4PORT(VALUE) _DP_LOG_UINT("port", VALUE)
 #define DP_LOG_SRC_PORT(VALUE) _DP_LOG_UINT("src_port", VALUE)
 #define DP_LOG_DST_PORT(VALUE) _DP_LOG_UINT("dst_port", VALUE)

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -54,8 +54,8 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
-										  struct dp_iface_route *route);
-
+										  struct dp_iface_route *route,
+										  uint8_t route_key[RTE_RIB6_IPV6_ADDR_SIZE]);
 uint32_t dp_get_gw_ip4(void);
 const uint8_t *dp_get_gw_ip6(void);
 

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -53,7 +53,7 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
-										  const struct rte_ipv6_hdr *ipv6_hdr,
+										  const struct dp_flow *df,
 										  struct dp_iface_route *route);
 
 uint32_t dp_get_gw_ip4(void);

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -55,7 +55,7 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint8_t route_key[RTE_RIB6_IPV6_ADDR_SIZE]);
+										  uint8_t route_key[DP_IPV6_ADDR_SIZE]);
 uint32_t dp_get_gw_ip4(void);
 const uint8_t *dp_get_gw_ip6(void);
 

--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -44,6 +44,8 @@ enum dp_nat_type {
 	DP_NAT_CHG_DST_IP,
 	DP_CHG_UL_DST_IP,
 	DP_LB_RECIRC,
+	DP_NAT_64_CHG_SRC_IP,
+	DP_NAT_64_CHG_DST_IP,
 } __rte_packed;
 
 struct dp_flow {

--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -166,13 +166,10 @@ static __rte_always_inline int dp_extract_l4_header(struct dp_flow *df, const vo
 		df->l4_info.trans_port.dst_port = ((const struct rte_udp_hdr *)l4_hdr)->dst_port;
 		df->l4_info.trans_port.src_port = ((const struct rte_udp_hdr *)l4_hdr)->src_port;
 		return DP_OK;
-	} else if (df->l4_type == IPPROTO_ICMP) {
+	} else if (df->l4_type == IPPROTO_ICMP || df->l4_type == IPPROTO_ICMPV6) {
 		df->l4_info.icmp_field.icmp_type = ((const struct rte_icmp_hdr *)l4_hdr)->icmp_type;
 		df->l4_info.icmp_field.icmp_code = ((const struct rte_icmp_hdr *)l4_hdr)->icmp_code;
 		df->l4_info.icmp_field.icmp_identifier = ((const struct rte_icmp_hdr *)l4_hdr)->icmp_ident;
-		return DP_OK;
-	} else if (df->l4_type == IPPROTO_ICMPV6) {
-		df->l4_info.icmp_field.icmp_type = ((const struct rte_icmp_hdr *)l4_hdr)->icmp_type;
 		return DP_OK;
 	}
 

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -17,11 +17,7 @@ extern "C" {
 #endif
 
 #define DP_NAT64_PREFIX		"\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00"
-#define DP_MIN_PACKET_SIZE	64
 
-
-// TODO: change this to a configurable value
-#define DP_NETWORK_NAT_MAX_ENTRY	256
 #define DP_NETWORK_NAT_ALL_VNI		0
 
 struct nat_key {
@@ -54,7 +50,7 @@ struct dnat_data {
 };
 
 struct netnat_portmap_key {
-	struct dpgrpc_address	src_ip;
+	struct dp_ip_address	src_ip;
 	uint32_t				vni;
 	uint16_t				iface_src_port;
 } __rte_packed;
@@ -97,8 +93,8 @@ int dp_set_dnat_ip(uint32_t d_ip, uint32_t dnat_ip, uint32_t vni);
 void dp_nat_chg_ip(struct dp_flow *df, struct rte_ipv4_hdr *ipv4_hdr,
 				   struct rte_mbuf *m);
 
-rte_be32_t dp_nat_chg_ipv6_to_ipv4_hdr(struct dp_flow *df, struct rte_mbuf *m, uint32_t nat_ip);
-void dp_nat_chg_ipv4_to_ipv6_hdr(struct dp_flow *df, struct rte_mbuf *m, uint8_t *ipv6_addr);
+int dp_nat_chg_ipv6_to_ipv4_hdr(struct dp_flow *df, struct rte_mbuf *m, uint32_t nat_ip, rte_be32_t *dest_ip /* out */);
+int dp_nat_chg_ipv4_to_ipv6_hdr(struct dp_flow *df, struct rte_mbuf *m, uint8_t *ipv6_addr);
 
 void dp_del_vip_from_dnat(uint32_t d_ip, uint32_t vni);
 

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -36,6 +36,8 @@ struct dp_port_iface {
 	uint32_t				vni;
 	char					id[DP_IFACE_ID_MAX_LEN];
 	uint8_t					ul_ipv6[16];
+	uint32_t				nat_ip;
+	uint16_t				nat_port_range[2];
 	bool					ready;
 };
 

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -9,6 +9,7 @@
 #include <net/if.h>
 #include <rte_pci.h>
 #include "dp_conf.h"
+#include "dp_util.h"
 #include "dp_firewall.h"
 #include "dp_internal_stats.h"
 #include "dpdk_layer.h"
@@ -23,8 +24,8 @@ struct dp_iface_cfg {
 	uint32_t				own_ip;
 	uint32_t				neigh_ip;
 	uint8_t					ip_depth;
-	uint8_t					dhcp_ipv6[16];
-	uint8_t					own_ipv6[16];
+	uint8_t					dhcp_ipv6[DP_IPV6_ADDR_SIZE];
+	uint8_t					own_ipv6[DP_IPV6_ADDR_SIZE];
 	uint8_t					ip6_depth;
 	uint32_t				pxe_ip;
 	char					pxe_str[DP_IFACE_PXE_MAX_LEN];
@@ -35,7 +36,7 @@ struct dp_port_iface {
 	struct dp_iface_cfg		cfg;
 	uint32_t				vni;
 	char					id[DP_IFACE_ID_MAX_LEN];
-	uint8_t					ul_ipv6[16];
+	uint8_t					ul_ipv6[DP_IPV6_ADDR_SIZE];
 	uint32_t				nat_ip;
 	uint16_t				nat_port_range[2];
 	bool					ready;

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -39,7 +39,7 @@ extern "C" {
 #define DP_TCP_PKT_FLAG_SYNACK(FLAGS) \
 	(((FLAGS) & (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG)) == (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG))
 
-struct dpgrpc_address {
+struct dp_ip_address {
 	uint32_t				ip_type;
 	union {
 		uint32_t			ipv4;

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -21,6 +21,7 @@ extern "C" {
 #define DP_IFACE_PXE_MAX_LEN	32
 #define DP_LB_ID_MAX_LEN		64
 #define DP_LB_MAX_PORTS			16
+#define DP_IPV6_ADDR_SIZE		16
 
 #define DP_MAC_EQUAL(mac1, mac2) (((mac1)->addr_bytes[0] == (mac2)->addr_bytes[0]) && \
 								((mac1)->addr_bytes[1] == (mac2)->addr_bytes[1]) && \

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -40,10 +40,10 @@ extern "C" {
 	(((FLAGS) & (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG)) == (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG))
 
 struct dp_ip_address {
-	uint32_t				ip_type;
+	uint16_t		ip_type;
 	union {
-		uint32_t			ipv4;
-		uint8_t				ipv6[DP_IPV6_ADDR_SIZE];
+		uint32_t	ipv4;
+		uint8_t		ipv6[DP_IPV6_ADDR_SIZE];
 	};
 };
 

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -39,6 +39,13 @@ extern "C" {
 #define DP_TCP_PKT_FLAG_SYNACK(FLAGS) \
 	(((FLAGS) & (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG)) == (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG))
 
+struct dpgrpc_address {
+	uint32_t				ip_type;
+	union {
+		uint32_t			ipv4;
+		uint8_t				ipv6[DP_IPV6_ADDR_SIZE];
+	};
+};
 
 int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IF_NAMESIZE]);
 

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -50,9 +50,9 @@ int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type t
 const struct dp_vnf *dp_get_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 
-bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len);
+bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix_ip, uint8_t prefix_len);
 
-int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len);
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix_ip, uint8_t prefix_len);
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder);
 

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -31,7 +31,7 @@ enum dp_vnf_type {
 } __rte_packed;  // for 'struct dp_flow' and 'struct flow_key'
 
 struct dp_vnf_prefix {
-	struct dpgrpc_address ol;
+	struct dp_ip_address ol;
 	uint8_t				  length;
 };
 
@@ -46,13 +46,13 @@ int dp_vnf_init(int socket_id);
 void dp_vnf_free(void);
 
 int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type type,
-			   uint16_t port_id, uint32_t vni, struct dpgrpc_address *pfx_ip, uint8_t prefix_len);
+			   uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len);
 const struct dp_vnf *dp_get_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 
-bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dpgrpc_address *pfx_ip, uint8_t prefix_len);
+bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len);
 
-int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dpgrpc_address *pfx_ip, uint8_t prefix_len);
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len);
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder);
 

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <rte_common.h>
+#include "dp_util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,8 +31,8 @@ enum dp_vnf_type {
 } __rte_packed;  // for 'struct dp_flow' and 'struct flow_key'
 
 struct dp_vnf_prefix {
-	uint32_t	ip;
-	uint8_t		length;
+	struct dpgrpc_address ol;
+	uint8_t				  length;
 };
 
 struct dp_vnf {
@@ -45,13 +46,13 @@ int dp_vnf_init(int socket_id);
 void dp_vnf_free(void);
 
 int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type type,
-			   uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len);
+			   uint16_t port_id, uint32_t vni, struct dpgrpc_address *pfx_ip, uint8_t prefix_len);
 const struct dp_vnf *dp_get_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 
-bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len);
+bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dpgrpc_address *pfx_ip, uint8_t prefix_len);
 
-int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, uint32_t prefix_ip, uint8_t prefix_len);
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dpgrpc_address *pfx_ip, uint8_t prefix_len);
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder);
 

--- a/include/grpc/dp_grpc_api.h
+++ b/include/grpc/dp_grpc_api.h
@@ -90,28 +90,28 @@ struct dpgrpc_iface_id {
 };
 
 struct dpgrpc_prefix {
-	struct dpgrpc_address	addr;
+	struct dp_ip_address	addr;
 	uint8_t					length;
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
 };
 
 struct dpgrpc_route {
-	struct dpgrpc_address	pfx_addr;
+	struct dp_ip_address	pfx_addr;
 	uint8_t					pfx_length;
 	uint32_t				vni;
-	struct dpgrpc_address	trgt_addr;
+	struct dp_ip_address	trgt_addr;
 	uint32_t				trgt_vni;
 };
 
 struct dpgrpc_vip {
-	struct dpgrpc_address	addr;
+	struct dp_ip_address	addr;
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
 	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
 };
 
 struct dpgrpc_nat {
 	char					iface_id[DP_IFACE_ID_MAX_LEN];		// local only
-	struct dpgrpc_address	addr;
+	struct dp_ip_address	addr;
 	uint16_t				min_port;
 	uint16_t				max_port;
 	uint32_t				vni;								// neighnat or reply only
@@ -126,7 +126,7 @@ struct dpgrpc_lb_port {
 
 struct dpgrpc_lb {
 	char					lb_id[DP_LB_ID_MAX_LEN];			// request only
-	struct dpgrpc_address	addr;
+	struct dp_ip_address	addr;
 	uint32_t				vni;
 	struct dpgrpc_lb_port	lbports[DP_LB_MAX_PORTS];
 	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
@@ -138,7 +138,7 @@ struct dpgrpc_lb_id {
 
 struct dpgrpc_lb_target {
 	char					lb_id[DP_LB_ID_MAX_LEN];
-	struct dpgrpc_address	addr;
+	struct dp_ip_address	addr;
 };
 
 struct dpgrpc_fwrule {
@@ -203,8 +203,8 @@ struct dpgrpc_request {
 		struct dpgrpc_iface_id	get_nat;
 		struct dpgrpc_nat		add_neighnat;
 		struct dpgrpc_nat		del_neighnat;
-		struct dpgrpc_address	list_localnat;
-		struct dpgrpc_address	list_neighnat;
+		struct dp_ip_address	list_localnat;
+		struct dp_ip_address	list_neighnat;
 		struct dpgrpc_lb		add_lb;
 		struct dpgrpc_lb_id		del_lb;
 		struct dpgrpc_lb_id		get_lb;

--- a/include/grpc/dp_grpc_api.h
+++ b/include/grpc/dp_grpc_api.h
@@ -8,14 +8,11 @@
 #include "dp_firewall.h"
 #include "dp_iface.h"
 #include "dp_util.h"
-#include "dp_vnf.h"
 #include "monitoring/dp_monitoring.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define DP_VNF_IPV6_ADDR_SIZE	16
 
 #define DP_GRPC_VERSION_MAX_LEN	64
 
@@ -80,24 +77,16 @@ enum dpgrpc_capture_iface_type {
 struct dpgrpc_iface {
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
 	uint32_t				ip4_addr;
-	uint8_t					ip6_addr[DP_VNF_IPV6_ADDR_SIZE];
+	uint8_t					ip6_addr[DP_IPV6_ADDR_SIZE];
 	uint32_t				vni;
 	uint32_t				ip4_pxe_addr;						// request (create) only
 	char					pxe_str[DP_IFACE_PXE_MAX_LEN];		// request (create) only
 	char					pci_name[RTE_ETH_NAME_MAX_LEN];
-	uint8_t					ul_addr6[DP_VNF_IPV6_ADDR_SIZE];	// reply only
+	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
 };
 
 struct dpgrpc_iface_id {
 	char 					iface_id[DP_IFACE_ID_MAX_LEN];
-};
-
-struct dpgrpc_address {
-	uint32_t				ip_type;
-	union {
-		uint32_t			ipv4;
-		uint8_t				ipv6[DP_VNF_IPV6_ADDR_SIZE];
-	};
 };
 
 struct dpgrpc_prefix {
@@ -117,7 +106,7 @@ struct dpgrpc_route {
 struct dpgrpc_vip {
 	struct dpgrpc_address	addr;
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
-	uint8_t					ul_addr6[DP_VNF_IPV6_ADDR_SIZE];	// reply only
+	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
 };
 
 struct dpgrpc_nat {
@@ -126,8 +115,8 @@ struct dpgrpc_nat {
 	uint16_t				min_port;
 	uint16_t				max_port;
 	uint32_t				vni;								// neighnat or reply only
-	uint8_t					neigh_addr6[DP_VNF_IPV6_ADDR_SIZE];	// neighnat only
-	uint8_t					ul_addr6[DP_VNF_IPV6_ADDR_SIZE];	// reply only
+	uint8_t					neigh_addr6[DP_IPV6_ADDR_SIZE];	// neighnat only
+	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
 };
 
 struct dpgrpc_lb_port {
@@ -140,7 +129,7 @@ struct dpgrpc_lb {
 	struct dpgrpc_address	addr;
 	uint32_t				vni;
 	struct dpgrpc_lb_port	lbports[DP_LB_MAX_PORTS];
-	uint8_t					ul_addr6[DP_VNF_IPV6_ADDR_SIZE];	// reply only
+	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
 };
 
 struct dpgrpc_lb_id {
@@ -182,7 +171,7 @@ struct dpgrpc_capture_interface {
 };
 
 struct dpgrpc_capture {
-	uint8_t			dst_addr6[DP_VNF_IPV6_ADDR_SIZE];
+	uint8_t			dst_addr6[DP_IPV6_ADDR_SIZE];
 	uint8_t			interface_count;
 	uint16_t		udp_src_port;
 	uint16_t		udp_dst_port;
@@ -238,11 +227,11 @@ struct dpgrpc_request {
 
 struct dpgrpc_vf_pci {
 	char		name[RTE_ETH_NAME_MAX_LEN];
-	uint8_t		ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
+	uint8_t		ul_addr6[DP_IPV6_ADDR_SIZE];
 };
 
 struct dpgrpc_ul_addr {
-	uint8_t		addr6[DP_VNF_IPV6_ADDR_SIZE];
+	uint8_t		addr6[DP_IPV6_ADDR_SIZE];
 };
 
 struct dpgrpc_fwrule_info {

--- a/include/grpc/dp_grpc_conv.h
+++ b/include/grpc/dp_grpc_conv.h
@@ -34,6 +34,8 @@ namespace GrpcConv
 
 	bool Ipv4PrefixLenToMask(uint32_t prefix_length, uint32_t *mask);
 
+	bool Ipv6PrefixLenToMask(uint32_t prefix_length, uint8_t *mask);
+
 	void DpToGrpcInterface(const struct dpgrpc_iface *dp_iface, Interface *grpc_iface);
 
 	void DpToGrpcFwrule(const struct dp_fwall_rule *dp_rule, FirewallRule *grpc_rule);

--- a/include/grpc/dp_grpc_conv.h
+++ b/include/grpc/dp_grpc_conv.h
@@ -19,7 +19,7 @@ namespace GrpcConv
 	bool StrToIpv4(const std::string& str, uint32_t *dst);
 	bool StrToIpv6(const std::string& str, uint8_t *dst);
 
-	bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dpgrpc_address *dp_addr);
+	bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr);
 
 	bool GrpcToDpVniType(const VniType& grpc_type, enum dpgrpc_vni_type *dp_type);
 

--- a/include/protocols/dp_dhcpv6.h
+++ b/include/protocols/dp_dhcpv6.h
@@ -53,6 +53,7 @@
 #define DHCPV6_OPT_IAADDR		5
 #define DHCPV6_OPT_STATUS_CODE	13
 #define DHCPV6_OPT_RAPID_COMMIT	14
+#define DHCPV6_OPT_DNS			23
 #define DHCPV6_OPT_IA_PD		25
 #define DHCPV6_OPT_IAPREFIX		26
 
@@ -67,6 +68,12 @@ struct dhcpv6_option {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	uint8_t data[];
+};
+
+struct dhcpv6_opt_dns_servers {
+	uint16_t opt_code;
+	uint16_t opt_len;
+	struct in6_addr dns_server_addrs[]; // Array of IPv6 addresses
 };
 
 // client id can be of any type, this is the maximum size allowed

--- a/include/protocols/dp_icmpv6.h
+++ b/include/protocols/dp_icmpv6.h
@@ -1,0 +1,7 @@
+#ifndef __INCLUDE_DP_DHCPV6_H__
+#define __INCLUDE_DP_DHCPV6_H__
+
+#define	DP_ICMPV6_ECHO_REQUEST	128
+#define	DP_ICMPV6_ECHO_REPLY	129
+
+#endif

--- a/include/protocols/dp_icmpv6.h
+++ b/include/protocols/dp_icmpv6.h
@@ -1,5 +1,5 @@
-#ifndef __INCLUDE_DP_DHCPV6_H__
-#define __INCLUDE_DP_DHCPV6_H__
+#ifndef __INCLUDE_DP_ICMPV6_H__
+#define __INCLUDE_DP_ICMPV6_H__
 
 #define	DP_ICMPV6_ECHO_REQUEST	128
 #define	DP_ICMPV6_ECHO_REPLY	129

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -149,6 +149,7 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 {
 	struct flow_value *flow_val;
 	struct flow_key inverted_key;
+	struct dpgrpc_address pfx_ip;
 
 	flow_val = rte_zmalloc("flow_val", sizeof(struct flow_value), RTE_CACHE_LINE_SIZE);
 	if (!flow_val) {
@@ -161,12 +162,15 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	flow_val->timeout_value = flow_timeout;
 	flow_val->created_port_id = port->port_id;
 
+	memset(&pfx_ip, 0, sizeof(pfx_ip));
+	pfx_ip.ip_type = RTE_ETHER_TYPE_IPV4;
+	pfx_ip.ipv4 = key->l3_dst.ip4;
 	/* Target ip of the traffic is an alias prefix of a VM in the same VNI on this dp-service */
 	/* This will be an uni-directional traffic, which does not expect its corresponding reverse traffic */
 	/* Details can be found in https://github.com/ironcore-dev/dpservice/pull/341 */
 	if (offload_mode_enabled
 		&& !port->is_pf
-		&& dp_vnf_lbprefix_exists(DP_VNF_MATCH_ALL_PORT_IDS, key->vni, key->l3_dst.ip4, 32)
+		&& dp_vnf_lbprefix_exists(DP_VNF_MATCH_ALL_PORT_IDS, key->vni, &pfx_ip, 32)
 	)
 		flow_val->nf_info.nat_type = DP_FLOW_LB_TYPE_LOCAL_NEIGH_TRAFFIC;
 	else

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -302,8 +302,10 @@ int dp_cntrack_handle(struct rte_mbuf *m, struct dp_flow *df)
 	if (df->l4_type == IPPROTO_TCP && df->vnf_type != DP_VNF_TYPE_LB) {
 		if (df->l3_type == RTE_ETHER_TYPE_IPV4)
 			tcp_hdr = (struct rte_tcp_hdr *)(dp_get_ipv4_hdr(m) + 1);
-		else
+		else if (df->l3_type == RTE_ETHER_TYPE_IPV6)
 			tcp_hdr = (struct rte_tcp_hdr *)(dp_get_ipv6_hdr(m) + 1);
+		else
+			return DP_ERROR;
 		dp_cntrack_tcp_state(flow_val, tcp_hdr);
 		dp_cntrack_set_timeout_tcp_flow(m, flow_val, df);
 	}

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -149,7 +149,7 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 {
 	struct flow_value *flow_val;
 	struct flow_key inverted_key;
-	struct dpgrpc_address pfx_ip;
+	struct dp_ip_address pfx_ip;
 
 	flow_val = rte_zmalloc("flow_val", sizeof(struct flow_value), RTE_CACHE_LINE_SIZE);
 	if (!flow_val) {

--- a/src/dp_conf.c
+++ b/src/dp_conf.c
@@ -85,12 +85,12 @@ static int add_dhcpv6_dns(const char *str)
 		return DP_ERROR;
 	}
 
-	if (dhcpv6_dns.len + 16 > UINT8_MAX) {
+	if (dhcpv6_dns.len + DP_IPV6_ADDR_SIZE > UINT8_MAX) {
 		DP_EARLY_ERR("Too many DHCPv6 DNS addresses specified");
 		return DP_ERROR;
 	}
 
-	tmp = (uint8_t *)realloc(dhcpv6_dns.array, dhcpv6_dns.len + 16);
+	tmp = (uint8_t *)realloc(dhcpv6_dns.array, dhcpv6_dns.len + DP_IPV6_ADDR_SIZE);
 	if (!tmp) {
 		DP_EARLY_ERR("Cannot allocate memory for DHCPv6 DNS address");
 		return DP_ERROR;
@@ -98,7 +98,7 @@ static int add_dhcpv6_dns(const char *str)
 	dhcpv6_dns.array = tmp;
 
 	memcpy(&dhcpv6_dns.array[dhcpv6_dns.len], &addr6.s6_addr, sizeof(addr6.s6_addr));
-	dhcpv6_dns.len += 16;
+	dhcpv6_dns.len += DP_IPV6_ADDR_SIZE;
 	return DP_OK;
 }
 

--- a/src/dp_conf_opts.c
+++ b/src/dp_conf_opts.c
@@ -24,6 +24,7 @@ _OPT_SHOPT_MAX = 255,
 	OPT_VF_PATTERN,
 	OPT_DHCP_MTU,
 	OPT_DHCP_DNS,
+	OPT_DHCPV6_DNS,
 #ifdef ENABLE_VIRTSVC
 	OPT_UDP_VIRTSVC,
 #endif
@@ -58,6 +59,7 @@ static const struct option dp_conf_longopts[] = {
 	{ "vf-pattern", 1, 0, OPT_VF_PATTERN },
 	{ "dhcp-mtu", 1, 0, OPT_DHCP_MTU },
 	{ "dhcp-dns", 1, 0, OPT_DHCP_DNS },
+	{ "dhcpv6-dns", 1, 0, OPT_DHCPV6_DNS },
 #ifdef ENABLE_VIRTSVC
 	{ "udp-virtsvc", 1, 0, OPT_UDP_VIRTSVC },
 #endif
@@ -203,6 +205,7 @@ int dp_conf_get_flow_timeout(void)
 static void dp_argparse_version(void);
 static int dp_argparse_opt_ipv6(const char *arg);
 static int dp_argparse_opt_dhcp_dns(const char *arg);
+static int dp_argparse_opt_dhcpv6_dns(const char *arg);
 #ifdef ENABLE_VIRTSVC
 static int dp_argparse_opt_udp_virtsvc(const char *arg);
 #endif
@@ -222,6 +225,7 @@ static inline void dp_argparse_help(const char *progname, FILE *outfile)
 		"     --vf-pattern=PATTERN               virtual interface name pattern (e.g. 'eth1vf')\n"
 		"     --dhcp-mtu=SIZE                    set the mtu field in DHCP responses (68 - 1500)\n"
 		"     --dhcp-dns=IPv4                    set the domain name server field in DHCP responses (can be used multiple times)\n"
+		"     --dhcpv6-dns=ADDR6                 set the domain name server field in DHCPv6 responses (can be used multiple times)\n"
 #ifdef ENABLE_VIRTSVC
 		"     --udp-virtsvc=IPv4,port,IPv6,port  map a VM-accessible IPv4 endpoint to an outside IPv6 UDP service\n"
 #endif
@@ -262,6 +266,8 @@ static int dp_conf_parse_arg(int opt, const char *arg)
 		return dp_argparse_int(arg, &dhcp_mtu, 68, 1500);
 	case OPT_DHCP_DNS:
 		return dp_argparse_opt_dhcp_dns(arg);
+	case OPT_DHCPV6_DNS:
+		return dp_argparse_opt_dhcpv6_dns(arg);
 #ifdef ENABLE_VIRTSVC
 	case OPT_UDP_VIRTSVC:
 		return dp_argparse_opt_udp_virtsvc(arg);

--- a/src/dp_firewall.c
+++ b/src/dp_firewall.c
@@ -74,10 +74,10 @@ int dp_list_firewall_rules(const struct dp_port *port, struct dp_grpc_responder 
 	return DP_GRPC_OK;
 }
 
-static __rte_always_inline void dp_apply_ipv6_mask(const uint8_t *addr, const uint8_t *mask, uint8_t *result) {
-    for (int i = 0; i < DP_IPV6_ADDR_SIZE; i++) {
-        result[i] = addr[i] & mask[i];
-    }
+static __rte_always_inline void dp_apply_ipv6_mask(const uint8_t *addr, const uint8_t *mask, uint8_t *result)
+{
+	for (int i = 0; i < DP_IPV6_ADDR_SIZE; i++)
+		result[i] = addr[i] & mask[i];
 }
 
 static __rte_always_inline bool dp_is_rule_matching(const struct dp_fwall_rule *rule,
@@ -144,7 +144,7 @@ static __rte_always_inline bool dp_is_rule_matching(const struct dp_fwall_rule *
 		return false;
 	}
 
-	return ( is_ip_match &&
+	return (is_ip_match &&
 		((src_port_lower == DP_FWALL_MATCH_ANY_PORT) ||
 		 (src_port >= src_port_lower && src_port <= src_port_upper)) &&
 		((dst_port_lower == DP_FWALL_MATCH_ANY_PORT) ||

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -112,6 +112,11 @@ static __rte_always_inline int dp_build_icmp_flow_key(const struct dp_flow *df, 
 static __rte_always_inline void dp_mark_vnf_type(struct dp_flow *df, const struct dp_port *port, struct flow_key *key)
 {
 	struct snat_data *s_data;
+	struct dpgrpc_address pfx_ip;
+
+	memset(&pfx_ip, 0, sizeof(pfx_ip));
+	pfx_ip.ip_type = RTE_ETHER_TYPE_IPV4;
+	pfx_ip.ipv4 = key->l3_src.ip4;
 
 	if (port->is_pf) {
 		if (df->vnf_type == DP_VNF_TYPE_NAT || df->vnf_type == DP_VNF_TYPE_LB_ALIAS_PFX)
@@ -122,7 +127,7 @@ static __rte_always_inline void dp_mark_vnf_type(struct dp_flow *df, const struc
 		s_data = dp_get_iface_snat_data(key->l3_src.ip4, key->vni);
 		if (s_data && s_data->nat_ip != 0)
 			key->vnf_type = DP_VNF_TYPE_NAT;
-		else if (dp_vnf_lbprefix_exists(port->port_id, key->vni, key->l3_src.ip4, 32))
+		else if (dp_vnf_lbprefix_exists(port->port_id, key->vni, &pfx_ip, 32))
 			key->vnf_type = DP_VNF_TYPE_LB_ALIAS_PFX;
 		else
 			key->vnf_type = DP_VNF_TYPE_UNDEFINED;

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -152,11 +152,12 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 	const struct dp_port *port = dp_get_in_port(m);
 	int ret = DP_OK;
 
-	memset(key, 0, sizeof(struct flow_key));
 	key->l3_type = df->l3_type;
 
 	switch (df->l3_type) {
 	case RTE_ETHER_TYPE_IPV4:
+		memset(key->l3_src.ip6, 0, sizeof(key->l3_src.ip6));
+		memset(key->l3_dst.ip6, 0, sizeof(key->l3_dst.ip6));
 		key->l3_dst.ip4 = ntohl(df->dst.dst_addr);
 		key->l3_src.ip4 = ntohl(df->src.src_addr);
 		break;

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -195,7 +195,7 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 	case IPPROTO_ICMPV6:
 		key->port_dst = ntohs(df->l4_info.icmp_field.icmp_identifier);
 		key->src.type_src = df->l4_info.icmp_field.icmp_type;
-		return DP_OK;
+		break;
 	default:
 		key->port_dst = 0;
 		key->src.port_src = 0;

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -138,8 +138,7 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 	memset(key, 0, sizeof(struct flow_key));
 	key->l3_type = df->l3_type;
 
-	switch (df->l3_type)
-	{
+	switch (df->l3_type) {
 	case RTE_ETHER_TYPE_IPV4:
 		key->l3_dst.ip4 = ntohl(df->dst.dst_addr);
 		key->l3_src.ip4 = ntohl(df->src.src_addr);

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -123,6 +123,9 @@ static __rte_always_inline void dp_mark_vnf_type(struct dp_flow *df, const struc
 			key->vnf_type = df->vnf_type;
 		else
 			key->vnf_type = DP_VNF_TYPE_UNDEFINED;
+	} else if (key->l3_type == RTE_ETHER_TYPE_IPV6) {
+		if (dp_is_ip6_in_nat64_range(key->l3_dst.ip6))
+			key->vnf_type = DP_VNF_TYPE_NAT;
 	} else {
 		s_data = dp_get_iface_snat_data(key->l3_src.ip4, key->vni);
 		if (s_data && s_data->nat_ip != 0)

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -317,7 +317,7 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint8_t route_key[RTE_RIB6_IPV6_ADDR_SIZE])
+										  uint8_t route_key[DP_IPV6_ADDR_SIZE])
 {
 	struct rte_rib6_node *node;
 	struct rte_rib6 *root;

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -316,7 +316,8 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
-										  struct dp_iface_route *route)
+										  struct dp_iface_route *route,
+										  uint8_t route_key[RTE_RIB6_IPV6_ADDR_SIZE])
 {
 	struct rte_rib6_node *node;
 	struct rte_rib6 *root;
@@ -343,6 +344,9 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 
 	if (dst_port->is_pf)
 		*route = *(struct dp_iface_route *)rte_rib6_get_ext(node);
+
+	if (DP_FAILED(rte_rib6_get_ip(node, route_key)))
+		return NULL;
 
 	return dst_port;
 }

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -315,7 +315,7 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
-										  const struct rte_ipv6_hdr *ipv6_hdr,
+										  const struct dp_flow *df,
 										  struct dp_iface_route *route)
 {
 	struct rte_rib6_node *node;
@@ -330,7 +330,7 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 	if (!root)
 		return NULL;
 
-	node = rte_rib6_lookup(root, ipv6_hdr->dst_addr);
+	node = rte_rib6_lookup(root, df->dst.dst_addr6);
 	if (!node)
 		return NULL;
 

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -354,7 +354,6 @@ int dp_nat_chg_ipv6_to_ipv4_hdr(struct dp_flow *df, struct rte_mbuf *m, uint32_t
 	ipv4_hdr->dst_addr = *dest_ip;
 	ipv4_hdr->hdr_checksum = 0;
 
-	m->tx_offload = 0;
 	m->packet_type = (m->packet_type & ~RTE_PTYPE_L3_MASK) | RTE_PTYPE_L3_IPV4;
 	m->ol_flags |= RTE_MBUF_F_TX_IPV4;
 	m->ol_flags |= RTE_MBUF_F_TX_IP_CKSUM;

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -532,9 +532,9 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 	struct dp_port *created_port;
 	int ret;
 
-	portoverload_tbl_key.nat_ip = cntrack->flow_key[DP_FLOW_DIR_REPLY].ip_dst;
+	portoverload_tbl_key.nat_ip = cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4;
 	portoverload_tbl_key.nat_port = cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst;
-	portoverload_tbl_key.dst_ip = cntrack->flow_key[DP_FLOW_DIR_ORG].ip_dst;
+	portoverload_tbl_key.dst_ip = cntrack->flow_key[DP_FLOW_DIR_ORG].l3_dst.ip4;
 	portoverload_tbl_key.dst_port = cntrack->flow_key[DP_FLOW_DIR_ORG].port_dst;
 	portoverload_tbl_key.l4_type = cntrack->flow_key[DP_FLOW_DIR_ORG].proto;
 
@@ -543,7 +543,7 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 	if (DP_FAILED(ret) && ret != -ENOENT)
 		return ret;
 
-	portmap_key.iface_src_ip = cntrack->flow_key[DP_FLOW_DIR_ORG].ip_src;
+	portmap_key.iface_src_ip = cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4;
 	portmap_key.iface_src_port = cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src;
 	portmap_key.vni = cntrack->nf_info.vni;
 

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -300,18 +300,18 @@ void dp_nat_chg_ip(struct dp_flow *df, struct rte_ipv4_hdr *ipv4_hdr,
 static void dp_calculate_icmp_checksum(struct rte_icmp_hdr *icmp_hdr, size_t icmp_len)
 {
 	uint32_t sum = 0;
+	uint16_t word;
 	uint8_t *ptr = (uint8_t *)icmp_hdr;
 
 	icmp_hdr->icmp_cksum = 0;
 
 	for (size_t i = 0; i < icmp_len; i += 2) {
-		uint16_t word = (uint16_t)((uint16_t)ptr[i] | ((uint16_t)ptr[i + 1] << 8));
+		word = (uint16_t)((uint16_t)ptr[i] | ((uint16_t)ptr[i + 1] << 8));
 		sum += word;
 	}
 
-	while (sum >> 16) {
+	while (sum >> 16)
 		sum = (sum & 0xFFFF) + (sum >> 16);
-	}
 
 	icmp_hdr->icmp_cksum = ~((uint16_t)sum);
 }
@@ -394,7 +394,6 @@ int dp_nat_chg_ipv6_to_ipv4_hdr(struct dp_flow *df, struct rte_mbuf *m, uint32_t
 	break;
 	default:
 		return DP_ERROR;
-	break;
 	}
 
 	return DP_OK;
@@ -473,7 +472,6 @@ int dp_nat_chg_ipv4_to_ipv6_hdr(struct dp_flow *df, struct rte_mbuf *m, uint8_t 
 		break;
 	default:
 		return DP_ERROR;
-		break;
 	}
 	return DP_OK;
 }

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -28,7 +28,7 @@ void dp_vnf_free(void)
 }
 
 int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type type,
-			   uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len)
+			   uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix, uint8_t prefix_len)
 {
 	struct dp_vnf *vnf;
 	int ret;
@@ -38,29 +38,29 @@ int dp_add_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE], enum dp_vnf_type t
 
 	vnf = rte_zmalloc("vnf_handle_mapping", sizeof(struct dp_vnf), RTE_CACHE_LINE_SIZE);
 	if (!vnf) {
-		if (pfx_ip->ip_type == RTE_ETHER_TYPE_IPV4)
+		if (prefix->ip_type == RTE_ETHER_TYPE_IPV4)
 			DPS_LOG_WARNING("VNF handle allocation failed", DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
-							DP_LOG_PORTID(port_id), DP_LOG_IPV4(pfx_ip->ipv4), DP_LOG_PREFLEN(prefix_len));
+							DP_LOG_PORTID(port_id), DP_LOG_IPV4(prefix->ipv4), DP_LOG_PREFLEN(prefix_len));
 		else
 			DPS_LOG_WARNING("VNF handle allocation failed", DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
-							DP_LOG_PORTID(port_id), DP_LOG_IPV6(pfx_ip->ipv6), DP_LOG_PREFLEN(prefix_len));
+							DP_LOG_PORTID(port_id), DP_LOG_IPV6(prefix->ipv6), DP_LOG_PREFLEN(prefix_len));
 		return DP_ERROR;
 	}
 
 	vnf->type = type;
 	vnf->vni = vni;
 	vnf->port_id = port_id;
-	vnf->alias_pfx.ol = *pfx_ip;
+	vnf->alias_pfx.ol = *prefix;
 	vnf->alias_pfx.length = prefix_len;
 
 	ret = rte_hash_add_key_data(vnf_handle_tbl, ul_addr6, vnf);
 	if (DP_FAILED(ret)) {
-		if (pfx_ip->ip_type == RTE_ETHER_TYPE_IPV4)
+		if (prefix->ip_type == RTE_ETHER_TYPE_IPV4)
 			DPS_LOG_WARNING("VNF handle addition failed", DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
-							DP_LOG_PORTID(port_id), DP_LOG_IPV4(pfx_ip->ipv4), DP_LOG_PREFLEN(prefix_len), DP_LOG_RET(ret));
+							DP_LOG_PORTID(port_id), DP_LOG_IPV4(prefix->ipv4), DP_LOG_PREFLEN(prefix_len), DP_LOG_RET(ret));
 		else
 			DPS_LOG_WARNING("VNF handle addition failed", DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
-							DP_LOG_PORTID(port_id), DP_LOG_IPV6(pfx_ip->ipv6), DP_LOG_PREFLEN(prefix_len), DP_LOG_RET(ret));
+							DP_LOG_PORTID(port_id), DP_LOG_IPV6(prefix->ipv6), DP_LOG_PREFLEN(prefix_len), DP_LOG_RET(ret));
 		rte_free(vnf);
 		return DP_ERROR;
 	}
@@ -102,17 +102,18 @@ int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE])
 
 static __rte_always_inline bool dp_vnf_match(const struct dp_vnf *vnf, enum dp_vnf_type type,
 											 uint16_t port_id, uint32_t vni,
-											 struct dp_ip_address *pfx_ip, uint8_t prefix_len)
+											 struct dp_ip_address *prefix, uint8_t prefix_len)
 {
 	return (port_id == DP_VNF_MATCH_ALL_PORT_IDS || vnf->port_id == port_id)
 		&& vnf->vni == vni
-		&& ((vnf->alias_pfx.ol.ip_type == RTE_ETHER_TYPE_IPV4 && vnf->alias_pfx.ol.ipv4 == pfx_ip->ipv4)
-			|| (vnf->alias_pfx.ol.ip_type == RTE_ETHER_TYPE_IPV6 && rte_rib6_is_equal(vnf->alias_pfx.ol.ipv6, pfx_ip->ipv6)))
-		&& vnf->alias_pfx.length == prefix_len
-		&& vnf->type == type;
+		&& vnf->type == type
+		&& vnf->alias_pfx.ol.ip_type == prefix->ip_type
+		&& ((vnf->alias_pfx.ol.ip_type == RTE_ETHER_TYPE_IPV4 && vnf->alias_pfx.ol.ipv4 == prefix->ipv4)
+			|| (vnf->alias_pfx.ol.ip_type == RTE_ETHER_TYPE_IPV6 && rte_rib6_is_equal(vnf->alias_pfx.ol.ipv6, prefix->ipv6)))
+		&& vnf->alias_pfx.length == prefix_len;
 }
 
-bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len)
+bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix_ip, uint8_t prefix_len)
 {
 	struct dp_vnf *vnf;
 	uint32_t iter = 0;
@@ -121,21 +122,21 @@ bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address
 
 	while ((ret = rte_hash_iterate(vnf_handle_tbl, &key, (void **)&vnf, &iter)) != -ENOENT) {
 		if (DP_FAILED(ret)) {
-			if (pfx_ip->ip_type == RTE_ETHER_TYPE_IPV4)
+			if (prefix_ip->ip_type == RTE_ETHER_TYPE_IPV4)
 				DPS_LOG_WARNING("Iterating VNF table failed", DP_LOG_RET(ret), DP_LOG_PORTID(port_id),
-								DP_LOG_VNI(vni), DP_LOG_IPV4(pfx_ip->ipv4), DP_LOG_PREFLEN(prefix_len));
+								DP_LOG_VNI(vni), DP_LOG_IPV4(prefix_ip->ipv4), DP_LOG_PREFLEN(prefix_len));
 			else
 				DPS_LOG_WARNING("Iterating VNF table failed", DP_LOG_RET(ret), DP_LOG_PORTID(port_id),
-								DP_LOG_VNI(vni), DP_LOG_IPV6(pfx_ip->ipv6), DP_LOG_PREFLEN(prefix_len));
+								DP_LOG_VNI(vni), DP_LOG_IPV6(prefix_ip->ipv6), DP_LOG_PREFLEN(prefix_len));
 			return false;
 		}
-		if (dp_vnf_match(vnf, DP_VNF_TYPE_LB_ALIAS_PFX, port_id, vni, pfx_ip, prefix_len))
+		if (dp_vnf_match(vnf, DP_VNF_TYPE_LB_ALIAS_PFX, port_id, vni, prefix_ip, prefix_len))
 			return true;
 	}
 	return false;
 }
 
-int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dp_ip_address *pfx_ip, uint8_t prefix_len)
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix_ip, uint8_t prefix_len)
 {
 	struct dp_vnf *vnf;
 	uint32_t iter = 0;
@@ -147,7 +148,7 @@ int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, s
 		if (DP_FAILED(ret))
 			return DP_GRPC_ERR_ITERATOR;
 
-		if (dp_vnf_match(vnf, type, port_id, vni, pfx_ip, prefix_len)) {
+		if (dp_vnf_match(vnf, type, port_id, vni, prefix_ip, prefix_len)) {
 			delete_count++;
 			rte_free(vnf);
 			// this seems unsafe (deletion during traversal), but should be convered by having the table big enough
@@ -155,12 +156,12 @@ int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, s
 			// should only ever fail on no-entry or invalid-arguments, but both are covered by rte_hash_iterate()
 			ret = rte_hash_del_key(vnf_handle_tbl, key);
 			if (DP_FAILED(ret)) {
-				if (pfx_ip->ip_type == RTE_ETHER_TYPE_IPV4)
+				if (prefix_ip->ip_type == RTE_ETHER_TYPE_IPV4)
 					DPS_LOG_ERR("Cannot delete VNF key", DP_LOG_RET(ret), DP_LOG_VNF_TYPE(type), DP_LOG_PORTID(port_id),
-								DP_LOG_VNI(vni), DP_LOG_IPV4(pfx_ip->ipv4), DP_LOG_PREFLEN(prefix_len));
+								DP_LOG_VNI(vni), DP_LOG_IPV4(prefix_ip->ipv4), DP_LOG_PREFLEN(prefix_len));
 				else
 					DPS_LOG_ERR("Cannot delete VNF key", DP_LOG_RET(ret), DP_LOG_VNF_TYPE(type), DP_LOG_PORTID(port_id),
-								DP_LOG_VNI(vni), DP_LOG_IPV6(pfx_ip->ipv6), DP_LOG_PREFLEN(prefix_len));
+								DP_LOG_VNI(vni), DP_LOG_IPV6(prefix_ip->ipv6), DP_LOG_PREFLEN(prefix_len));
 			}
 		}
 	}

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -756,11 +756,14 @@ void GetLoadBalancerCall::ParseReply(struct dpgrpc_reply* reply)
 
 	reply_.set_vni(reply->lb.vni);
 	lb_ip = new IpAddress();
-	lb_ip->set_address(GrpcConv::Ipv4ToStr(reply->lb.addr.ipv4));
-	if (reply->lb.addr.ip_type == RTE_ETHER_TYPE_IPV4)
+	if (reply->lb.addr.ip_type == RTE_ETHER_TYPE_IPV4) {
 		lb_ip->set_ipver(IpVersion::IPV4);
-	else
+		lb_ip->set_address(GrpcConv::Ipv4ToStr(reply->lb.addr.ipv4));
+	} else {
 		lb_ip->set_ipver(IpVersion::IPV6);
+		inet_ntop(AF_INET6, reply->lb.addr.ipv6, strbuf, sizeof(strbuf));
+		lb_ip->set_address(strbuf);
+	}
 	reply_.set_allocated_loadbalanced_ip(lb_ip);
 	for (int i = 0; i < DP_LB_MAX_PORTS; ++i) {
 		if (reply->lb.lbports[i].port == 0)

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -370,11 +370,15 @@ void ListPrefixesCall::ParseReply(struct dpgrpc_reply* reply)
 		if (route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV4) {
 			pfx_ip->set_address(GrpcConv::Ipv4ToStr(route->pfx_addr.ipv4));
 			pfx_ip->set_ipver(IpVersion::IPV4);
-			pfx->set_length(route->pfx_length);
-			inet_ntop(AF_INET6, route->trgt_addr.ipv6, strbuf, sizeof(strbuf));
-			pfx->set_underlay_route(strbuf);
+		} else if (route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV6) {
+			inet_ntop(AF_INET6, route->pfx_addr.ipv6, strbuf, sizeof(strbuf));
+			pfx_ip->set_address(strbuf);
+			pfx_ip->set_ipver(IpVersion::IPV6);
 		} else
-			assert(route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV4);
+			assert(route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV4 || route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV6);
+		pfx->set_length(route->pfx_length);
+		inet_ntop(AF_INET6, route->trgt_addr.ipv6, strbuf, sizeof(strbuf));
+		pfx->set_underlay_route(strbuf);
 		pfx->set_allocated_ip(pfx_ip);
 	}
 }
@@ -899,8 +903,15 @@ void ListLoadBalancerPrefixesCall::ParseReply(struct dpgrpc_reply* reply)
 			pfx->set_length(route->pfx_length);
 			inet_ntop(AF_INET6, route->trgt_addr.ipv6, strbuf, sizeof(strbuf));
 			pfx->set_underlay_route(strbuf);
+		} else if (route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV6) {
+			inet_ntop(AF_INET6, route->pfx_addr.ipv6, strbuf, sizeof(strbuf));
+			pfx_ip->set_address(strbuf);
+			pfx_ip->set_ipver(IpVersion::IPV6);
 		} else
-			assert(route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV4);
+			assert(route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV4 || route->pfx_addr.ip_type == RTE_ETHER_TYPE_IPV6);
+		pfx->set_length(route->pfx_length);
+		inet_ntop(AF_INET6, route->trgt_addr.ipv6, strbuf, sizeof(strbuf));
+		pfx->set_underlay_route(strbuf);
 		pfx->set_allocated_ip(pfx_ip);
 	}
 }

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -197,7 +197,6 @@ uint32_t DpIpv6MaskToPrefixLen(const uint8_t *mask)
 	uint64_t high = rte_be_to_cpu_64(*((const uint64_t *)(mask)));
 	uint64_t low = rte_be_to_cpu_64(*((const uint64_t *)(mask + 8)));
 
-
 	return __builtin_popcountll(high) + __builtin_popcountll(low);
 }
 
@@ -222,6 +221,8 @@ void SetupIpAndPrefix(const struct dp_fwall_rule *dp_rule, IpAddress* ip, Prefix
 
 void DpToGrpcFwrule(const struct dp_fwall_rule *dp_rule, FirewallRule *grpc_rule)
 {
+	constexpr bool IS_SRC = true;
+	constexpr bool IS_DST = false;
 	IcmpFilter *icmp_filter;
 	ProtocolFilter *filter;
 	TcpFilter *tcp_filter;
@@ -230,7 +231,6 @@ void DpToGrpcFwrule(const struct dp_fwall_rule *dp_rule, FirewallRule *grpc_rule
 	Prefix *dst_pfx;
 	IpAddress *src_ip;
 	IpAddress *dst_ip;
-	bool is_src = true;
 
 	grpc_rule->set_id(dp_rule->rule_id);
 	grpc_rule->set_priority(dp_rule->priority);
@@ -246,12 +246,12 @@ void DpToGrpcFwrule(const struct dp_fwall_rule *dp_rule, FirewallRule *grpc_rule
 
 	src_ip = new IpAddress();
 	src_pfx = new Prefix();
-	SetupIpAndPrefix(dp_rule, src_ip, src_pfx, is_src);
+	SetupIpAndPrefix(dp_rule, src_ip, src_pfx, IS_SRC);
 	grpc_rule->set_allocated_source_prefix(src_pfx);
 
 	dst_ip = new IpAddress();
 	dst_pfx = new Prefix();
-	SetupIpAndPrefix(dp_rule, dst_ip, dst_pfx, !is_src);
+	SetupIpAndPrefix(dp_rule, dst_ip, dst_pfx, IS_DST);
 	grpc_rule->set_allocated_destination_prefix(dst_pfx);
 
 	filter = new ProtocolFilter();

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -44,7 +44,7 @@ bool StrToIpv6(const std::string& str, uint8_t *dst)
 	return inet_pton(AF_INET6, str.c_str(), dst) == 1;
 }
 
-bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dpgrpc_address *dp_addr)
+bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr)
 {
 	switch (grpc_addr.ipver()) {
 	case IpVersion::IPV4:

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -171,7 +171,7 @@ bool Ipv6PrefixLenToMask(uint32_t prefix_length, uint8_t *mask) {
 	memset(mask, 0, DP_IPV6_ADDR_SIZE); // Initialize mask to all zeros
 
 	for (uint32_t i = 0; i < prefix_length; i++) {
-		mask[i / 8] |= (1 << (7 - (i % 8)));
+		mask[i / 8] |= (uint8_t)(1 << (7 - (i % 8)));
 	}
 
 	return true;

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -73,7 +73,7 @@ static int dp_process_create_lb(struct dp_grpc_responder *responder)
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
 	int ret = DP_GRPC_OK;
 
-	if (request->addr.ip_type == RTE_ETHER_TYPE_IPV4) {
+	if (request->addr.ip_type == RTE_ETHER_TYPE_IPV4 || request->addr.ip_type == RTE_ETHER_TYPE_IPV6) {
 		if (DP_FAILED(dp_create_vnf_route(ul_addr6, DP_VNF_TYPE_LB, request->vni, dp_get_pf0(), 0, 0))) {
 			ret = DP_GRPC_ERR_VNF_INSERT;
 			goto err;

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -633,6 +633,9 @@ static int dp_process_create_nat(struct dp_grpc_responder *responder)
 		ret = dp_set_dnat_ip(request->addr.ipv4, 0, iface_vni);
 		if (DP_FAILED(ret) && ret != DP_GRPC_ERR_DNAT_EXISTS)
 			goto err_dnat;
+		port->iface.nat_ip = request->addr.ipv4;
+		port->iface.nat_port_range[0] = request->min_port;
+		port->iface.nat_port_range[1] = request->max_port;
 		rte_memcpy(reply->addr6, ul_addr6, sizeof(reply->addr6));
 	} else {
 		ret = DP_GRPC_ERR_BAD_IPVER;
@@ -674,6 +677,9 @@ static int dp_process_delete_nat(struct dp_grpc_responder *responder)
 	reply->addr.ip_type = RTE_ETHER_TYPE_IPV4;
 	reply->addr.ipv4 = s_data->nat_ip;
 	dp_del_vip_from_dnat(s_data->nat_ip, iface_vni);
+	port->iface.nat_ip = 0;
+	port->iface.nat_port_range[0] = 0;
+	port->iface.nat_port_range[1] = 0;
 	dp_remove_nat_flows(port->port_id, DP_FLOW_NAT_TYPE_NETWORK_LOCAL);
 	return dp_del_iface_nat_ip(iface_ip, iface_vni);
 }

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -69,12 +69,13 @@ static int dp_process_create_lb(struct dp_grpc_responder *responder)
 {
 	struct dpgrpc_lb *request = &responder->request.add_lb;
 	struct dpgrpc_ul_addr *reply = dp_grpc_single_reply(responder);
-	struct dp_ip_address pfx_ip;
+	struct dp_ip_address pfx_ip = {
+		.ip_type = request->addr.ip_type
+	};
 
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
 	int ret = DP_GRPC_OK;
 
-	memset(&pfx_ip, 0, sizeof(pfx_ip));
 	if (request->addr.ip_type == RTE_ETHER_TYPE_IPV4 || request->addr.ip_type == RTE_ETHER_TYPE_IPV6) {
 		if (DP_FAILED(dp_create_vnf_route(ul_addr6, DP_VNF_TYPE_LB, request->vni, dp_get_pf0(), &pfx_ip, 0))) {
 			ret = DP_GRPC_ERR_VNF_INSERT;
@@ -243,7 +244,9 @@ static int dp_process_create_vip(struct dp_grpc_responder *responder)
 	struct dpgrpc_ul_addr *reply = dp_grpc_single_reply(responder);
 
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
-	struct dp_ip_address pfx_ip;
+	struct dp_ip_address pfx_ip = {
+		.ip_type = request->addr.ip_type
+	};
 	uint32_t iface_ip, iface_vni;
 	struct dp_port *port;
 	uint32_t vip;
@@ -255,7 +258,6 @@ static int dp_process_create_vip(struct dp_grpc_responder *responder)
 		goto err;
 	}
 
-	memset(&pfx_ip, 0, sizeof(pfx_ip));
 	if (request->addr.ip_type == RTE_ETHER_TYPE_IPV4) {
 		iface_ip = port->iface.cfg.own_ip;
 		iface_vni = port->iface.vni;
@@ -453,10 +455,11 @@ static int dp_process_create_interface(struct dp_grpc_responder *responder)
 
 	struct dp_port *port;
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
-	struct dp_ip_address pfx_ip;
+	struct dp_ip_address pfx_ip = {
+		.ip_type = RTE_ETHER_TYPE_IPV4 // Just pick a random valid type, not relevant for this VNF
+	};
 	int ret = DP_GRPC_OK;
 
-	memset(&pfx_ip, 0, sizeof(pfx_ip));
 	port = dp_get_port_by_name(request->pci_name);
 	if (!port) {
 		ret = DP_GRPC_ERR_NOT_FOUND;
@@ -605,7 +608,9 @@ static int dp_process_create_nat(struct dp_grpc_responder *responder)
 	struct dpgrpc_ul_addr *reply = dp_grpc_single_reply(responder);
 
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
-	struct dp_ip_address pfx_ip;
+	struct dp_ip_address pfx_ip = {
+		.ip_type = request->addr.ip_type
+	};
 	struct dp_port *port;
 	uint32_t iface_ip, iface_vni;
 	int ret;
@@ -616,7 +621,6 @@ static int dp_process_create_nat(struct dp_grpc_responder *responder)
 		goto err;
 	}
 
-	memset(&pfx_ip, 0, sizeof(pfx_ip));
 	if (request->addr.ip_type == RTE_ETHER_TYPE_IPV4) {
 		iface_ip = port->iface.cfg.own_ip;
 		iface_vni = port->iface.vni;

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -59,7 +59,7 @@ static __rte_always_inline void dp_generate_underlay_ipv6(uint8_t route[DP_VNF_I
 
 static int dp_create_vnf_route(uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE] /* out */,
 							   enum dp_vnf_type type, uint32_t vni, const struct dp_port *port,
-							   struct dpgrpc_address *pfx_ip, uint8_t prefix_len)
+							   struct dp_ip_address *pfx_ip, uint8_t prefix_len)
 {
 	dp_generate_underlay_ipv6(ul_addr6);
 	return dp_add_vnf(ul_addr6, type, port->port_id, vni, pfx_ip, prefix_len);
@@ -69,7 +69,7 @@ static int dp_process_create_lb(struct dp_grpc_responder *responder)
 {
 	struct dpgrpc_lb *request = &responder->request.add_lb;
 	struct dpgrpc_ul_addr *reply = dp_grpc_single_reply(responder);
-	struct dpgrpc_address pfx_ip;
+	struct dp_ip_address pfx_ip;
 
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
 	int ret = DP_GRPC_OK;
@@ -243,7 +243,7 @@ static int dp_process_create_vip(struct dp_grpc_responder *responder)
 	struct dpgrpc_ul_addr *reply = dp_grpc_single_reply(responder);
 
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
-	struct dpgrpc_address pfx_ip;
+	struct dp_ip_address pfx_ip;
 	uint32_t iface_ip, iface_vni;
 	struct dp_port *port;
 	uint32_t vip;
@@ -453,7 +453,7 @@ static int dp_process_create_interface(struct dp_grpc_responder *responder)
 
 	struct dp_port *port;
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
-	struct dpgrpc_address pfx_ip;
+	struct dp_ip_address pfx_ip;
 	int ret = DP_GRPC_OK;
 
 	memset(&pfx_ip, 0, sizeof(pfx_ip));
@@ -605,7 +605,7 @@ static int dp_process_create_nat(struct dp_grpc_responder *responder)
 	struct dpgrpc_ul_addr *reply = dp_grpc_single_reply(responder);
 
 	uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE];
-	struct dpgrpc_address pfx_ip;
+	struct dp_ip_address pfx_ip;
 	struct dp_port *port;
 	uint32_t iface_ip, iface_vni;
 	int ret;
@@ -832,7 +832,7 @@ static int dp_process_list_prefixes(struct dp_grpc_responder *responder)
 
 static int dp_process_list_localnats(struct dp_grpc_responder *responder)
 {
-	struct dpgrpc_address *request = &responder->request.list_localnat;
+	struct dp_ip_address *request = &responder->request.list_localnat;
 
 	if (request->ip_type == RTE_ETHER_TYPE_IPV4)
 		return dp_list_nat_local_entries(request->ipv4, responder);
@@ -842,7 +842,7 @@ static int dp_process_list_localnats(struct dp_grpc_responder *responder)
 
 static int dp_process_list_neighnats(struct dp_grpc_responder *responder)
 {
-	struct dpgrpc_address *request = &responder->request.list_neighnat;
+	struct dp_ip_address *request = &responder->request.list_neighnat;
 
 	if (request->ip_type == RTE_ETHER_TYPE_IPV4)
 		return dp_list_nat_neigh_entries(request->ipv4, responder);

--- a/src/nodes/cls_node.c
+++ b/src/nodes/cls_node.c
@@ -28,7 +28,6 @@
 	NEXT(CLS_NEXT_IPV6_ND, "ipv6_nd") \
 	NEXT(CLS_NEXT_CONNTRACK, "conntrack") \
 	NEXT(CLS_NEXT_IPIP_DECAP, "ipip_decap") \
-	NEXT(CLS_NEXT_IPV6_LOOKUP, "ipv6_lookup") \
 	VIRTSVC_NEXT(NEXT)
 
 #ifdef ENABLE_VIRTSVC
@@ -191,7 +190,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 				break;
 			default:
 				df->l3_type = ntohs(ether_hdr->ether_type);
-				return CLS_NEXT_IPV6_LOOKUP;
+				return CLS_NEXT_CONNTRACK;
 			}
 			df->tun_info.l3_type = ntohs(ether_hdr->ether_type);
 			dp_extract_underlay_header(df, ipv6_hdr);
@@ -200,7 +199,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			if (is_ipv6_nd(ipv6_hdr))
 				return CLS_NEXT_IPV6_ND;
 			df->l3_type = ntohs(ether_hdr->ether_type);
-			return CLS_NEXT_IPV6_LOOKUP;
+			return CLS_NEXT_CONNTRACK;
 		}
 	}
 

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -66,13 +66,9 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		return CONNTRACK_NEXT_DROP;
 	}
 
-	if (!dp_get_in_port(m)->is_pf) {
 	// VFs packets have no VNF information (no tunnel/underlay)
-		if (df->l3_type == RTE_ETHER_TYPE_IPV6)
-			return CONNTRACK_IPV6_LOOKUP;
-		else
-			return CONNTRACK_NEXT_DNAT;
-	}
+	if (!dp_get_in_port(m)->is_pf)
+		return CONNTRACK_NEXT_DNAT;
 
 	switch (df->vnf_type) {
 	case DP_VNF_TYPE_LB:

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -14,11 +14,14 @@
 #include "dp_mbuf_dyn.h"
 #include "dp_vnf.h"
 #include "nodes/common_node.h"
+#include "protocols/dp_dhcpv6.h"
 #include "nodes/dhcp_node.h"
 #include "rte_flow/dp_rte_flow.h"
 
 #define NEXT_NODES(NEXT) \
 	NEXT(CONNTRACK_NEXT_LB, "lb") \
+	NEXT(CONNTRACK_NEXT_DHCPV6, "dhcpv6") \
+	NEXT(CONNTRACK_IPV6_LOOKUP, "ipv6_lookup") \
 	NEXT(CONNTRACK_NEXT_DNAT, "dnat") \
 	NEXT(CONNTRACK_NEXT_FIREWALL, "firewall")
 DP_NODE_REGISTER(CONNTRACK, conntrack, NEXT_NODES);
@@ -32,15 +35,22 @@ static int conntrack_node_init(__rte_unused const struct rte_graph *graph, __rte
 static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_node *node, struct rte_mbuf *m)
 {
 	struct dp_flow *df = dp_get_flow_ptr(m);
+	struct rte_ipv6_hdr *ipv6_hdr = dp_get_ipv6_hdr(m);
 	struct rte_ipv4_hdr *ipv4_hdr = dp_get_ipv4_hdr(m);
 
-	dp_extract_ipv4_header(df, ipv4_hdr);
-
-	if (DP_FAILED(dp_extract_l4_header(df, ipv4_hdr + 1)))
-		return CONNTRACK_NEXT_DROP;
-
-	if (df->l4_type == DP_IP_PROTO_UDP && df->l4_info.trans_port.dst_port == htons(DP_BOOTP_SRV_PORT))
-		return CONNTRACK_NEXT_DNAT;
+	if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
+		dp_extract_ipv4_header(df, ipv4_hdr);
+		if (DP_FAILED(dp_extract_l4_header(df, ipv4_hdr + 1)))
+			return CONNTRACK_NEXT_DROP;
+		if (df->l4_type == DP_IP_PROTO_UDP && df->l4_info.trans_port.dst_port == htons(DP_BOOTP_SRV_PORT))
+			return CONNTRACK_NEXT_DNAT;
+	} else if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
+		dp_extract_ipv6_header(df, ipv6_hdr);
+		if (DP_FAILED(dp_extract_l4_header(df, ipv6_hdr + 1)))
+			return CONNTRACK_NEXT_DROP;
+		if (df->l4_type == DP_IP_PROTO_UDP && df->l4_info.trans_port.dst_port == htons(DHCPV6_SERVER_PORT))
+			return CONNTRACK_NEXT_DHCPV6;
+	}
 
 	if (!dp_conf_is_conntrack_enabled())
 		return CONNTRACK_NEXT_DNAT;
@@ -48,6 +58,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (df->l4_type == IPPROTO_TCP
 		|| df->l4_type == IPPROTO_UDP
 		|| df->l4_type == IPPROTO_ICMP
+		|| df->l4_type == IPPROTO_ICMPV6
 	) {
 		if (DP_FAILED(dp_cntrack_handle(m, df)))
 			return CONNTRACK_NEXT_DROP;
@@ -55,9 +66,13 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		return CONNTRACK_NEXT_DROP;
 	}
 
+	if (!dp_get_in_port(m)->is_pf) {
 	// VFs packets have no VNF information (no tunnel/underlay)
-	if (!dp_get_in_port(m)->is_pf)
-		return CONNTRACK_NEXT_DNAT;
+		if (df->l3_type == RTE_ETHER_TYPE_IPV6)
+			return CONNTRACK_IPV6_LOOKUP;
+		else
+			return CONNTRACK_NEXT_DNAT;
+	}
 
 	switch (df->vnf_type) {
 	case DP_VNF_TYPE_LB:

--- a/src/nodes/dhcpv6_node.c
+++ b/src/nodes/dhcpv6_node.c
@@ -174,7 +174,7 @@ static int generate_reply_options(struct rte_mbuf *m, uint8_t *options, int opti
 	rte_ether_addr_copy(&rte_pktmbuf_mtod(m, struct rte_ether_hdr *)->dst_addr, &opt_sid.id.mac);
 
 	reply_options_len = (int)sizeof(opt_sid) + reply_options.opt_cid_len + reply_options.opt_iana_len + reply_options.opt_rapid_len;
-	reply_options_len += sizeof(dns_opt.opt_code) + sizeof(dns_opt.opt_len) + ntohs(dns_opt.opt_len);
+	reply_options_len += (int)(sizeof(dns_opt.opt_code) + sizeof(dns_opt.opt_len) + ntohs(dns_opt.opt_len));
 
 	if (DP_FAILED(resize_packet(m, reply_options_len - options_len)))
 		return DP_ERROR;

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -140,8 +140,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		rte_memcpy(df->dst.dst_addr6, cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip6, DP_IPV6_ADDR_SIZE);
 		df->nat_addr = df->dst.dst_addr;
 		if (cntrack->nf_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
-			if (df->l4_type == IPPROTO_ICMPV6) {
-				if (df->l4_info.icmp_field.icmp_type == RTE_IP_ICMP_ECHO_REPLY) /* TODO implement */
+			if (df->l4_type == IPPROTO_ICMP) {
+				if (df->l4_info.icmp_field.icmp_type == RTE_IP_ICMP_ECHO_REPLY)
 					dp_change_icmp_identifier(m, cntrack->flow_key[DP_FLOW_DIR_ORG].port_dst);
 			} else {
 				dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_DST, cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src);

--- a/src/nodes/ipip_decap_node.c
+++ b/src/nodes/ipip_decap_node.c
@@ -21,7 +21,6 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	struct rte_ether_hdr *ether_hdr;
 	const struct dp_vnf *vnf;
 	struct dp_port *dst_port;
-	rte_edge_t next_node;
 	uint32_t l3_type;
 
 	vnf = dp_get_vnf(df->tun_info.ul_dst_addr6);
@@ -39,11 +38,9 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	switch (df->tun_info.proto_id) {
 	case DP_IP_PROTO_IPv4_ENCAP:
 		l3_type = RTE_PTYPE_L3_IPV4;
-		next_node = IPIP_DECAP_NEXT_CONNTRACK;
 		break;
 	case DP_IP_PROTO_IPv6_ENCAP:
 		l3_type = RTE_PTYPE_L3_IPV6;
-		next_node = IPIP_DECAP_NEXT_CONNTRACK;
 		break;
 	default:
 		return IPIP_DECAP_NEXT_DROP;
@@ -57,7 +54,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	// this shift is non-standard as the actual values of PTYPE should be opaque
 	m->packet_type = ((m->packet_type & RTE_PTYPE_INNER_L4_MASK) >> 16) | l3_type | RTE_PTYPE_L2_ETHER;
 
-	return next_node;
+	return IPIP_DECAP_NEXT_CONNTRACK;
 }
 
 static uint16_t ipip_decap_node_process(struct rte_graph *graph,

--- a/src/nodes/ipip_decap_node.c
+++ b/src/nodes/ipip_decap_node.c
@@ -12,8 +12,7 @@
 #include "rte_flow/dp_rte_flow.h"
 
 #define NEXT_NODES(NEXT) \
-	NEXT(IPIP_DECAP_NEXT_IPV4_CONNTRACK, "conntrack") \
-	NEXT(IPIP_DECAP_NEXT_IPV6_LOOKUP, "ipv6_lookup")
+	NEXT(IPIP_DECAP_NEXT_CONNTRACK, "conntrack")
 DP_NODE_REGISTER_NOINIT(IPIP_DECAP, ipip_decap, NEXT_NODES);
 
 static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_node *node, struct rte_mbuf *m)
@@ -40,11 +39,11 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	switch (df->tun_info.proto_id) {
 	case DP_IP_PROTO_IPv4_ENCAP:
 		l3_type = RTE_PTYPE_L3_IPV4;
-		next_node = IPIP_DECAP_NEXT_IPV4_CONNTRACK;
+		next_node = IPIP_DECAP_NEXT_CONNTRACK;
 		break;
 	case DP_IP_PROTO_IPv6_ENCAP:
 		l3_type = RTE_PTYPE_L3_IPV6;
-		next_node = IPIP_DECAP_NEXT_IPV6_LOOKUP;
+		next_node = IPIP_DECAP_NEXT_CONNTRACK;
 		break;
 	default:
 		return IPIP_DECAP_NEXT_DROP;
@@ -66,6 +65,6 @@ static uint16_t ipip_decap_node_process(struct rte_graph *graph,
 										 void **objs,
 										 uint16_t nb_objs)
 {
-	dp_foreach_graph_packet(graph, node, objs, nb_objs, IPIP_DECAP_NEXT_IPV4_CONNTRACK, get_next_index);
+	dp_foreach_graph_packet(graph, node, objs, nb_objs, IPIP_DECAP_NEXT_CONNTRACK, get_next_index);
 	return nb_objs;
 }

--- a/src/nodes/lb_node.c
+++ b/src/nodes/lb_node.c
@@ -37,8 +37,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 {
 	struct dp_flow *df = dp_get_flow_ptr(m);
 	struct flow_value *cntrack = df->conntrack;
-	uint32_t dst_ip, vni;
 	uint8_t *target_ip6;
+	uint32_t vni;
 
 	if (!cntrack)
 		return LB_NEXT_DNAT;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -129,6 +129,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 				dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_SRC, nat_port);
 			}
 
+			ipv4_hdr = dp_get_ipv4_hdr(m);
 			cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_LOCAL;
 			cntrack->nf_info.vni = vni;
 			cntrack->nf_info.l4_type = df->l4_type;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -78,7 +78,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			/* Expect the new destination in this conntrack object */
 			cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
 			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].ip_dst = ntohl(ipv4_hdr->src_addr);
+			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = ntohl(ipv4_hdr->src_addr);
 			if (snat_data->nat_ip != 0)
 				cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 
@@ -93,7 +93,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	/* We already know what to do */
 	if (DP_FLOW_HAS_FLAG_SRC_NAT(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_ORG) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
-		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].ip_dst);
+		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4);
 
 		if (cntrack->nf_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
 			df->nat_port = cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst;
@@ -112,7 +112,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		&& (df->flow_dir == DP_FLOW_DIR_REPLY)) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		df->src.src_addr = ipv4_hdr->src_addr;
-		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].ip_dst);
+		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_dst.ip4);
 		df->nat_addr = ipv4_hdr->src_addr;
 		df->nat_type = DP_NAT_CHG_SRC_IP;
 		dp_nat_chg_ip(df, ipv4_hdr, m);

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -23,7 +23,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 {
 	struct dp_flow *df = dp_get_flow_ptr(m);
 	struct flow_value *cntrack = df->conntrack;
-	struct snat_data *snat_data_p = NULL;
+	struct snat_data *snat_data = NULL;
+	struct snat_data snat64_data = {0};
 	struct rte_ipv4_hdr *ipv4_hdr;
 	struct dp_port *port;
 	rte_be32_t dest_ip4;
@@ -41,23 +42,23 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 		if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
 			src_ip = ntohl(df->src.src_addr);
-			snat_data_p = dp_get_iface_snat_data(src_ip, vni);
+			snat_data = dp_get_iface_snat_data(src_ip, vni);
 		}
 
-		if (snat_data_p && (snat_data_p->vip_ip != 0 || snat_data_p->nat_ip != 0)
+		if (snat_data && (snat_data->vip_ip != 0 || snat_data->nat_ip != 0)
 			&& df->flow_type == DP_FLOW_SOUTH_NORTH) {
 			ipv4_hdr = dp_get_ipv4_hdr(m);
 			// TODO(tao?): in case of both VIP and NAT set, VIP gets written here and immediately overwritten by NAT
-			if (snat_data_p->vip_ip != 0) {
-				ipv4_hdr->src_addr = htonl(snat_data_p->vip_ip);
+			if (snat_data->vip_ip != 0) {
+				ipv4_hdr->src_addr = htonl(snat_data->vip_ip);
 				cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_VIP;
 			}
-			if (snat_data_p->nat_ip != 0) {
-				ret = dp_allocate_network_snat_port(snat_data_p, df, vni);
+			if (snat_data->nat_ip != 0) {
+				ret = dp_allocate_network_snat_port(snat_data, df, vni);
 				if (DP_FAILED(ret))
 					return SNAT_NEXT_DROP;
 				nat_port = (uint16_t)ret;
-				ipv4_hdr->src_addr = htonl(snat_data_p->nat_ip);
+				ipv4_hdr->src_addr = htonl(snat_data->nat_ip);
 
 				DP_STATS_NAT_INC_USED_PORT_CNT(port);
 
@@ -84,7 +85,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
 			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = ntohl(ipv4_hdr->src_addr);
-			if (snat_data_p->nat_ip != 0)
+			if (snat_data->nat_ip != 0)
 				cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 
 			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
@@ -93,12 +94,11 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 		if (df->l3_type == RTE_ETHER_TYPE_IPV6 && port->iface.nat_ip && dp_is_ip6_in_nat64_range(df->dst.dst_addr6)
 		    && df->flow_type == DP_FLOW_SOUTH_NORTH) {
-			struct snat_data snat_data = {0};
 
-			snat_data.nat_ip = port->iface.nat_ip;
-			snat_data.nat_port_range[0] = port->iface.nat_port_range[0];
-			snat_data.nat_port_range[1] = port->iface.nat_port_range[1];
-			ret = dp_allocate_network_snat_port(&snat_data, df, vni);
+			snat64_data.nat_ip = port->iface.nat_ip;
+			snat64_data.nat_port_range[0] = port->iface.nat_port_range[0];
+			snat64_data.nat_port_range[1] = port->iface.nat_port_range[1];
+			ret = dp_allocate_network_snat_port(&snat64_data, df, vni);
 			if (DP_FAILED(ret))
 				return SNAT_NEXT_DROP;
 			nat_port = (uint16_t)ret;
@@ -107,8 +107,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 			df->nat_port = nat_port;
 			df->nat_type = DP_NAT_64_CHG_SRC_IP;
-			df->nat_addr = snat_data.nat_ip;
-			if (DP_FAILED(dp_nat_chg_ipv6_to_ipv4_hdr(df, m, snat_data.nat_ip, &dest_ip4))) {
+			df->nat_addr = snat64_data.nat_ip;
+			if (DP_FAILED(dp_nat_chg_ipv6_to_ipv4_hdr(df, m, snat64_data.nat_ip, &dest_ip4))) {
 				dp_remove_network_snat_port(cntrack);
 				DP_STATS_NAT_DEC_USED_PORT_CNT(port);
 				return SNAT_NEXT_DROP;
@@ -141,7 +141,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			memset(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip6, 0, DP_IPV6_ADDR_SIZE);
 			memset(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip6, 0, DP_IPV6_ADDR_SIZE);
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4 = ntohl(dest_ip4);
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = snat_data.nat_ip;
+			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = snat64_data.nat_ip;
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].proto = df->l4_type;
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_type = RTE_ETHER_TYPE_IPV4;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -19,134 +19,156 @@
 	NEXT(SNAT_NEXT_FIREWALL, "firewall")
 DP_NODE_REGISTER_NOINIT(SNAT, snat, NEXT_NODES);
 
+static __rte_always_inline int dp_process_ipv4_snat(struct rte_mbuf *m, struct dp_flow *df,
+													struct flow_value *cntrack, struct dp_port *port,
+													struct snat_data *snat_data)
+{
+	struct rte_ipv4_hdr *ipv4_hdr = dp_get_ipv4_hdr(m);
+	uint16_t nat_port;
+	int ret;
+
+	// TODO(tao?): in case of both VIP and NAT set, VIP gets written here and immediately overwritten by NAT
+	if (snat_data->vip_ip != 0) {
+		ipv4_hdr->src_addr = htonl(snat_data->vip_ip);
+		cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_VIP;
+	}
+	if (snat_data->nat_ip != 0) {
+		ret = dp_allocate_network_snat_port(snat_data, df, port->iface.vni);
+		if (DP_FAILED(ret))
+			return DP_ERROR;
+		nat_port = (uint16_t)ret;
+		ipv4_hdr->src_addr = htonl(snat_data->nat_ip);
+
+		DP_STATS_NAT_INC_USED_PORT_CNT(port);
+
+		if (df->l4_type == DP_IP_PROTO_ICMP) {
+			dp_change_icmp_identifier(m, nat_port);
+			cntrack->offload_state.orig = DP_FLOW_OFFLOADED;
+			cntrack->offload_state.reply = DP_FLOW_OFFLOADED;
+			df->offload_state = DP_FLOW_NON_OFFLOAD;
+		} else {
+			dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_SRC, nat_port);
+		}
+
+		cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_LOCAL;
+		cntrack->nf_info.vni = port->iface.vni;
+		cntrack->nf_info.l4_type = df->l4_type;
+		cntrack->nf_info.icmp_err_ip_cksum = ipv4_hdr->hdr_checksum;
+		df->nat_port = nat_port;
+	}
+	df->nat_type = DP_NAT_CHG_SRC_IP;
+	df->nat_addr = ipv4_hdr->src_addr; // nat_addr is the new src_addr in ipv4_hdr
+	dp_nat_chg_ip(df, ipv4_hdr, m);
+
+	/* Expect the new destination in this conntrack object */
+	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
+	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = ntohl(ipv4_hdr->src_addr);
+	if (snat_data->nat_ip != 0)
+		cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
+
+	if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
+		return DP_ERROR;
+
+	return DP_OK;
+}
+
+static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct dp_flow *df,
+													 struct flow_value *cntrack, struct dp_port *port)
+{
+	struct snat_data snat64_data = {0};
+	struct rte_ipv4_hdr *ipv4_hdr;
+	rte_be32_t dest_ip4;
+	uint16_t nat_port;
+	int ret;
+
+	snat64_data.nat_ip = port->iface.nat_ip;
+	snat64_data.nat_port_range[0] = port->iface.nat_port_range[0];
+	snat64_data.nat_port_range[1] = port->iface.nat_port_range[1];
+	ret = dp_allocate_network_snat_port(&snat64_data, df, port->iface.vni);
+	if (DP_FAILED(ret))
+		return DP_ERROR;
+	nat_port = (uint16_t)ret;
+
+	DP_STATS_NAT_INC_USED_PORT_CNT(port);
+
+	df->nat_port = nat_port;
+	df->nat_type = DP_NAT_64_CHG_SRC_IP;
+	df->nat_addr = snat64_data.nat_ip;
+	if (DP_FAILED(dp_nat_chg_ipv6_to_ipv4_hdr(df, m, snat64_data.nat_ip, &dest_ip4))) {
+		dp_remove_network_snat_port(cntrack);
+		DP_STATS_NAT_DEC_USED_PORT_CNT(port);
+		return DP_ERROR;
+	}
+
+	if (df->l4_type == IPPROTO_ICMP) {
+		dp_change_icmp_identifier(m, nat_port);
+		cntrack->offload_state.orig = DP_FLOW_OFFLOADED;
+		cntrack->offload_state.reply = DP_FLOW_OFFLOADED;
+		df->offload_state = DP_FLOW_NON_OFFLOAD;
+		if (cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src == DP_ICMPV6_ECHO_REQUEST)
+			cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src = RTE_IP_ICMP_ECHO_REQUEST;
+		else if (cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src == DP_ICMPV6_ECHO_REPLY)
+			cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src = RTE_IP_ICMP_ECHO_REPLY;
+		else
+			cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src = 0;
+	} else {
+		dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_SRC, nat_port);
+	}
+
+	ipv4_hdr = dp_get_ipv4_hdr(m);
+	cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_LOCAL;
+	cntrack->nf_info.vni = port->iface.vni;
+	cntrack->nf_info.l4_type = df->l4_type;
+	cntrack->nf_info.icmp_err_ip_cksum = ipv4_hdr->hdr_checksum;
+
+	/* Expect the new destination in this conntrack object */
+	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT64;
+	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+	memset(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip6, 0, DP_IPV6_ADDR_SIZE);
+	memset(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip6, 0, DP_IPV6_ADDR_SIZE);
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4 = ntohl(dest_ip4);
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = snat64_data.nat_ip;
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].proto = df->l4_type;
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_type = RTE_ETHER_TYPE_IPV4;
+
+	if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
+		return DP_ERROR;
+
+	return DP_OK;
+}
+
 static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_node *node, struct rte_mbuf *m)
 {
 	struct dp_flow *df = dp_get_flow_ptr(m);
 	struct flow_value *cntrack = df->conntrack;
 	struct snat_data *snat_data = NULL;
-	struct snat_data snat64_data = {0};
 	struct rte_ipv4_hdr *ipv4_hdr;
 	struct dp_port *port;
 	rte_be32_t dest_ip4;
-	uint16_t nat_port;
 	uint32_t src_ip;
-	uint32_t vni;
-	int ret;
 
 	if (!cntrack)
 		return SNAT_NEXT_FIREWALL;
 
 	port = dp_get_in_port(m);
 	if (DP_FLOW_HAS_NO_FLAGS(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_ORG) {
-		vni = port->iface.vni;
 
 		if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
 			src_ip = ntohl(df->src.src_addr);
-			snat_data = dp_get_iface_snat_data(src_ip, vni);
+			snat_data = dp_get_iface_snat_data(src_ip, port->iface.vni);
 		}
 
 		if (snat_data && (snat_data->vip_ip != 0 || snat_data->nat_ip != 0)
 			&& df->flow_type == DP_FLOW_SOUTH_NORTH) {
-			ipv4_hdr = dp_get_ipv4_hdr(m);
-			// TODO(tao?): in case of both VIP and NAT set, VIP gets written here and immediately overwritten by NAT
-			if (snat_data->vip_ip != 0) {
-				ipv4_hdr->src_addr = htonl(snat_data->vip_ip);
-				cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_VIP;
-			}
-			if (snat_data->nat_ip != 0) {
-				ret = dp_allocate_network_snat_port(snat_data, df, vni);
-				if (DP_FAILED(ret))
-					return SNAT_NEXT_DROP;
-				nat_port = (uint16_t)ret;
-				ipv4_hdr->src_addr = htonl(snat_data->nat_ip);
-
-				DP_STATS_NAT_INC_USED_PORT_CNT(port);
-
-				if (df->l4_type == DP_IP_PROTO_ICMP) {
-					dp_change_icmp_identifier(m, nat_port);
-					cntrack->offload_state.orig = DP_FLOW_OFFLOADED;
-					cntrack->offload_state.reply = DP_FLOW_OFFLOADED;
-					df->offload_state = DP_FLOW_NON_OFFLOAD;
-				} else {
-					dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_SRC, nat_port);
-				}
-
-				cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_LOCAL;
-				cntrack->nf_info.vni = vni;
-				cntrack->nf_info.l4_type = df->l4_type;
-				cntrack->nf_info.icmp_err_ip_cksum = ipv4_hdr->hdr_checksum;
-				df->nat_port = nat_port;
-			}
-			df->nat_type = DP_NAT_CHG_SRC_IP;
-			df->nat_addr = ipv4_hdr->src_addr; // nat_addr is the new src_addr in ipv4_hdr
-			dp_nat_chg_ip(df, ipv4_hdr, m);
-
-			/* Expect the new destination in this conntrack object */
-			cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
-			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = ntohl(ipv4_hdr->src_addr);
-			if (snat_data->nat_ip != 0)
-				cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
-
-			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
+			if (DP_FAILED(dp_process_ipv4_snat(m, df, cntrack, port, snat_data)))
 				return SNAT_NEXT_DROP;
 		}
 
 		if (df->l3_type == RTE_ETHER_TYPE_IPV6 && port->iface.nat_ip && dp_is_ip6_in_nat64_range(df->dst.dst_addr6)
 		    && df->flow_type == DP_FLOW_SOUTH_NORTH) {
-
-			snat64_data.nat_ip = port->iface.nat_ip;
-			snat64_data.nat_port_range[0] = port->iface.nat_port_range[0];
-			snat64_data.nat_port_range[1] = port->iface.nat_port_range[1];
-			ret = dp_allocate_network_snat_port(&snat64_data, df, vni);
-			if (DP_FAILED(ret))
-				return SNAT_NEXT_DROP;
-			nat_port = (uint16_t)ret;
-
-			DP_STATS_NAT_INC_USED_PORT_CNT(port);
-
-			df->nat_port = nat_port;
-			df->nat_type = DP_NAT_64_CHG_SRC_IP;
-			df->nat_addr = snat64_data.nat_ip;
-			if (DP_FAILED(dp_nat_chg_ipv6_to_ipv4_hdr(df, m, snat64_data.nat_ip, &dest_ip4))) {
-				dp_remove_network_snat_port(cntrack);
-				DP_STATS_NAT_DEC_USED_PORT_CNT(port);
-				return SNAT_NEXT_DROP;
-			}
-
-			if (df->l4_type == IPPROTO_ICMP) {
-				dp_change_icmp_identifier(m, nat_port);
-				cntrack->offload_state.orig = DP_FLOW_OFFLOADED;
-				cntrack->offload_state.reply = DP_FLOW_OFFLOADED;
-				df->offload_state = DP_FLOW_NON_OFFLOAD;
-				if (cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src == DP_ICMPV6_ECHO_REQUEST)
-					cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src = RTE_IP_ICMP_ECHO_REQUEST;
-				else if (cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src == DP_ICMPV6_ECHO_REPLY)
-					cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src = RTE_IP_ICMP_ECHO_REPLY;
-				else
-					cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src = 0;
-			} else {
-				dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_SRC, nat_port);
-			}
-
-			ipv4_hdr = dp_get_ipv4_hdr(m);
-			cntrack->nf_info.nat_type = DP_FLOW_NAT_TYPE_NETWORK_LOCAL;
-			cntrack->nf_info.vni = vni;
-			cntrack->nf_info.l4_type = df->l4_type;
-			cntrack->nf_info.icmp_err_ip_cksum = ipv4_hdr->hdr_checksum;
-
-			/* Expect the new destination in this conntrack object */
-			cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT64;
-			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-			memset(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip6, 0, DP_IPV6_ADDR_SIZE);
-			memset(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip6, 0, DP_IPV6_ADDR_SIZE);
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4 = ntohl(dest_ip4);
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = snat64_data.nat_ip;
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].proto = df->l4_type;
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_type = RTE_ETHER_TYPE_IPV4;
-
-			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
+			if (DP_FAILED(dp_process_ipv6_nat64(m, df, cntrack, port)))
 				return SNAT_NEXT_DROP;
 
 			return SNAT_NEXT_FIREWALL;

--- a/src/rte_flow/dp_rte_flow.c
+++ b/src/rte_flow/dp_rte_flow.c
@@ -100,7 +100,6 @@ void dp_change_icmp_identifier(struct rte_mbuf *m, uint16_t new_val)
 	icmp_hdr->icmp_cksum = (~cksum) & 0xffff;
 }
 
-
 struct rte_flow *dp_install_rte_flow(uint16_t port_id,
 									 const struct rte_flow_attr *attr,
 									 const struct rte_flow_item pattern[],

--- a/src/rte_flow/dp_rte_flow.c
+++ b/src/rte_flow/dp_rte_flow.c
@@ -100,6 +100,7 @@ void dp_change_icmp_identifier(struct rte_mbuf *m, uint16_t new_val)
 	icmp_hdr->icmp_cksum = (~cksum) & 0xffff;
 }
 
+
 struct rte_flow *dp_install_rte_flow(uint16_t port_id,
 									 const struct rte_flow_attr *attr,
 									 const struct rte_flow_item pattern[],

--- a/test/config.py
+++ b/test/config.py
@@ -57,6 +57,9 @@ dhcp_dns2 = "8.8.8.8"
 
 # Some "random" IP on the internet
 public_ip = "45.86.6.6"
+public_ip2 = "45.86.6.106"
+public_ip3 = "45.86.6.206"
+public_ipv6 = "2001:4860:4860::8888"
 
 # Virtual IP functionality
 vip_vip = "172.20.0.1"

--- a/test/config.py
+++ b/test/config.py
@@ -75,6 +75,7 @@ nat_neigh_max_port = 520
 lb_name = "my_lb"
 lb_ip = "172.22.2.1"
 pfx_ip = "172.23.3.0"
+pfx_ip6 = "2a10:defe:dede:f4::1"
 lb_ip6 = "2a10:defe:e01f:f4::2"
 
 # Virtual services functionality

--- a/test/config.py
+++ b/test/config.py
@@ -60,6 +60,7 @@ public_ip = "45.86.6.6"
 public_ip2 = "45.86.6.106"
 public_ip3 = "45.86.6.206"
 public_ipv6 = "2001:4860:4860::8888"
+public_nat64_ipv6 = "64:ff9b::808:808"
 
 # Virtual IP functionality
 vip_vip = "172.20.0.1"

--- a/test/config.py
+++ b/test/config.py
@@ -81,6 +81,7 @@ lb_pfx = "172.22.2.1/32"
 pfx_ip = "172.23.3.0"
 pfx_ip6 = "2a10:defe:dede:f4::1"
 lb_ip6 = "2a10:defe:e01f:f4::2"
+lb_ip6_pfx = "2a10:defe:e01f:f4::2/128"
 
 # Virtual services functionality
 virtsvc_udp_svc_ipv6 = "2a00:da8:fff6::1"

--- a/test/config.py
+++ b/test/config.py
@@ -54,6 +54,8 @@ neigh_vni1_ov_ipv6_route = f"{neigh_vni1_ov_ipv6_prefix}::/104"
 dhcp_mtu = 1337
 dhcp_dns1 = "8.8.4.4"
 dhcp_dns2 = "8.8.8.8"
+dhcpv6_dns1 = "2001:4860:4860::6464"
+dhcpv6_dns2 = "2002:4861:4861::6464"
 
 # Some "random" IP on the internet
 public_ip = "45.86.6.6"

--- a/test/config.py
+++ b/test/config.py
@@ -75,6 +75,7 @@ nat_neigh_max_port = 520
 lb_name = "my_lb"
 lb_ip = "172.22.2.1"
 pfx_ip = "172.23.3.0"
+lb_ip6 = "2a10:defe:e01f:f4::2"
 
 # Virtual services functionality
 virtsvc_udp_svc_ipv6 = "2a00:da8:fff6::1"

--- a/test/config.py
+++ b/test/config.py
@@ -77,6 +77,7 @@ nat_neigh_max_port = 520
 # Loadbalancer functionality
 lb_name = "my_lb"
 lb_ip = "172.22.2.1"
+lb_pfx = "172.22.2.1/32"
 pfx_ip = "172.23.3.0"
 pfx_ip6 = "2a10:defe:dede:f4::1"
 lb_ip6 = "2a10:defe:e01f:f4::2"

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -98,6 +98,8 @@ class DpService:
 		grpc_client.addroute(vni1, neigh_vni1_ov_ipv6_route, 0, neigh_vni1_ul_ipv6)
 		grpc_client.addroute(vni1, "0.0.0.0/0", vni1, router_ul_ipv6)
 		grpc_client.addroute(vni2, "0.0.0.0/0", vni2, router_ul_ipv6)
+		grpc_client.addroute(vni1, "::/0", vni1, router_ul_ipv6)
+		grpc_client.addroute(vni2, "::/0", vni2, router_ul_ipv6)
 
 	def attach(self, grpc_client):
 		VM1.ul_ipv6 = grpc_client.getinterface(VM1.name)['underlay_route']

--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -51,6 +51,7 @@ class DpService:
 		self.cmd +=	(f' --ipv6={local_ul_ipv6} --enable-ipv6-overlay'
 					 f' --dhcp-mtu={dhcp_mtu}'
 					 f' --dhcp-dns="{dhcp_dns1}" --dhcp-dns="{dhcp_dns2}"'
+					 f' --dhcpv6-dns="{dhcpv6_dns1}" --dhcpv6-dns="{dhcpv6_dns2}"'
 					 f' --grpc-port={grpc_port}'
 					  ' --no-stats'
 					  ' --color=auto')

--- a/test/grpc_client.py
+++ b/test/grpc_client.py
@@ -161,11 +161,11 @@ class GrpcClient:
 	def listlbtargets(self, lb_name):
 		return self._getSpecList(f"list lbtargets --lb-id={lb_name}")
 
-	def addlbprefix(self, vm_name, vip):
-		return self._getUnderlayRoute(f"add lbprefix --interface-id={vm_name} --prefix={vip}/32")
+	def addlbprefix(self, vm_name, prefix):
+		return self._getUnderlayRoute(f"add lbprefix --interface-id={vm_name} --prefix={prefix}")
 
-	def dellbprefix(self, vm_name, vip):
-		self._call(f"del lbprefix --interface-id={vm_name} --prefix={vip}/32")
+	def dellbprefix(self, vm_name, prefix):
+		self._call(f"del lbprefix --interface-id={vm_name} --prefix={prefix}")
 
 	def listlbprefixes(self, vm_name):
 		return self._getSpecList(f"list lbprefixes --interface-id={vm_name}")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -7,7 +7,7 @@ import time
 from scapy.all import *
 from scapy.layers.dhcp import *
 from scapy.layers.inet import Ether, ICMP, TCP
-from scapy.layers.inet6 import IPv6, _ICMPv6
+from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, _ICMPv6
 
 from config import *
 
@@ -41,8 +41,14 @@ def request_ip(vm):
 def is_icmp_pkt(pkt):
 	return ICMP in pkt
 
+def is_icmpv6_echo_pkt(pkt):
+	return ICMPv6EchoRequest in pkt
+
 def is_udp_pkt(pkt):
 	return UDP in pkt
+
+def is_ipv6_tcp_pkt(pkt):
+	return IPv6 in pkt and TCP in pkt
 
 def is_tcp_pkt(pkt):
 	return TCP in pkt
@@ -50,7 +56,7 @@ def is_tcp_pkt(pkt):
 def is_tcp_vip_src_pkt(pkt):
 	return TCP in pkt and pkt[IP].src == vip_vip
 
-def is_icmpv6echo_pkt(pkt):
+def is_icmpv6echo_reply_pkt(pkt):
 	return ICMPv6EchoReply in pkt
 
 def is_encaped_icmpv6_pkt(pkt):

--- a/test/test_dhcpv6.py
+++ b/test/test_dhcpv6.py
@@ -27,6 +27,16 @@ def test_dhcpv6(prepare_ifaces):
 	assert answer[DHCP6OptIA_NA].iaid == IAID, \
 		f"Bad IA id in DHCPv6 Solicit"
 
+	# Extracting the DNS servers from the DHCPv6 reply
+	dns_servers = None
+	if DHCP6OptDNSServers in answer:
+		dns_servers = answer[DHCP6OptDNSServers].dnsservers
+	else:
+		raise AssertionError("No DNS servers option in DHCPv6 reply")
+
+	if not dns_servers or dhcpv6_dns1 not in dns_servers or dhcpv6_dns2 not in dns_servers:
+		raise AssertionError(f"DHCPv6 reply does not specify the correct DNS servers: {dns_servers} instead of {dhcpv6_dns1} and {dhcpv6_dns2}")
+
 	req = DHCP6_Request()
 	iana_op = DHCP6OptIA_NA(iaid=IAID, T1=0, T2=0, ianaopts=[answer[DHCP6OptIAAddress]])
 	pkt = eth / ip6 / udp / req / iana_op / rc_op / et_op / cid_op / opreq

--- a/test/test_dhcpv6.py
+++ b/test/test_dhcpv6.py
@@ -31,11 +31,14 @@ def test_dhcpv6(prepare_ifaces):
 	dns_servers = None
 	if DHCP6OptDNSServers in answer:
 		dns_servers = answer[DHCP6OptDNSServers].dnsservers
-	else:
-		raise AssertionError("No DNS servers option in DHCPv6 reply")
 
-	if not dns_servers or dhcpv6_dns1 not in dns_servers or dhcpv6_dns2 not in dns_servers:
-		raise AssertionError(f"DHCPv6 reply does not specify the correct DNS servers: {dns_servers} instead of {dhcpv6_dns1} and {dhcpv6_dns2}")
+	# Check if DNS servers option is in DHCPv6 reply
+	assert dns_servers is not None, \
+		f"No DNS servers option in DHCPv6 reply"
+
+	# Check if the correct DNS servers are specified in the DHCPv6 reply
+	assert dhcpv6_dns1 in dns_servers and dhcpv6_dns2 in dns_servers, \
+		f"DHCPv6 reply does not specify the correct DNS servers: {dns_servers} instead of {dhcpv6_dns1} and {dhcpv6_dns2}"
 
 	req = DHCP6_Request()
 	iana_op = DHCP6OptIA_NA(iaid=IAID, T1=0, T2=0, ianaopts=[answer[DHCP6OptIAAddress]])

--- a/test/test_encap.py
+++ b/test/test_encap.py
@@ -56,6 +56,6 @@ def test_ipv6_in_ipv6(prepare_ifaces, port_redundancy):
 					 ICMPv6EchoRequest())
 	delayed_sendp(icmp_echo_pkt, VM1.tap)
 
-	pkt = sniff_packet(VM1.tap, is_icmpv6echo_pkt)
+	pkt = sniff_packet(VM1.tap, is_icmpv6echo_reply_pkt)
 	assert pkt[ICMPv6EchoReply].type == 129, \
 		"Bad ECHOv6 reply"

--- a/test/test_encap.py
+++ b/test/test_encap.py
@@ -29,9 +29,9 @@ def send_ipv4_icmp(dst_ip, pf_name, responder, vm_ipv6):
 		"Wrong ICMP reply"
 
 def test_ipv4_in_ipv6(prepare_ipv4, port_redundancy):
-	send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.9", PF0.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
+	send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.102", PF0.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
 	if port_redundancy:
-		send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.5", PF1.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
+		send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.125", PF1.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
 
 
 def ipv6_in_ipv6_icmp6_responder(pf_name, vm_ul_ipv6):

--- a/test/test_lb.py
+++ b/test/test_lb.py
@@ -65,9 +65,9 @@ def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy
 		pytest.skip("Port redundancy is not supported for LB(vni1) <-> VIP/NAT(vni2) test")
 
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_ip)
+	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip}/32")
 	grpc_client.addlbtarget(lb_name, lb_vm1_ul_ipv6)
-	lb_vm2_ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_ip)
+	lb_vm2_ul_ipv6 = grpc_client.addlbprefix(VM2.name, f"{lb_ip}/32")
 	grpc_client.addlbtarget(lb_name, lb_vm2_ul_ipv6)
 
 	vip_ipv6 = grpc_client.addvip(VM3.name, vip_vip)
@@ -88,9 +88,9 @@ def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy
 	grpc_client.delnat(VM3.name)
 
 	grpc_client.dellbtarget(lb_name, lb_vm2_ul_ipv6)
-	grpc_client.dellbprefix(VM2.name, lb_ip)
+	grpc_client.dellbprefix(VM2.name, f"{lb_ip}/32")
 	grpc_client.dellbtarget(lb_name, lb_vm1_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, lb_ip)
+	grpc_client.dellbprefix(VM1.name, f"{lb_ip}/32")
 	grpc_client.dellb(lb_name)
 
 	grpc_client.delfwallrule(VM2.name, "fw0-vm2")
@@ -108,7 +108,7 @@ def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 
 	# Create a VM on VNI1 under a loadbalancer and NAT
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_ip)
+	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip}/32")
 	grpc_client.addlbtarget(lb_name, lb_vm1_ul_ipv6)
 	nat1_ipv6 = grpc_client.addnat(VM1.name, nat_vip, 100, 101)
 
@@ -122,7 +122,7 @@ def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 
 	grpc_client.delnat(VM1.name)
 	grpc_client.dellbtarget(lb_name, lb_vm1_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, lb_ip)
+	grpc_client.dellbprefix(VM1.name, f"{lb_ip}/32")
 	grpc_client.dellb(lb_name)
 
 def send_bounce_pkt_to_pf(ipv6_lb):

--- a/test/test_lb.py
+++ b/test/test_lb.py
@@ -65,9 +65,9 @@ def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy
 		pytest.skip("Port redundancy is not supported for LB(vni1) <-> VIP/NAT(vni2) test")
 
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip}/32")
+	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_pfx)
 	grpc_client.addlbtarget(lb_name, lb_vm1_ul_ipv6)
-	lb_vm2_ul_ipv6 = grpc_client.addlbprefix(VM2.name, f"{lb_ip}/32")
+	lb_vm2_ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_pfx)
 	grpc_client.addlbtarget(lb_name, lb_vm2_ul_ipv6)
 
 	vip_ipv6 = grpc_client.addvip(VM3.name, vip_vip)
@@ -88,9 +88,9 @@ def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy
 	grpc_client.delnat(VM3.name)
 
 	grpc_client.dellbtarget(lb_name, lb_vm2_ul_ipv6)
-	grpc_client.dellbprefix(VM2.name, f"{lb_ip}/32")
+	grpc_client.dellbprefix(VM2.name, lb_pfx)
 	grpc_client.dellbtarget(lb_name, lb_vm1_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, f"{lb_ip}/32")
+	grpc_client.dellbprefix(VM1.name, lb_pfx)
 	grpc_client.dellb(lb_name)
 
 	grpc_client.delfwallrule(VM2.name, "fw0-vm2")
@@ -108,7 +108,7 @@ def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 
 	# Create a VM on VNI1 under a loadbalancer and NAT
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip}/32")
+	lb_vm1_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_pfx)
 	grpc_client.addlbtarget(lb_name, lb_vm1_ul_ipv6)
 	nat1_ipv6 = grpc_client.addnat(VM1.name, nat_vip, 100, 101)
 
@@ -122,7 +122,7 @@ def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 
 	grpc_client.delnat(VM1.name)
 	grpc_client.dellbtarget(lb_name, lb_vm1_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, f"{lb_ip}/32")
+	grpc_client.dellbprefix(VM1.name, lb_pfx)
 	grpc_client.dellb(lb_name)
 
 def send_bounce_pkt_to_pf(ipv6_lb):

--- a/test/test_pf_to_vf.py
+++ b/test/test_pf_to_vf.py
@@ -14,7 +14,7 @@ def send_lb_pkt_to_pf(lb_ul_ipv6):
 
 def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_ip)
+	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip}/32")
 	grpc_client.addlbtarget(lb_name, lbpfx_ul_ipv6)
 
 	threading.Thread(target=send_lb_pkt_to_pf, args=(lb_ul_ipv6,)).start()
@@ -26,9 +26,35 @@ def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 		f"Wrong packet received (ip: {dst_ip}, dport: {dport})"
 
 	grpc_client.dellbtarget(lb_name, lbpfx_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, lb_ip)
+	grpc_client.dellbprefix(VM1.name, f"{lb_ip}/32")
 	grpc_client.dellb(lb_name)
 	grpc_client.delfwallrule(VM1.name, "fw0-vm1")
 	# TODO: Currently, to use this test again with the same port(s)
 	# you need to wait for the used flow to be aged-out (done every 30s)
 	# If TCP RST is implemented down the line, this can be overcome
+
+def send_lb_ipv6_pkt_to_pf(lb_ul_ipv6):
+	lb_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
+			  IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6, nh=0x29) /
+			  IPv6(dst=lb_ip6, src=public_ipv6) /
+			  TCP(sport=1234, dport=8080))
+	delayed_sendp(lb_pkt, PF0.tap)
+
+def test_pf_to_vf_lb_ipv6_tcp(prepare_ifaces, grpc_client):
+
+	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip6, "tcp/8080")
+	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip6}/128")
+	grpc_client.addlbtarget(lb_name, lbpfx_ul_ipv6)
+
+	threading.Thread(target=send_lb_ipv6_pkt_to_pf, args=(lb_ul_ipv6,)).start()
+	#grpc_client.addfwallrule(VM1.name, "fw0-vm1", proto="tcp", dst_port_min=8080, dst_port_max=8080)
+	pkt = sniff_packet(VM1.tap, is_ipv6_tcp_pkt)
+	dst_ip = pkt[IPv6].dst
+	dport = pkt[TCP].dport
+	assert dst_ip == lb_ip6 and dport == 8080, \
+		f"Wrong packet received (ip: {dst_ip}, dport: {dport})"
+
+	grpc_client.dellbtarget(lb_name, lbpfx_ul_ipv6)
+	grpc_client.dellbprefix(VM1.name, f"{lb_ip6}/128")
+	grpc_client.dellb(lb_name)
+	#grpc_client.delfwallrule(VM1.name, "fw0-vm1")

--- a/test/test_pf_to_vf.py
+++ b/test/test_pf_to_vf.py
@@ -14,7 +14,7 @@ def send_lb_pkt_to_pf(lb_ul_ipv6):
 
 def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip}/32")
+	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_pfx)
 	grpc_client.addlbtarget(lb_name, lbpfx_ul_ipv6)
 
 	threading.Thread(target=send_lb_pkt_to_pf, args=(lb_ul_ipv6,)).start()
@@ -26,7 +26,7 @@ def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 		f"Wrong packet received (ip: {dst_ip}, dport: {dport})"
 
 	grpc_client.dellbtarget(lb_name, lbpfx_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, f"{lb_ip}/32")
+	grpc_client.dellbprefix(VM1.name, lb_pfx)
 	grpc_client.dellb(lb_name)
 	grpc_client.delfwallrule(VM1.name, "fw0-vm1")
 	# TODO: Currently, to use this test again with the same port(s)
@@ -43,7 +43,7 @@ def send_lb_ipv6_pkt_to_pf(lb_ul_ipv6):
 def test_pf_to_vf_lb_ipv6_tcp(prepare_ifaces, grpc_client):
 
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip6, "tcp/8080")
-	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, f"{lb_ip6}/128")
+	lbpfx_ul_ipv6 = grpc_client.addlbprefix(VM1.name, lb_ip6_pfx)
 	grpc_client.addlbtarget(lb_name, lbpfx_ul_ipv6)
 
 	threading.Thread(target=send_lb_ipv6_pkt_to_pf, args=(lb_ul_ipv6,)).start()
@@ -55,6 +55,6 @@ def test_pf_to_vf_lb_ipv6_tcp(prepare_ifaces, grpc_client):
 		f"Wrong packet received (ip: {dst_ip}, dport: {dport})"
 
 	grpc_client.dellbtarget(lb_name, lbpfx_ul_ipv6)
-	grpc_client.dellbprefix(VM1.name, f"{lb_ip6}/128")
+	grpc_client.dellbprefix(VM1.name, lb_ip6_pfx)
 	grpc_client.dellb(lb_name)
 	#grpc_client.delfwallrule(VM1.name, "fw0-vm1")

--- a/test/test_vf_to_pf.py
+++ b/test/test_vf_to_pf.py
@@ -24,7 +24,7 @@ def test_vf_to_pf_network_nat_icmp(prepare_ipv4, grpc_client):
 	threading.Thread(target=reply_icmp_pkt_from_vm1, args=(nat_ul_ipv6,)).start()
 
 	icmp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
-			    IP(dst=public_ip, src=VM1.ip) /
+			    IP(dst=public_ip3, src=VM1.ip) /
 			    ICMP(type=8, id=0x0040))
 	delayed_sendp(icmp_pkt, VM1.tap)
 
@@ -61,7 +61,7 @@ def reply_tcp_pkt_from_vm1_max_port(nat_ul_ipv6):
 
 def send_tcp_through_port(port):
 	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
-			   IP(dst=public_ip, src=VM1.ip) /
+			   IP(dst=public_ip3, src=VM1.ip) /
 			   TCP(sport=port))
 	delayed_sendp(tcp_pkt, VM1.tap)
 
@@ -76,7 +76,7 @@ def test_vf_to_pf_network_nat_max_port_tcp(prepare_ipv4, grpc_client, port_redun
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 	threading.Thread(target=reply_tcp_pkt_from_vm1_max_port, args=(nat_ul_ipv6,)).start()
 	send_tcp_through_port(1246)
-	send_tcp_through_port(1247)
+	send_tcp_through_port(1547)
 	grpc_client.delnat(VM1.name)
 
 
@@ -106,9 +106,9 @@ def request_tcp(dport, pf_name, vip_ul_ipv6):
 
 def test_vf_to_pf_vip_snat(prepare_ipv4, grpc_client, port_redundancy):
 	vip_ul_ipv6 = grpc_client.addvip(VM2.name, vip_vip)
-	request_tcp(80, PF0.tap, vip_ul_ipv6)
+	request_tcp(180, PF0.tap, vip_ul_ipv6)
 	if port_redundancy:
-		request_tcp(82, PF1.tap, vip_ul_ipv6)
+		request_tcp(120, PF1.tap, vip_ul_ipv6)
 	grpc_client.delvip(VM2.name)
 
 
@@ -147,7 +147,7 @@ def test_vm_nat_async_tcp_icmperr(prepare_ipv4, grpc_client, port_redundancy):
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 	request_icmperr(501, PF0.tap, nat_ul_ipv6)
 	if port_redundancy:
-		request_icmperr(500, PF1.tap, nat_ul_ipv6)
+		request_icmperr(565, PF1.tap, nat_ul_ipv6)
 	grpc_client.delnat(VM1.name)
 
 def test_vf_to_pf_firewall_tcp_block(prepare_ipv4, grpc_client):

--- a/test/test_vf_to_pf.py
+++ b/test/test_vf_to_pf.py
@@ -229,7 +229,7 @@ def test_vf_to_pf_firewall_ipv6_tcp_allow(prepare_ipv4, grpc_client, port_redund
 	resp_thread = threading.Thread(target=sniff_tcp_fwall_packet, args=(PF0.tap, sniff_tcp_data,))
 	resp_thread.start()
 	# Allow only tcp packets leaving the VM with destination port 456
-	grpc_client.addfwallrule(VM1.name, "fw1-vm16", proto="tcp", dst_port_min=456, dst_port_max=456, direction="egress")
+	grpc_client.addfwallrule(VM1.name, "fw1-vm16", src_prefix="::/0", dst_prefix="::/0", proto="tcp", dst_port_min=456, dst_port_max=456, direction="egress")
 	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x86DD) /
 			   IPv6(dst=public_ipv6, src=VM1.ipv6) /
 			   TCP(dport=453))

--- a/test/test_vf_to_pf.py
+++ b/test/test_vf_to_pf.py
@@ -222,6 +222,24 @@ def test_vf_to_pf_firewall_tcp_allow(prepare_ipv4, grpc_client, port_redundancy)
 		"Packet should not have been filtered"
 	grpc_client.delfwallrule(VM1.name, "fw1-vm1")
 
+def test_vf_to_pf_firewall_ipv6_tcp_allow(prepare_ipv4, grpc_client, port_redundancy):
+	if port_redundancy:
+		pytest.skip()
+	sniff_tcp_data = {}
+	resp_thread = threading.Thread(target=sniff_tcp_fwall_packet, args=(PF0.tap, sniff_tcp_data,))
+	resp_thread.start()
+	# Allow only tcp packets leaving the VM with destination port 456
+	grpc_client.addfwallrule(VM1.name, "fw1-vm16", proto="tcp", dst_port_min=456, dst_port_max=456, direction="egress")
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x86DD) /
+			   IPv6(dst=public_ipv6, src=VM1.ipv6) /
+			   TCP(dport=453))
+	delayed_sendp(tcp_pkt, VM1.tap)
+
+	resp_thread.join()
+	assert sniff_tcp_data["pkt"] != None, \
+		"Packet should not have been filtered"
+	grpc_client.delfwallrule(VM1.name, "fw1-vm16")
+
 def encaped_tcp_ipv6_in_ipv6_responder(pf_name):
 	pkt = sniff_packet(pf_name, is_ipv6_tcp_pkt)
 	reply_pkt = (Ether(dst=pkt.getlayer(Ether).src, src=pkt.getlayer(Ether).dst, type=0x86DD) /

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -138,22 +138,55 @@ def test_grpc_add_list_delPfx(prepare_ifaces, grpc_client):
 	assert myspec not in specs, \
 		f"Prefix {prefix} not deleted properly"
 
+def test_grpc_add_list_delPfx_ipv6(prepare_ifaces, grpc_client):
+	# Try to add Prefix, list, test error cases, delete prefix and list again
+	prefix = f"{pfx_ip6}/124"
+	ul_ipv6 = grpc_client.addprefix(VM2.name, prefix)
+	myspec = { "prefix": prefix, "underlay_route": ul_ipv6 }
+	specs = grpc_client.listprefixes(VM2.name)
+	assert myspec in specs, \
+		f"Prefix {prefix} not added properly"
+	# Try to add the same pfx again
+	grpc_client.expect_error(301).addprefix(VM2.name, prefix)
+	# Try to add/delete to/from a machine which doesnt exist
+	grpc_client.expect_error(205).addprefix("invalid_name", prefix)
+	grpc_client.expect_error(205).delprefix("invalid_name", prefix)
+	grpc_client.delprefix(VM2.name, prefix)
+	specs = grpc_client.listprefixes(VM2.name)
+	assert myspec not in specs, \
+		f"Prefix {prefix} not deleted properly"
+
 def test_grpc_add_list_delLoadBalancerTargets(prepare_ifaces, grpc_client):
 	# Try to add Prefix, list, test error cases, delete prefix and list again
 	lb_prefix = f"{lb_ip}/32"
-	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_ip)
+	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_prefix)
 	myspec = { "prefix": lb_prefix, "underlay_route": ul_ipv6 }
 	specs = grpc_client.listlbprefixes(VM2.name)
 	assert myspec in specs, \
 		f"Loadbalancer prefix {lb_prefix} not added properly"
 	# Try to add/delete to/from a machine which doesnt exist
-	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_ip)
-	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_ip)
-	grpc_client.dellbprefix(VM2.name, lb_ip)
+	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_prefix)
+	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_prefix)
+	grpc_client.dellbprefix(VM2.name, lb_prefix)
 	specs = grpc_client.listlbprefixes(VM2.name)
 	assert myspec not in specs, \
 		f"Loadbalancer prefix {lb_prefix} not deleted properly"
 
+def test_grpc_add_list_delLoadBalancerTargets_ipv6(prepare_ifaces, grpc_client):
+	# Try to add Prefix, list, test error cases, delete prefix and list again
+	lb_prefix = f"{lb_ip6}/128"
+	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_prefix)
+	myspec = { "prefix": lb_prefix, "underlay_route": ul_ipv6 }
+	specs = grpc_client.listlbprefixes(VM2.name)
+	assert myspec in specs, \
+		f"Loadbalancer prefix {lb_prefix} not added properly"
+	# Try to add/delete to/from a machine which doesnt exist
+	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_prefix)
+	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_prefix)
+	grpc_client.dellbprefix(VM2.name, lb_prefix)
+	specs = grpc_client.listlbprefixes(VM2.name)
+	assert myspec not in specs, \
+		f"Loadbalancer prefix {lb_prefix} not deleted properly"
 
 def test_grpc_add_list_delFirewallRules(prepare_ifaces, grpc_client):
 	# Try to add FirewallRule, get, list, delete and test error cases

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -158,35 +158,33 @@ def test_grpc_add_list_delPfx_ipv6(prepare_ifaces, grpc_client):
 
 def test_grpc_add_list_delLoadBalancerTargets(prepare_ifaces, grpc_client):
 	# Try to add Prefix, list, test error cases, delete prefix and list again
-	lb_prefix = f"{lb_ip}/32"
-	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_prefix)
-	myspec = { "prefix": lb_prefix, "underlay_route": ul_ipv6 }
+	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_pfx)
+	myspec = { "prefix": lb_pfx, "underlay_route": ul_ipv6 }
 	specs = grpc_client.listlbprefixes(VM2.name)
 	assert myspec in specs, \
-		f"Loadbalancer prefix {lb_prefix} not added properly"
+		f"Loadbalancer prefix {lb_pfx} not added properly"
 	# Try to add/delete to/from a machine which doesnt exist
-	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_prefix)
-	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_prefix)
-	grpc_client.dellbprefix(VM2.name, lb_prefix)
+	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_pfx)
+	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_pfx)
+	grpc_client.dellbprefix(VM2.name, lb_pfx)
 	specs = grpc_client.listlbprefixes(VM2.name)
 	assert myspec not in specs, \
-		f"Loadbalancer prefix {lb_prefix} not deleted properly"
+		f"Loadbalancer prefix {lb_pfx} not deleted properly"
 
 def test_grpc_add_list_delLoadBalancerTargets_ipv6(prepare_ifaces, grpc_client):
 	# Try to add Prefix, list, test error cases, delete prefix and list again
-	lb_prefix = f"{lb_ip6}/128"
-	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_prefix)
-	myspec = { "prefix": lb_prefix, "underlay_route": ul_ipv6 }
+	ul_ipv6 = grpc_client.addlbprefix(VM2.name, lb_ip6_pfx)
+	myspec = { "prefix": lb_ip6_pfx, "underlay_route": ul_ipv6 }
 	specs = grpc_client.listlbprefixes(VM2.name)
 	assert myspec in specs, \
-		f"Loadbalancer prefix {lb_prefix} not added properly"
+		f"Loadbalancer prefix {lb_ip6_pfx} not added properly"
 	# Try to add/delete to/from a machine which doesnt exist
-	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_prefix)
-	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_prefix)
-	grpc_client.dellbprefix(VM2.name, lb_prefix)
+	grpc_client.expect_error(205).addlbprefix("invalid_name", lb_ip6_pfx)
+	grpc_client.expect_error(205).dellbprefix("invalid_name", lb_ip6_pfx)
+	grpc_client.dellbprefix(VM2.name, lb_ip6_pfx)
 	specs = grpc_client.listlbprefixes(VM2.name)
 	assert myspec not in specs, \
-		f"Loadbalancer prefix {lb_prefix} not deleted properly"
+		f"Loadbalancer prefix {lb_ip6_pfx} not deleted properly"
 
 def test_grpc_add_list_delFirewallRules(prepare_ifaces, grpc_client):
 	# Try to add FirewallRule, get, list, delete and test error cases


### PR DESCRIPTION
Introduced following network functions to support overlay ipv6 in non-offloading path:

-  IPv6 conntrack support.
-  IPv6 HV-HV routing.
-  IPv6 Loadbalancer support.
-  Alias v6 Prefixes and v6 LB Alias Prefixes.
-  NAT64 support.
-  TCP/UDP NAT64.
-  ICMP NAT64.
-  DHCPv6 DNS Support.
-  Scapy tests.
-  v6 Firewall.

Scapy tests can be still extended but for the beginning there is at least one scapy test to test the introduced ipv6 overlay 
network function.

Unfortunately the commits are not suitable to be reviewed separately. As there is a cleanup commit at the end of the 
series so better take a look to the complete PR diff. The changes are somehow connected anyway.

checkpatch fails because of the cpp changes.