### PR TITLE
Fix packed structure being used for nat portmap hash key

### DIFF
--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -50,9 +50,13 @@ struct dnat_data {
 };
 
 struct netnat_portmap_key {
-	struct dp_ip_address	src_ip;
-	uint32_t				vni;
-	uint16_t				iface_src_port;
+	union {
+		uint8_t		src_ipv6[DP_IPV6_ADDR_SIZE];
+		uint32_t	src_ipv4;
+	};
+	uint16_t		src_type;
+	uint16_t		iface_src_port;
+	uint32_t		vni;
 } __rte_packed;
 
 struct netnat_portmap_data {

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -619,16 +619,17 @@ int dp_allocate_network_snat_port(struct snat_data *snat_data, struct dp_flow *d
 	uint64_t timestamp;
 
 	if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
-		portmap_key.src_ip.ipv4 = iface_src_ip;
+		portmap_key.src_ipv4 = iface_src_ip;
 		portoverload_tbl_key.dst_ip = ntohl(df->dst.dst_addr);
 	} else if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
-		rte_memcpy(portmap_key.src_ip.ipv6, df->src.src_addr6, sizeof(portmap_key.src_ip.ipv6));
+		rte_memcpy(portmap_key.src_ipv6, df->src.src_addr6, sizeof(portmap_key.src_ipv6));
 		portoverload_tbl_key.dst_ip = ntohl(*(rte_be32_t *)&df->dst.dst_addr6[12]);
 	} else {
 		return DP_GRPC_ERR_BAD_IPVER;
 	}
-	portmap_key.vni = vni;
+	portmap_key.src_type = df->l3_type;
 	portmap_key.iface_src_port = iface_src_port;
+	portmap_key.vni = vni;
 
 	portoverload_tbl_key.nat_ip = snat_data->nat_ip;
 	portoverload_tbl_key.dst_port = ntohs(df->l4_info.trans_port.dst_port);
@@ -732,12 +733,13 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 		return ret;
 
 	if (cntrack->flow_key[DP_FLOW_DIR_ORG].l3_type == RTE_ETHER_TYPE_IPV4)
-		portmap_key.src_ip.ipv4 = cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4;
+		portmap_key.src_ipv4 = cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4;
 	else if (cntrack->flow_key[DP_FLOW_DIR_ORG].l3_type == RTE_ETHER_TYPE_IPV6)
-		rte_memcpy(portmap_key.src_ip.ipv6, cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip6, sizeof(portmap_key.src_ip.ipv6));
+		rte_memcpy(portmap_key.src_ipv6, cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip6, sizeof(portmap_key.src_ipv6));
 	else
 		return DP_GRPC_ERR_BAD_IPVER;
 
+	portmap_key.src_type = cntrack->flow_key[DP_FLOW_DIR_ORG].l3_type;
 	portmap_key.iface_src_port = cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src;
 	portmap_key.vni = cntrack->nf_info.vni;
 

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -63,7 +63,7 @@ def test_neighnat_table_flush(prepare_ipv4, grpc_client, port_redundancy):
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 
 	global nat_only_port
-	nat_only_port = nat_local_min_port
+	nat_only_port = nat_local_min_port+1
 	tester = TCPTesterPublic(VM1, 12345, nat_ul_ipv6, PF0, public_ip, 443, server_pkt_check=tcp_server_nat_pkt_check)
 	tester.communicate()
 


### PR DESCRIPTION
I simply unrolled the `dp_ip_address` structure into the key, like `struct lb_key` does. There will be a bigger upcoming change to the `dp_ip_address` itself that will touch this code again, so I did not optimize anything.

I also noticed that the IP type was never set for this key, which would only be a problem when IPv4 followed by all zeroes would match an IPv6 I guess, but I still added the type.

I reordered the key for better alignment, that's why other fields are moved too.

The change in test is caused by a different hash for the same data (since I reordered and removed padding), thus a resulting NAT port is chosen differently.

Fixes #518