### PR TITLE
Adjust prepare.sh script to support Bluefield 2

### DIFF
--- a/hack/prepare.sh
+++ b/hack/prepare.sh
@@ -9,8 +9,10 @@ set -Eeuo pipefail
 # Use as /usr/local/sbin/dp-prepare.sh
 #
 
+BLUEFIELD_IDENTIFIERS=("MT_0000000543")
 NUMVFS=126
 CONFIG="/tmp/dp_service.conf"
+IS_BLUEFIELD=false
 
 function log() {
 	echo "$(date +"%Y-%m-%d_%H-%M-%S-%3N") $1"
@@ -25,6 +27,21 @@ function get_pf() {
 	readarray -t devs < <(devlink dev | awk -F/ '{print $2}')
 }
 
+function detect_card_type() {
+	local pf="${devs[0]}"
+	for id in "${BLUEFIELD_IDENTIFIERS[@]}"; do
+		if devlink dev info pci/$pf | grep -q "$id"; then
+			IS_BLUEFIELD=true
+			log "Detected BlueField card with identifier $id on pf: $pf"
+			break
+		fi
+	done
+
+	if ! $IS_BLUEFIELD; then
+		log "Detected Mellanox card on pf: $pf"
+	fi
+}
+
 function validate() {
 	# we check if we have devlink available
 	if ! command -v devlink 2> /dev/null; then
@@ -33,6 +50,11 @@ function validate() {
 }
 
 function validate_pf() {
+	if $IS_BLUEFIELD; then
+		log "Skipping PF validation for BlueField card"
+		return
+	fi
+
 	# we check if sr-iov is enabled and the dev is using the mlx5 driver
 	unset valid_devs
 	for pf in "${devs[@]}"; do
@@ -52,6 +74,12 @@ function validate_pf() {
 }
 
 function create_vf() {
+	if $IS_BLUEFIELD; then
+		actualvfs=$NUMVFS
+		log "Skipping VF creation for BlueField card"
+		return
+	fi
+
 	local pf="${devs[0]}"
 	# we disable automatic binding so that VFs don't get created, saves a lot of time
 	# plus we don't need to unbind them before enabling switchdev mode
@@ -120,6 +148,7 @@ fi
 
 validate
 get_pf
+detect_card_type
 validate_pf
 create_vf
 make_config


### PR DESCRIPTION
Adjust prepare.sh in such a way that it supports bluefield 2 card in a backward compatible way and still works with mellanox cards.
Bluefield cards are configured on the host side but the Bluefield card side still needs the dp_service.conf so the script should 
generate dp_service.conf without complaining about the missing sysfs file parts on the bluefield.
