### PR TITLE
Enhance GRPC function implementations to support different combination of ipv4/ipv6 address cases

### DIFF
--- a/include/dp_iface.h
+++ b/include/dp_iface.h
@@ -38,6 +38,13 @@ void dp_fill_ether_hdr(struct rte_ether_hdr *ether_hdr, const struct dp_port *po
 	ether_hdr->ether_type = htons(ether_type);
 }
 
+static __rte_always_inline
+bool dp_is_ipv6_addr_zero(const uint8_t *addr)
+{
+	static_assert(DP_IPV6_ADDR_SIZE == 2 * sizeof(uint64_t), "uint64_t doesn't have the expected size");
+	return *((const uint64_t *)addr) == 0 && *((const uint64_t *)(addr + sizeof(uint64_t))) == 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -39,7 +39,6 @@ struct dp_port_iface {
 	uint8_t					ul_ipv6[DP_IPV6_ADDR_SIZE];
 	uint32_t				nat_ip;
 	uint16_t				nat_port_range[2];
-	bool					is_ipv6_set;
 	bool					ready;
 };
 

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -39,6 +39,7 @@ struct dp_port_iface {
 	uint8_t					ul_ipv6[DP_IPV6_ADDR_SIZE];
 	uint32_t				nat_ip;
 	uint16_t				nat_port_range[2];
+	bool					is_ipv6_set;
 	bool					ready;
 };
 

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -33,6 +33,9 @@ void send_to_all_vfs(const struct rte_mbuf *pkt, uint16_t eth_type)
 		if (eth_type == RTE_ETHER_TYPE_IPV6 && !port->iface.is_ipv6_set)
 			continue;
 
+		if (eth_type == RTE_ETHER_TYPE_IPV4 && port->iface.cfg.own_ip == 0)
+			continue;
+
 		clone_buf = rte_pktmbuf_copy(pkt, dp_layer->rte_mempool, 0, UINT32_MAX);
 		if (!clone_buf) {
 			DPS_LOG_ERR("Cannot clone periodic packet");

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -30,6 +30,9 @@ void send_to_all_vfs(const struct rte_mbuf *pkt, uint16_t eth_type)
 		if (port->is_pf || !port->allocated)
 			continue;
 
+		if (eth_type == RTE_ETHER_TYPE_IPV6 && !port->iface.is_ipv6_set)
+			continue;
+
 		clone_buf = rte_pktmbuf_copy(pkt, dp_layer->rte_mempool, 0, UINT32_MAX);
 		if (!clone_buf) {
 			DPS_LOG_ERR("Cannot clone periodic packet");

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -27,11 +27,9 @@ static uint32_t pfx_counter = 0;
 
 static __rte_always_inline bool dp_is_ipv6_addr_zero(const uint8_t *addr)
 {
-	for (int i = 0; i < DP_IPV6_ADDR_SIZE; i++) {
-		if (addr[i] != 0) {
+	for (int i = 0; i < DP_IPV6_ADDR_SIZE; i++)
+		if (addr[i] != 0)
 			return false;
-		}
-	}
 	return true;
 }
 

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -166,6 +166,8 @@ static int dp_process_check_vniinuse(struct dp_grpc_responder *responder)
 
 	if (request->type == DP_VNI_IPV4) {
 		reply->in_use = dp_is_vni_route_table_available(request->vni, DP_IP_PROTO_IPV4);
+	} else if (request->type == DP_VNI_IPV6) {
+		reply->in_use = dp_is_vni_route_table_available(request->vni, DP_IP_PROTO_IPV6);
 	} else
 		return DP_GRPC_ERR_WRONG_TYPE;
 

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -25,6 +25,16 @@
 
 static uint32_t pfx_counter = 0;
 
+static __rte_always_inline bool dp_is_ipv6_addr_zero(const uint8_t *addr)
+{
+	for (int i = 0; i < DP_IPV6_ADDR_SIZE; i++) {
+		if (addr[i] != 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
 static __rte_always_inline void dp_generate_underlay_ipv6(uint8_t route[DP_VNF_IPV6_ADDR_SIZE])
 {
 	rte_be32_t local;
@@ -487,6 +497,7 @@ static int dp_process_create_interface(struct dp_grpc_responder *responder)
 	rte_memcpy(port->iface.ul_ipv6, ul_addr6, sizeof(port->iface.ul_ipv6));
 	port->iface.cfg.own_ip = request->ip4_addr;
 	port->iface.cfg.ip_depth = DP_LPM_DHCP_IP_DEPTH;
+	port->iface.is_ipv6_set = !dp_is_ipv6_addr_zero(request->ip6_addr);
 	rte_memcpy(port->iface.cfg.dhcp_ipv6, request->ip6_addr, sizeof(port->iface.cfg.dhcp_ipv6));
 	port->iface.cfg.ip6_depth = DP_LPM_DHCP_IP6_DEPTH;
 	static_assert(sizeof(request->pxe_str) == sizeof(port->iface.cfg.pxe_str), "Incompatible interface PXE size");

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -25,14 +25,6 @@
 
 static uint32_t pfx_counter = 0;
 
-static __rte_always_inline bool dp_is_ipv6_addr_zero(const uint8_t *addr)
-{
-	for (int i = 0; i < DP_IPV6_ADDR_SIZE; i++)
-		if (addr[i] != 0)
-			return false;
-	return true;
-}
-
 static __rte_always_inline void dp_generate_underlay_ipv6(uint8_t route[DP_VNF_IPV6_ADDR_SIZE])
 {
 	rte_be32_t local;
@@ -495,7 +487,6 @@ static int dp_process_create_interface(struct dp_grpc_responder *responder)
 	rte_memcpy(port->iface.ul_ipv6, ul_addr6, sizeof(port->iface.ul_ipv6));
 	port->iface.cfg.own_ip = request->ip4_addr;
 	port->iface.cfg.ip_depth = DP_LPM_DHCP_IP_DEPTH;
-	port->iface.is_ipv6_set = !dp_is_ipv6_addr_zero(request->ip6_addr);
 	rte_memcpy(port->iface.cfg.dhcp_ipv6, request->ip6_addr, sizeof(port->iface.cfg.dhcp_ipv6));
 	port->iface.cfg.ip6_depth = DP_LPM_DHCP_IP6_DEPTH;
 	static_assert(sizeof(request->pxe_str) == sizeof(port->iface.cfg.pxe_str), "Incompatible interface PXE size");

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -192,6 +192,9 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	if (options_len < 0)
 		return DHCP_NEXT_DROP;
 
+	if (port->iface.cfg.own_ip == 0)
+		return DHCP_NEXT_DROP;
+
 	if (dhcp_hdr->op != DP_BOOTP_REQUEST) {
 		DPNODE_LOG_WARNING(node, "Not a DHCP request", DP_LOG_VALUE(dhcp_hdr->op));
 		return DHCP_NEXT_DROP;

--- a/src/nodes/dhcpv6_node.c
+++ b/src/nodes/dhcpv6_node.c
@@ -111,7 +111,7 @@ static __rte_always_inline int parse_options(struct rte_mbuf *m,
 			}
 			reply_options->opt_iana = opt_iana_template;
 			reply_options->opt_iana.ia_na.iaid = ((const struct dhcpv6_ia_na *)&opt->data)->iaid;
-			rte_memcpy(reply_options->opt_iana.ia_na.options[0].addr.ipv6, dp_get_in_port(m)->iface.cfg.dhcp_ipv6, 16);
+			rte_memcpy(reply_options->opt_iana.ia_na.options[0].addr.ipv6, dp_get_in_port(m)->iface.cfg.dhcp_ipv6, DP_IPV6_ADDR_SIZE);
 			reply_options->opt_iana_len = sizeof(opt_iana_template);
 			break;
 		case DHCPV6_OPT_RAPID_COMMIT:
@@ -212,6 +212,9 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	int req_options_len = rte_pktmbuf_data_len(m) - (int)DP_DHCPV6_PKT_FIXED_LEN;
 	int reply_options_len;
 	size_t payload_len;
+
+	if (!dp_get_in_port(m)->iface.is_ipv6_set)
+		return DHCPV6_NEXT_DROP;
 
 	// packet length is uint16_t, negative value means it's less than the required length
 	if (req_options_len < 0) {

--- a/src/nodes/dhcpv6_node.c
+++ b/src/nodes/dhcpv6_node.c
@@ -10,6 +10,7 @@
 #include "dp_error.h"
 #include "dp_log.h"
 #include "dp_lpm.h"
+#include "dp_iface.h"
 #include "nodes/common_node.h"
 #include "protocols/dp_dhcpv6.h"
 
@@ -213,7 +214,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	int reply_options_len;
 	size_t payload_len;
 
-	if (!dp_get_in_port(m)->iface.is_ipv6_set)
+	if (dp_is_ipv6_addr_zero(dp_get_in_port(m)->iface.cfg.dhcp_ipv6))
 		return DHCPV6_NEXT_DROP;
 
 	// packet length is uint16_t, negative value means it's less than the required length


### PR DESCRIPTION
Enhance GRPC function implementations to support different combination of ipv4/ipv6 address cases.
After ipv6 introduction, having only ipv6 address or having only ipv4 addresses (with enabled overall ipv6 flag of dpservice)
on dpservice interfaces are valid cases. These should be handled accordingly in the grpc implementation of 
relevant functions. (GetVNI, CreateInterface)