### PR TITLE
Test PR for pre-dpdk23 test

### DIFF
--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 
+
 #include "dp_vnf.h"
 #include <rte_malloc.h>
 #include "dp_error.h"


### PR DESCRIPTION
The idea is to find #513 happening before update to DPDK 23 so we can rule that out as a problem.