### PR TITLE
Update documentation to reflect DPDK 23.11 change

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 This is a beta version which
-- Uses [DPDK Graph Framework](https://doc.dpdk.org/guides/prog_guide/graph_lib.html) for the data plane. DPDK version 22.11 LTS or higher needed.
+- Uses [DPDK Graph Framework](https://doc.dpdk.org/guides/prog_guide/graph_lib.html) for the data plane. DPDK version 23.11 LTS or compatible needed.
 - [rte_flow](https://doc.dpdk.org/guides/prog_guide/rte_flow.html) offloading between the virtual network interfaces on a single heypervisor.
 - Uses GRPC to add virtual interfaces, loadbalancers, NAT Gateways and routes. There is a golang based GRPC
 test client (CLI) which can connect to the GRPC server

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -26,16 +26,15 @@ Dp-service currently only supports x86 architecture (amd64 instruction set actua
 
 
 ### DPDK
-The dataplane service is built upon the [DPDK library](https://dpdk.org). Currently, the only supported version is 22.11 LTS. Unfortunately, some patching is needed, thus it needs to be built from source. Building from source also has the advantage of easier debugging later.
+The dataplane service is built upon the [DPDK library](https://dpdk.org). Currently, the only supported version is 23.11 LTS. Unfortunately, some patching is needed, thus it needs to be built from source. Building from source also has the advantage of easier debugging later.
 ```bash
 git clone https://github.com/ironcore-dev/dpservice.git
-wget https://fast.dpdk.org/rel/dpdk-22.11.3.tar.xz
-tar xf dpdk-22.11.3.tar.xz
-cd dpdk-stable-22.11.3
-patch -p1 < ../dpservice/hack/dpdk_22_11_gcc12.patch
-patch -p1 < ../dpservice/hack/dpdk_22_11_log.patch
-patch -p1 < ../dpservice/hack/dpdk_22_11_telemetry_key.patch
-patch -p1 < ../dpservice/hack/dpdk_22_11_ethdev_conversion.patch
+wget https://fast.dpdk.org/rel/dpdk-23.11.tar.xz
+tar xf dpdk-23.11.tar.xz
+cd dpdk-stable-23.11
+patch -p1 < ../dpservice/hack/dpdk_23_11_log.patch
+patch -p1 < ../dpservice/hack/dpdk_23_11_telemetry_key.patch
+patch -p1 < ../dpservice/hack/dpdk_23_11_ethdev_conversion.patch
 meson setup build
 ninja -C build
 sudo ninja -C build install


### PR DESCRIPTION
Just some docs update so the dpservice build guide can still be followed step-by step with the updated DPDK library.