### PR TITLE
Discussion about potential problems in IPv4/IPv6 structures

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -69,6 +69,9 @@ enum dp_flow_tcp_state {
 };
 
 struct flow_key {
+	// my proposed refactor would be much simpler if there could be l3_type for *both* l3_src and l3_dst
+	// (as part of a common packed struct dp_ip_addr_key)
+	// I realize that having DST and SRC types differ makes no sense, so it would waste one byte, but all handling functions would be cleaner
 	union {
 		uint32_t	ip4;
 		uint8_t		ip6[DP_IPV6_ADDR_SIZE];

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -162,6 +162,7 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	flow_val->timeout_value = flow_timeout;
 	flow_val->created_port_id = port->port_id;
 
+	// what if key->l3_type == RTE_ETHER_TYPE_IPV6?
 	pfx_ip.ip_type = RTE_ETHER_TYPE_IPV4;
 	pfx_ip.ipv4 = key->l3_dst.ip4;
 	/* Target ip of the traffic is an alias prefix of a VM in the same VNI on this dp-service */

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -721,6 +721,7 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 	struct dp_port *created_port;
 	int ret;
 
+	// what if cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_type == RTE_ETHER_TYPE_IPV6?
 	portoverload_tbl_key.nat_ip = cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4;
 	portoverload_tbl_key.dst_ip = cntrack->flow_key[DP_FLOW_DIR_ORG].l3_dst.ip4;
 	portoverload_tbl_key.nat_port = cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst;

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -83,6 +83,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_flags |= DP_FLOW_FLAG_DST_NAT;
 			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+			// l3_type can be IPV6 in theory
 			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4 = ntohl(ipv4_hdr->dst_addr);
 			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 				return DNAT_NEXT_DROP;
@@ -102,6 +103,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 	if (DP_FLOW_HAS_FLAG_DST_NAT(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_ORG) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
+		// l3_type can be IPV6 in theory
 		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4);
 		df->nat_type = DP_NAT_CHG_DST_IP;
 		df->nat_addr = df->dst.dst_addr;
@@ -112,6 +114,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	/* We already know what to do */
 	if (DP_FLOW_HAS_FLAG_SRC_NAT(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_REPLY) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
+		// l3_type can be IPV6 in theory
 		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4);
 		if (cntrack->nf_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
 			if (df->l4_type == IPPROTO_ICMP) {
@@ -122,6 +125,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 					dp_get_icmp_err_ip_hdr(m, &icmp_err_ip_info);
 					if (!icmp_err_ip_info.err_ipv4_hdr || !icmp_err_ip_info.l4_src_port || !icmp_err_ip_info.l4_dst_port)
 						return DNAT_NEXT_DROP;
+					// l3_type can be IPV6 in theory
 					icmp_err_ip_info.err_ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4);
 					icmp_err_ip_info.err_ipv4_hdr->hdr_checksum = cntrack->nf_info.icmp_err_ip_cksum;
 					dp_change_icmp_err_l4_src_port(m, &icmp_err_ip_info, cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src);

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -65,6 +65,7 @@ static __rte_always_inline int dp_process_ipv4_snat(struct rte_mbuf *m, struct d
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+	// l3_type can be IPV6 in theory
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = ntohl(ipv4_hdr->src_addr);
 	if (snat_data->nat_ip != 0)
 		cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
@@ -189,6 +190,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	/* We already know what to do */
 	if (DP_FLOW_HAS_FLAG_SRC_NAT(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_ORG) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
+		// l3_type can be IPV6 in theory
 		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4);
 
 		if (cntrack->nf_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
@@ -208,6 +210,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		&& (df->flow_dir == DP_FLOW_DIR_REPLY)) {
 		ipv4_hdr = dp_get_ipv4_hdr(m);
 		df->src.src_addr = ipv4_hdr->src_addr;
+		// l3_type can be IPV6 in theory
 		ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_dst.ip4);
 		df->nat_addr = ipv4_hdr->src_addr;
 		df->nat_type = DP_NAT_CHG_SRC_IP;


### PR DESCRIPTION
I noticed the following inconsistencies when trying to add some safer wrappers around all the places where (now dual IPv4/IPv6) IP address needs to be present in some hash key.

The last place that needs it is `struct dp_flow_key` and while doing the change I noticed that sometimes the code is not updated to the new fact that the IP can be both IPv4 and IPv6.
