### PR TITLE
Fix VNF reverse lookup

### DIFF
--- a/include/dp_error.h
+++ b/include/dp_error.h
@@ -67,6 +67,7 @@ const char *dp_strerror_verbose(int error);
 	ERR(PORT_METER,							383) \
 	ERR(VNF_INSERT,							401) \
 	ERR(VM_HANDLE,							402) \
+	ERR(VNF_DELETE,							403) \
 	ERR(NO_BACKIP,							421) \
 	ERR(NO_LB,								422) \
 	ERR(NO_DROP_SUPPORT,					441) \

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -56,6 +56,18 @@ int dp_del_vnf_by_value(struct dp_vnf *target_vnf);
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder);
 
+static __rte_always_inline
+void dp_assign_ip_address(struct dp_ip_address *dest, const struct dp_ip_address *src)
+{
+	if (src->ip_type == RTE_ETHER_TYPE_IPV4) {
+		memset(dest->ipv6, 0, DP_IPV6_ADDR_SIZE);
+		dest->ip_type = src->ip_type;
+		dest->ipv4 = src->ipv4;
+		return;
+	}
+	*dest = *src;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -52,21 +52,10 @@ int dp_del_vnf(const uint8_t ul_addr6[DP_VNF_IPV6_ADDR_SIZE]);
 
 bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix_ip, uint8_t prefix_len);
 
-int dp_del_vnf_by_value(struct dp_vnf *target_vnf);
+int dp_del_vnf_by_value(enum dp_vnf_type type, uint16_t port_id, uint32_t vni, struct dp_ip_address *prefix_ip, uint8_t prefix_len);
 
 int dp_list_vnf_alias_prefixes(uint16_t port_id, enum dp_vnf_type type, struct dp_grpc_responder *responder);
 
-static __rte_always_inline
-void dp_assign_ip_address(struct dp_ip_address *dest, const struct dp_ip_address *src)
-{
-	if (src->ip_type == RTE_ETHER_TYPE_IPV4) {
-		memset(dest->ipv6, 0, DP_IPV6_ADDR_SIZE);
-		dest->ip_type = src->ip_type;
-		dest->ipv4 = src->ipv4;
-		return;
-	}
-	*dest = *src;
-}
 
 #ifdef __cplusplus
 }

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -379,7 +379,6 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 	struct dp_vnf target_vnf = {
 		.type = DP_VNF_TYPE_LB_ALIAS_PFX,
 		.alias_pfx.length = request->length,
-		.alias_pfx.ol = request->addr
 	};
 
 	if (request->addr.ip_type != RTE_ETHER_TYPE_IPV4 && request->addr.ip_type != RTE_ETHER_TYPE_IPV6)
@@ -391,6 +390,7 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 
 	target_vnf.port_id = port->port_id;
 	target_vnf.vni = port->iface.vni;
+	dp_assign_ip_address(&target_vnf.alias_pfx.ol, &request->addr);
 
 	return dp_del_vnf_by_value(&target_vnf);
 }
@@ -443,7 +443,6 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 	struct dp_vnf target_vnf = {
 		.type = DP_VNF_TYPE_ALIAS_PFX,
 		.alias_pfx.length = request->length,
-		.alias_pfx.ol = request->addr
 	};
 
 	port = dp_get_port_with_iface_id(request->iface_id);
@@ -462,6 +461,7 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 	target_vnf.port_id = port->port_id;
 	target_vnf.vni = port->iface.vni;
 
+	dp_assign_ip_address(&target_vnf.alias_pfx.ol, &request->addr);
 	ret2 = dp_del_vnf_by_value(&target_vnf);
 	return DP_FAILED(ret) ? ret : ret2;
 }

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -376,11 +376,6 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 	struct dpgrpc_prefix *request = &responder->request.del_lbpfx;
 	struct dp_port *port;
 
-	struct dp_vnf target_vnf = {
-		.type = DP_VNF_TYPE_LB_ALIAS_PFX,
-		.alias_pfx.length = request->length,
-	};
-
 	if (request->addr.ip_type != RTE_ETHER_TYPE_IPV4 && request->addr.ip_type != RTE_ETHER_TYPE_IPV6)
 		return DP_GRPC_ERR_BAD_IPVER;
 
@@ -388,11 +383,7 @@ static int dp_process_delete_lbprefix(struct dp_grpc_responder *responder)
 	if (!port)
 		return DP_GRPC_ERR_NO_VM;
 
-	target_vnf.port_id = port->port_id;
-	target_vnf.vni = port->iface.vni;
-	dp_assign_ip_address(&target_vnf.alias_pfx.ol, &request->addr);
-
-	return dp_del_vnf_by_value(&target_vnf);
+	return dp_del_vnf_by_value(DP_VNF_TYPE_LB_ALIAS_PFX, port->port_id, port->iface.vni, &request->addr, request->length);
 }
 
 static int dp_process_create_prefix(struct dp_grpc_responder *responder)
@@ -440,11 +431,6 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 	struct dp_port *port;
 	int ret, ret2;
 
-	struct dp_vnf target_vnf = {
-		.type = DP_VNF_TYPE_ALIAS_PFX,
-		.alias_pfx.length = request->length,
-	};
-
 	port = dp_get_port_with_iface_id(request->iface_id);
 	if (!port)
 		return DP_GRPC_ERR_NO_VM;
@@ -458,11 +444,7 @@ static int dp_process_delete_prefix(struct dp_grpc_responder *responder)
 	} else
 		return DP_GRPC_ERR_BAD_IPVER;
 
-	target_vnf.port_id = port->port_id;
-	target_vnf.vni = port->iface.vni;
-
-	dp_assign_ip_address(&target_vnf.alias_pfx.ol, &request->addr);
-	ret2 = dp_del_vnf_by_value(&target_vnf);
+	ret2 = dp_del_vnf_by_value(DP_VNF_TYPE_ALIAS_PFX, port->port_id, port->iface.vni, &request->addr, request->length);
 	return DP_FAILED(ret) ? ret : ret2;
 }
 


### PR DESCRIPTION
Fix VNF reverse lookup so that the value used as key doesnt contain garbage bytes because of the used union structure for the ip addresses.
