### PR TITLE
Code fixing to avoid random bits in struct vnf used as key

### DIFF
--- a/include/dp_error.h
+++ b/include/dp_error.h
@@ -67,6 +67,7 @@ const char *dp_strerror_verbose(int error);
 	ERR(PORT_METER,							383) \
 	ERR(VNF_INSERT,							401) \
 	ERR(VM_HANDLE,							402) \
+	ERR(VNF_DELETE,							403) \
 	ERR(NO_BACKIP,							421) \
 	ERR(NO_LB,								422) \
 	ERR(NO_DROP_SUPPORT,					441) \

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -40,7 +40,7 @@ struct dp_vnf {
 	uint32_t				vni;
 	uint16_t				port_id;
 	struct dp_vnf_prefix	alias_pfx;
-};
+} __rte_packed;
 
 int dp_vnf_init(int socket_id);
 void dp_vnf_free(void);

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -40,6 +40,17 @@ struct dp_vnf {
 	uint32_t				vni;
 	uint16_t				port_id;
 	struct dp_vnf_prefix	alias_pfx;
+};
+
+struct dp_vnf_value_key {
+	enum dp_vnf_type		type;
+	uint32_t				vni;
+	uint16_t				port_id;
+	uint16_t				ip_type;
+	union {
+		uint32_t			ipv4;
+		uint8_t				ipv6[DP_IPV6_ADDR_SIZE];
+	};
 } __rte_packed;
 
 int dp_vnf_init(int socket_id);

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -190,8 +190,10 @@ bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address
 		.vni = vni,
 		.type = DP_VNF_TYPE_LB_ALIAS_PFX,
 		.alias_pfx.length = prefix_len,
-		.alias_pfx.ol = *prefix_ip,
+		.alias_pfx.ol = {0},
 	};
+	
+	vnf.alias_pfx.ol = *prefix_ip;
 
 	return dp_vnf_value_exists(&vnf);
 }
@@ -203,15 +205,21 @@ int dp_del_vnf_by_value(struct dp_vnf *target_vnf)
 
 	ret = rte_hash_lookup_data(vnf_value_tbl, target_vnf, (void **)&vnf_ul_addr6);
 	if (DP_FAILED(ret)) {
-		DP_LOG_VNF_WARNING("VNF value key lookup failed", target_vnf)
-		return DP_ERROR;
+		if (ret == -ENOENT)
+			return DP_GRPC_ERR_NOT_FOUND;
+		DP_LOG_VNF_WARNING("VNF value key lookup failed due to invalid parameters", target_vnf)
+		return DP_GRPC_ERR_VNF_DELETE;
 	}
 
 	ret = dp_del_vnf(vnf_ul_addr6);
-	if (DP_FAILED(ret))
-		return ret;
+	if (DP_FAILED(ret)) {
+		if (ret == -ENOENT)
+			return DP_GRPC_ERR_NOT_FOUND;
+		DP_LOG_VNF_WARNING("VNF underlying IPv6 as key lookup failed due to invalid parameters", target_vnf)
+		return DP_GRPC_ERR_VNF_DELETE;
+	}
 
-	return DP_OK;
+	return DP_GRPC_OK;
 }
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder)

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -379,7 +379,7 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 	struct dp_vnf target_vnf = {
 		.type = DP_VNF_TYPE_LB_ALIAS_PFX,
 		.alias_pfx.length = request->length,
-		.alias_pfx.ol = request->addr
+		.alias_pfx.ol = {0},
 	};
 
 	if (request->addr.ip_type != RTE_ETHER_TYPE_IPV4 && request->addr.ip_type != RTE_ETHER_TYPE_IPV6)
@@ -391,6 +391,7 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 
 	target_vnf.port_id = port->port_id;
 	target_vnf.vni = port->iface.vni;
+	target_vnf.alias_pfx.ol = request->addr;
 
 	return dp_del_vnf_by_value(&target_vnf);
 }
@@ -443,7 +444,7 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 	struct dp_vnf target_vnf = {
 		.type = DP_VNF_TYPE_ALIAS_PFX,
 		.alias_pfx.length = request->length,
-		.alias_pfx.ol = request->addr
+		.alias_pfx.ol = {0},
 	};
 
 	port = dp_get_port_with_iface_id(request->iface_id);
@@ -461,6 +462,7 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 
 	target_vnf.port_id = port->port_id;
 	target_vnf.vni = port->iface.vni;
+	target_vnf.alias_pfx.ol = request->addr;
 
 	ret2 = dp_del_vnf_by_value(&target_vnf);
 	return DP_FAILED(ret) ? ret : ret2;

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -379,7 +379,7 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 	struct dp_vnf target_vnf = {
 		.type = DP_VNF_TYPE_LB_ALIAS_PFX,
 		.alias_pfx.length = request->length,
-		.alias_pfx.ol = {0},
+		.alias_pfx.ol = request->addr,
 	};
 
 	if (request->addr.ip_type != RTE_ETHER_TYPE_IPV4 && request->addr.ip_type != RTE_ETHER_TYPE_IPV6)
@@ -391,7 +391,6 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 
 	target_vnf.port_id = port->port_id;
 	target_vnf.vni = port->iface.vni;
-	target_vnf.alias_pfx.ol = request->addr;
 
 	return dp_del_vnf_by_value(&target_vnf);
 }
@@ -444,7 +443,7 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 	struct dp_vnf target_vnf = {
 		.type = DP_VNF_TYPE_ALIAS_PFX,
 		.alias_pfx.length = request->length,
-		.alias_pfx.ol = {0},
+		.alias_pfx.ol = request->addr,
 	};
 
 	port = dp_get_port_with_iface_id(request->iface_id);
@@ -462,7 +461,6 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 
 	target_vnf.port_id = port->port_id;
 	target_vnf.vni = port->iface.vni;
-	target_vnf.alias_pfx.ol = request->addr;
 
 	ret2 = dp_del_vnf_by_value(&target_vnf);
 	return DP_FAILED(ret) ? ret : ret2;


### PR DESCRIPTION
The bugs were discovered during running dpservice-go tests. 

1) the union part from dp_vnf.alias_pfx needs to pre-filled to avoid random bits in unused places. It is especially important when it is used as hash table keys;
2) the return values from the function `dp_del_vnf_by_value` needs to be consistent with grpc's expected behaviour.

The tests from dpservice passed.
The tests from dpservice-go passed.