### PR TITLE
Ignore sysfs  error for metering config due to unknow linux 6.x issue

### DIFF
--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include <net/if.h>
 #include <rte_byteorder.h>
 #include <rte_ethdev.h>

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -197,6 +197,9 @@ int dp_set_vf_rate_limit(uint16_t port_id, uint64_t rate)
 		return DP_ERROR;
 	}
 
+	if (access(filename, F_OK) == -1)
+		return -ENOENT; // Log as warning is done in the caller
+
 	fp = fopen(filename, "w+");
 	if (!fp) {
 		DPS_LOG_ERR("Cannot open SR-IOV sysfs path to vf's max tx rate", DP_LOG_RET(errno));


### PR DESCRIPTION
To make sure interface can be created on linux 6.x machines, if corresponding sysfs file cannot be found (more precisely, the who sriov directory does not exist), the configuration for metering parameter of total traffic is ignored for now. The reason why sriov directory does not exist or other approach will be investigated further.