### PR TITLE
Do not add empty IP address of an interface to the route table

### DIFF
--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -233,6 +233,10 @@ const char* CreateInterfaceCall::FillRequest(struct dpgrpc_request* request)
 	request->add_iface.vni = request_.vni();
 	if (!GrpcConv::StrToIpv4(request_.ipv4_config().primary_address(), &request->add_iface.ip4_addr))
 		return "Invalid ipv4_config.primary_address";
+	if (!GrpcConv::StrToIpv6(request_.ipv6_config().primary_address(), request->add_iface.ip6_addr))
+		return "Invalid ipv6_config.primary_address";
+	if (request->add_iface.ip4_addr == 0 && dp_is_ipv6_addr_zero(request->add_iface.ip6_addr))
+		return "Invalid ipv4_config.primary_address and ipv6_config.primary_address combination";
 	if (!request_.pxe_config().next_server().empty()) {
 		DPGRPC_LOG_INFO("Setting PXE",
 						DP_LOG_IFACE(request_.interface_id().c_str()),
@@ -245,8 +249,6 @@ const char* CreateInterfaceCall::FillRequest(struct dpgrpc_request* request)
 	}
 	if (SNPRINTF_FAILED(request->add_iface.pci_name, request_.device_name()))
 		return "Invalid device_name";
-	if (!GrpcConv::StrToIpv6(request_.ipv6_config().primary_address(), request->add_iface.ip6_addr))
-		return "Invalid ipv6_config.primary_address";
 	if (SNPRINTF_FAILED(request->add_iface.iface_id, request_.interface_id()))
 		return "Invalid interface_id";
 

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from helpers import *
+import pytest
 
 def test_grpc_addinterface_already_exists(prepare_ifaces, grpc_client):
 	# Try to add using an existing vm identifier
@@ -10,6 +11,9 @@ def test_grpc_addinterface_already_exists(prepare_ifaces, grpc_client):
 def test_grpc_addinterface_bad_interface(prepare_ifaces, grpc_client):
 	# Try to add without specifying PCI address or using a bad one
 	grpc_client.expect_error(201).addinterface("new_vm", "invalid", VM2.vni, VM2.ip, VM2.ipv6)
+	# Try to add with zero IPs
+	with pytest.raises(RuntimeError, match="Grpc client failed"):
+		grpc_client.addinterface(VM4.name, VM4.pci, VM4.vni, "0.0.0.0", "::")
 
 def test_grpc_getmachine_single(prepare_ifaces, grpc_client):
 	# Try to get a single existing interface(machine)


### PR DESCRIPTION
After introducing IPv6 support, it is a valid case that an interface has an ipv4 and no ipv6 address or vice versa but it can not have empty ipv4 and ipv6 addresses. So reflect these constraints to the code.
