### PR TITLE
Introduce a new NIC type Bluefield2

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Docker Image
 
 env:
-  platforms: linux/amd64
+  platforms: linux/amd64,linux/arm64
 
 on:
   push:

--- a/docs/deployment/help_dpservice-bin.md
+++ b/docs/deployment/help_dpservice-bin.md
@@ -14,7 +14,7 @@
 | --udp-virtsvc | IPv4,port,IPv6,port | map a VM-accessible IPv4 endpoint to an outside IPv6 UDP service |  |
 | --tcp-virtsvc | IPv4,port,IPv6,port | map a VM-accessible IPv4 endpoint to an outside IPv6 TCP service |  |
 | --wcmp | PERCENTAGE | weighted-cost-multipath percentage for pf0 (0 - 100) |  |
-| --nic-type | NICTYPE | NIC type to use | 'hw' (default) or 'tap' |
+| --nic-type | NICTYPE | NIC type to use | 'mellanox' (default), 'tap' or 'bluefield2' |
 | --no-stats | None | do not print periodic statistics to stdout |  |
 | --no-conntrack | None | disable connection tracking |  |
 | --enable-ipv6-overlay | None | enable IPv6 overlay addresses |  |

--- a/hack/dp_conf.json
+++ b/hack/dp_conf.json
@@ -80,8 +80,8 @@
       "help": "NIC type to use",
       "var": "nic_type",
       "type": "enum",
-      "choices": [ "hw", "tap" ],
-      "default": "hw"
+      "choices": [ "mellanox", "tap", "bluefield2" ],
+      "default": "mellanox"
     },
     {
       "lgopt": "no-stats",

--- a/include/dp_conf_opts.h
+++ b/include/dp_conf_opts.h
@@ -9,8 +9,9 @@
 /***********************************************************************/
 
 enum dp_conf_nic_type {
-	DP_CONF_NIC_TYPE_HW,
+	DP_CONF_NIC_TYPE_MELLANOX,
 	DP_CONF_NIC_TYPE_TAP,
+	DP_CONF_NIC_TYPE_BLUEFIELD2,
 };
 
 enum dp_conf_color {

--- a/src/dp_conf_opts.c
+++ b/src/dp_conf_opts.c
@@ -85,8 +85,9 @@ static const struct option dp_conf_longopts[] = {
 };
 
 static const char *nic_type_choices[] = {
-	"hw",
+	"mellanox",
 	"tap",
+	"bluefield2",
 };
 
 static const char *color_choices[] = {
@@ -105,7 +106,7 @@ static char pf1_name[IF_NAMESIZE];
 static char vf_pattern[IF_NAMESIZE];
 static int dhcp_mtu = 1500;
 static int wcmp_perc = 100;
-static enum dp_conf_nic_type nic_type = DP_CONF_NIC_TYPE_HW;
+static enum dp_conf_nic_type nic_type = DP_CONF_NIC_TYPE_MELLANOX;
 static bool stats_enabled = true;
 static bool conntrack_enabled = true;
 static bool ipv6_overlay_enabled = false;
@@ -233,7 +234,7 @@ static inline void dp_argparse_help(const char *progname, FILE *outfile)
 		"     --tcp-virtsvc=IPv4,port,IPv6,port  map a VM-accessible IPv4 endpoint to an outside IPv6 TCP service\n"
 #endif
 		"     --wcmp=PERCENTAGE                  weighted-cost-multipath percentage for pf0 (0 - 100)\n"
-		"     --nic-type=NICTYPE                 NIC type to use: 'hw' (default) or 'tap'\n"
+		"     --nic-type=NICTYPE                 NIC type to use: 'mellanox' (default), 'tap' or 'bluefield2'\n"
 		"     --no-stats                         do not print periodic statistics to stdout\n"
 		"     --no-conntrack                     disable connection tracking\n"
 		"     --enable-ipv6-overlay              enable IPv6 overlay addresses\n"

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -506,8 +506,12 @@ static int dp_port_public_flow_meter_config(struct dp_port *port, uint64_t publi
 
 int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uint64_t public_flow_rate_cap)
 {
-	if (dp_conf_get_nic_type() == DP_CONF_NIC_TYPE_TAP)
+	if (dp_conf_get_nic_type() != DP_CONF_NIC_TYPE_MELLANOX) {
+		if (public_flow_rate_cap != 0 || total_flow_rate_cap != 0)
+			DPS_LOG_WARNING("Metering config will not take effect due to the NIC type",
+							DP_LOG_PORT(port), DP_LOG_METER_TOTAL(total_flow_rate_cap), DP_LOG_METER_PUBLIC(public_flow_rate_cap));
 		return DP_OK;
+	}
 
 	if (public_flow_rate_cap > total_flow_rate_cap) {
 		DPS_LOG_ERR("Public flow rate cap cannot be greater than total flow rate cap",

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -89,7 +89,7 @@ static int get_num_of_vfs_pattern(void)
 
 int dp_get_num_of_vfs(void)
 {
-	int vfs = dp_conf_get_nic_type() == DP_CONF_NIC_TYPE_TAP
+	int vfs = dp_conf_get_nic_type() != DP_CONF_NIC_TYPE_MELLANOX
 		? get_num_of_vfs_pattern()
 		: get_num_of_vfs_sriov();
 


### PR DESCRIPTION
The sysfs structure on Bluefield2 is different and the VF sysfs entries are actually on the host side and not on the Bluefield side.
React on Bluefield2 card correctly by introducing it as a new NIC type.