### PR TITLE
Fix for running automation test on the tester machine

### DIFF
--- a/test/dp_service.py
+++ b/test/dp_service.py
@@ -36,7 +36,7 @@ class DpService:
 			script_path = os.path.dirname(os.path.abspath(__file__))
 			self.cmd = f"gdb -x {script_path}/gdbinit --args "
 
-		self.cmd += f'{self.build_path}/src/dpservice-bin -l 0,1 --log-level=user*:8'
+		self.cmd += f'{self.build_path}/src/dpservice-bin -l 0,1 --log-level=user*:8 --huge-unlink '
 		if not self.hardware:
 			self.cmd += (f' --no-pci'
 						 f' --vdev={PF0.pci},iface={PF0.tap},mac="{PF0.mac}"'


### PR DESCRIPTION
It seems to be the most probable fix for #513. As it does not fail for continues re-running of the corresponding build&test step and after the forcing-updating. And it makes dpdk app to give back huge page resource to OS after each execution. As explained in the [documentation](https://doc.dpdk.org/guides/linux_gsg/linux_eal_parameters.html), using this flag makes it impossible to start a secondary process, which is not required in automation tests. It is worthy of merging it to verify in a long term period.

```
root@dpdk-github-runner:/home/tli# grep HugePages /proc/meminfo
AnonHugePages:    223232 kB
ShmemHugePages:        0 kB
FileHugePages:         0 kB
HugePages_Total:       4
HugePages_Free:        3
HugePages_Rsvd:        0
HugePages_Surp:        0
root@dpdk-github-runner:/home/tli# grep HugePages /proc/meminfo
AnonHugePages:    202752 kB
ShmemHugePages:        0 kB
FileHugePages:         0 kB
HugePages_Total:       4
HugePages_Free:        4
HugePages_Rsvd:        0
HugePages_Surp:        0
```