### PR TITLE
Remove duplicate rte_flow macro

### DIFF
--- a/include/rte_flow/dp_rte_flow_helpers.h
+++ b/include/rte_flow/dp_rte_flow_helpers.h
@@ -22,6 +22,10 @@ extern "C"
 
 #define DP_AGE_TIMEOUT_24BIT_MASK 0x00FFFFFF
 
+#define DP_RTE_FLOW_CAPTURE_PKT_HDR_SIZE (sizeof(struct rte_ether_hdr) \
+										  + sizeof(struct rte_ipv6_hdr) \
+										  + sizeof(struct rte_udp_hdr))
+
 union dp_flow_item_l3 {
 	struct rte_flow_item_ipv4 ipv4;
 	struct rte_flow_item_ipv6 ipv6;

--- a/src/rte_flow/dp_rte_flow_capture.c
+++ b/src/rte_flow/dp_rte_flow_capture.c
@@ -9,10 +9,6 @@
 #include "dp_conf.h"
 #include "monitoring/dp_monitoring.h"
 
-#define DP_RTE_FLOW_CAPTURE_PKT_HDR_SIZE (sizeof(struct rte_ether_hdr) \
-											 + sizeof(struct rte_ipv6_hdr) \
-											 + sizeof(struct rte_udp_hdr))
-
 // this attribute value is used to install a flow rule in the default group of a VF to switch between the capturing group and vnet group
 static const struct rte_flow_attr dp_flow_attr_default_jump_ingress = {
 	.group = DP_RTE_FLOW_DEFAULT_GROUP,

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -9,10 +9,6 @@
 #include "dp_conf.h"
 #include "monitoring/dp_monitoring.h"
 
-#define DP_RTE_FLOW_CAPTURE_PKT_HDR_SIZE (sizeof(struct rte_ether_hdr) \
-											 + sizeof(struct rte_ipv6_hdr) \
-											 + sizeof(struct rte_udp_hdr))
-
 static const struct rte_flow_attr dp_flow_attr_prio_ingress = {
 	.group = 0,
 	.priority = 1,


### PR DESCRIPTION
Just a removal of duplicate definition of the same macro. This is a PR in chain with #510