### PR TITLE
`dp_ip_address` structure safety

### DIFF
--- a/include/dp_firewall.h
+++ b/include/dp_firewall.h
@@ -7,10 +7,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #include <sys/queue.h>
 #include <rte_common.h>
+#include "dp_ipaddr.h"
 #include "dp_mbuf_dyn.h"
-#include "dp_util.h"
+
+#define DP_FIREWALL_ID_MAX_LEN	64
 
 #define DP_FWALL_MATCH_ANY_PORT			0xFFFFFFFF
 #define DP_FWALL_MATCH_ANY_ICMP_TYPE	0xFFFFFFFF

--- a/include/dp_firewall.h
+++ b/include/dp_firewall.h
@@ -47,8 +47,8 @@ struct dp_port_filter {
 
 struct dp_ip_mask {
 	union {
+		uint8_t  ip6[DP_IPV6_ADDR_SIZE];
 		uint32_t ip4;
-		uint8_t ip6[DP_IPV6_ADDR_SIZE];
 	};
 };
 
@@ -61,8 +61,8 @@ struct dp_fwall_rule {
 	uint16_t				priority;
 	uint8_t					protocol;
 	union {
-		struct dp_icmp_filter icmp;
 		struct dp_port_filter tcp_udp;
+		struct dp_icmp_filter icmp;
 	} filter;
 	enum dp_fwall_action action;
 	enum dp_fwall_direction dir;

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -83,7 +83,7 @@ struct flow_key {
 		uint16_t type_src; /* ICMP */
 	} src;
 	uint32_t vni;
-	uint16_t l3_type;
+	bool     is_v6;
 	uint8_t  proto;
 	enum dp_vnf_type vnf_type;
 } __rte_packed;

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -9,8 +9,8 @@
 #include <rte_flow.h>
 #include <rte_malloc.h>
 #include "dpdk_layer.h"
+#include "dp_ipaddr.h"
 #include "dp_firewall.h"
-#include "dp_util.h"
 #include "dp_mbuf_dyn.h"
 #include "dp_refcount.h"
 #include "dp_timers.h"

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -70,12 +70,12 @@ enum dp_flow_tcp_state {
 
 struct flow_key {
 	union {
-		uint32_t	ip4;
 		uint8_t		ip6[DP_IPV6_ADDR_SIZE];
+		uint32_t	ip4;
 	} l3_dst;
 	union {
-		uint32_t	ip4;
 		uint8_t		ip6[DP_IPV6_ADDR_SIZE];
+		uint32_t	ip4;
 	} l3_src;
 	uint16_t port_dst;
 	union {

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -69,10 +69,10 @@ enum dp_flow_tcp_state {
 };
 
 struct flow_key {
-	struct dp_ip_addr_key l3_dst;
+	struct dp_ip_address l3_dst;
 	uint8_t  proto;
 	uint16_t port_dst;
-	struct dp_ip_addr_key l3_src;
+	struct dp_ip_address l3_src;
 	enum dp_vnf_type vnf_type;
 	union {
 		uint16_t port_src;

--- a/include/dp_iface.h
+++ b/include/dp_iface.h
@@ -38,6 +38,7 @@ void dp_fill_ether_hdr(struct rte_ether_hdr *ether_hdr, const struct dp_port *po
 	ether_hdr->ether_type = htons(ether_type);
 }
 
+// TODO move this to ipaddr.h
 static __rte_always_inline
 bool dp_is_ipv6_addr_zero(const uint8_t *addr)
 {

--- a/include/dp_iface.h
+++ b/include/dp_iface.h
@@ -38,14 +38,6 @@ void dp_fill_ether_hdr(struct rte_ether_hdr *ether_hdr, const struct dp_port *po
 	ether_hdr->ether_type = htons(ether_type);
 }
 
-// TODO move this to ipaddr.h
-static __rte_always_inline
-bool dp_is_ipv6_addr_zero(const uint8_t *addr)
-{
-	static_assert(DP_IPV6_ADDR_SIZE == 2 * sizeof(uint64_t), "uint64_t doesn't have the expected size");
-	return *((const uint64_t *)addr) == 0 && *((const uint64_t *)(addr + sizeof(uint64_t))) == 0;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -32,7 +32,7 @@ bool dp_is_ipv6_addr_zero(const uint8_t *addr)
 // made read-only without the right macro to prevent uninitialized bytes due to the the use of this structure in hash keys
 struct dp_ip_address {
 	union {
-		uint64_t		_data[DP_IPV6_ADDR_SIZE/sizeof(uint64_t)];
+		uint8_t			_data[DP_IPV6_ADDR_SIZE];
 		const uint8_t	ipv6[DP_IPV6_ADDR_SIZE];
 		const uint32_t	ipv4;
 	};
@@ -63,8 +63,8 @@ static __rte_always_inline
 void dp_copy_ipaddr(struct dp_ip_address *dst, const struct dp_ip_address *src)
 {
 	dst->_is_v6 = src->_is_v6;
-	dst->_data[0] = src->_data[0];
-	dst->_data[1] = src->_data[1];
+	((uint64_t *)dst->_data)[0] = ((const uint64_t *)src->_data)[0];
+	((uint64_t *)dst->_data)[1] = ((const uint64_t *)src->_data)[1];
 }
 
 // These cannot be inlines due to sizeof() being checked for IPv6
@@ -74,14 +74,14 @@ void dp_copy_ipaddr(struct dp_ip_address *dst, const struct dp_ip_address *src)
 } while (0)
 #define DP_SET_IPADDR6_UNSAFE(ADDR, IPV6) do { \
 	(ADDR)._is_v6 = true; \
-	(ADDR)._data[0] = ((const uint64_t *)(IPV6))[0]; \
-	(ADDR)._data[1] = ((const uint64_t *)(IPV6))[1]; \
+	((uint64_t *)(ADDR)._data)[0] = ((const uint64_t *)(IPV6))[0]; \
+	((uint64_t *)(ADDR)._data)[1] = ((const uint64_t *)(IPV6))[1]; \
 } while (0)
 
 #define DP_SET_IPADDR4(ADDR, IPV4) do { \
 	(ADDR)._is_v6 = false; \
-	(ADDR)._data[0] = (ADDR)._data[1] = 0; \
-	*(uint32_t *)(ADDR)._data = (IPV4); \
+	((uint64_t *)(ADDR)._data)[0] = ((uint64_t *)(ADDR)._data)[1] = 0; \
+	((uint32_t *)(ADDR)._data)[0] = (IPV4); \
 } while (0)
 
 

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -8,6 +8,7 @@
 extern "C" {
 #endif
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -16,10 +17,59 @@ extern "C" {
 struct dp_ip_address {
 	bool			is_v6;
 	union {
+		// TODO maybe define this so there is no code duplication
+		uint32_t	_data[4];
+		// TODO should this be visible or not?
 		uint8_t		ipv6[DP_IPV6_ADDR_SIZE];
 		uint32_t	ipv4;
 	};
 };
+
+// To be used for hash keys needing dp_ip_address
+static_assert(sizeof(uint32_t)*4 == DP_IPV6_ADDR_SIZE, "DP_IPV6_ADDR_SIZE is invalid");
+struct dp_ip_addr_key {
+	uint32_t	_data[4];
+	// TODO also hide using underscore?
+	bool		is_v6;
+} __rte_packed;
+
+static __rte_always_inline
+void dp_fill_ipaddr(struct dp_ip_address *dst_addr, const struct dp_ip_addr_key *src_key)
+{
+	dst_addr->is_v6 = src_key->is_v6;
+	dst_addr->_data[0] = src_key->_data[0];
+	dst_addr->_data[1] = src_key->_data[1];
+	dst_addr->_data[2] = src_key->_data[2];
+	dst_addr->_data[3] = src_key->_data[3];
+}
+
+static __rte_always_inline
+void dp_fill_ipkey(struct dp_ip_addr_key *dst_key, const struct dp_ip_address *src_addr)
+{
+	dst_key->is_v6 = src_addr->is_v6;
+	dst_key->_data[0] = src_addr->_data[0];
+	dst_key->_data[1] = src_addr->_data[1];
+	dst_key->_data[2] = src_addr->_data[2];
+	dst_key->_data[3] = src_addr->_data[3];
+}
+// TODO macro/inline to copy the array
+
+// These cannot be inlines due to sizeof() being checked here
+#define DP_FILL_IPKEY6(KEY, IPV6) do { \
+	static_assert(sizeof(IPV6) == DP_IPV6_ADDR_SIZE, "Invalid IPv6 byte array passed to DP_FILL_IPKEY6()"); \
+	(KEY).is_v6 = true; \
+	(KEY)._data[0] = ((const uint32_t *)(IPV6))[0]; \
+	(KEY)._data[1] = ((const uint32_t *)(IPV6))[1]; \
+	(KEY)._data[2] = ((const uint32_t *)(IPV6))[2]; \
+	(KEY)._data[3] = ((const uint32_t *)(IPV6))[3]; \
+} while (0)
+
+#define DP_FILL_IPKEY4(KEY, IPV4) do { \
+	(KEY).is_v6 = false; \
+	(KEY)._data[0] = (IPV4); \
+	(KEY)._data[1] = (KEY)._data[2] = (KEY)._data[3] = 0; \
+} while (0)
+
 
 // inspired by DPDK's RTE_ETHER_ADDR_PRT_FMT and RTE_ETHER_ADDR_BYTES
 // network byte-order!

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -19,7 +19,7 @@ static_assert(sizeof(uint64_t) * 2 == DP_IPV6_ADDR_SIZE, "DP_IPV6_ADDR_SIZE is i
 
 // TODO(plague): do something for naked ipv6, that uses uint8_t, thus cannot check size properly
 
-// TODO(plague): move NAT64 handling here (part of the above)
+// TODO(plague): move NAT64 handling here (part of the above) + grep for [12] which means NAT64 ipv6 -> ipv4 conversion and wrap it
 
 // TODO(plague): This either needs to be a macro to enable checking for sizeof(addr) (or see above for the proposed ipv6 type)
 static __rte_always_inline

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __INCLUDE_DP_IPADDR_H__
+#define __INCLUDE_DP_IPADDR_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define DP_IPV6_ADDR_SIZE 16
+
+struct dp_ip_address {
+	bool			is_v6;
+	union {
+		uint8_t		ipv6[DP_IPV6_ADDR_SIZE];
+		uint32_t	ipv4;
+	};
+};
+
+// inspired by DPDK's RTE_ETHER_ADDR_PRT_FMT and RTE_ETHER_ADDR_BYTES
+// network byte-order!
+#define DP_IPV4_PRINT_FMT       "%u.%u.%u.%u"
+#define DP_IPV4_PRINT_BYTES(ip) (ip) & 0xFF, \
+								((ip) >> 8) & 0xFF, \
+								((ip) >> 16) & 0xFF, \
+								((ip) >> 24) & 0xFF
+
+#define DP_IPV6_PRINT_FMT       "%x:%x:%x:%x:%x:%x:%x:%x"
+#define DP_IPV6_PRINT_BYTES(ip) rte_cpu_to_be_16(((uint16_t *)(ip))[0]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[1]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[2]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[3]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[4]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[5]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[6]), \
+								rte_cpu_to_be_16(((uint16_t *)(ip))[7])
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -58,8 +58,6 @@ void dp_copy_ipaddr(struct dp_ip_address *dst, const struct dp_ip_address *src)
 // TODO macro/inline to copy the array??
 // TODO actually a helpful macro to copy IPv6 and guard the sizeof!
 
-// TODO move the is_addr_zero here
-
 // These cannot be inlines due to sizeof() being checked for IPv6
 #define DP_SET_IPADDR6(ADDR, IPV6) do { \
 	static_assert(sizeof(IPV6) == DP_IPV6_ADDR_SIZE, "Invalid IPv6 byte array passed to DP_FILL_IPADDR6()"); \
@@ -78,11 +76,19 @@ void dp_copy_ipaddr(struct dp_ip_address *dst, const struct dp_ip_address *src)
 	(ADDR)._data[0] = (IPV4); \
 	(ADDR)._data[1] = (ADDR)._data[2] = (ADDR)._data[3] = 0; \
 } while (0)
+// TODO why not use uint64_t ??
 
 // TODO move NAT64 here?
 
 
-// TODO these should be obsolete by now (logging already provides this)
+// TODO(plague): This needs to be a macro to enable checking for sizeof(addr)
+static __rte_always_inline
+bool dp_is_ipv6_addr_zero(const uint8_t *addr)
+{
+	static_assert(DP_IPV6_ADDR_SIZE == 2 * sizeof(uint64_t), "uint64_t doesn't have the expected size");
+	return *((const uint64_t *)addr) == 0 && *((const uint64_t *)(addr + sizeof(uint64_t))) == 0;
+}
+
 // inspired by DPDK's RTE_ETHER_ADDR_PRT_FMT and RTE_ETHER_ADDR_BYTES
 // network byte-order!
 #define DP_IPV4_PRINT_FMT       "%u.%u.%u.%u"

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -24,8 +24,8 @@ struct lb_key {
 		uint8_t		v6[DP_IPV6_ADDR_SIZE];
 		uint32_t	v4;
 	} ip;
-	uint16_t	ip_type;
 	uint32_t	vni;
+	bool		is_v6;
 } __rte_packed;
 
 struct lb_port {

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -21,8 +21,8 @@ extern "C" {
 
 struct lb_key {
 	union {
-		uint32_t	v4;
 		uint8_t		v6[DP_IPV6_ADDR_SIZE];
+		uint32_t	v4;
 	} ip;
 	uint16_t	ip_type;
 	uint32_t	vni;

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -20,12 +20,8 @@ extern "C" {
 #define DP_LB_DLB	3
 
 struct lb_key {
-	union {
-		uint8_t		v6[DP_IPV6_ADDR_SIZE];
-		uint32_t	v4;
-	} ip;
-	uint32_t	vni;
-	bool		is_v6;
+	uint32_t				vni;
+	struct dp_ip_addr_key	ip;
 } __rte_packed;
 
 struct lb_port {

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -21,7 +21,7 @@ extern "C" {
 
 struct lb_key {
 	uint32_t				vni;
-	struct dp_ip_addr_key	ip;
+	struct dp_ip_address	ip;
 } __rte_packed;
 
 struct lb_port {

--- a/include/dp_log.h
+++ b/include/dp_log.h
@@ -59,6 +59,8 @@ extern "C" {
 #define DP_LOG_DST_IPV4(VALUE) _DP_LOG_IPV4("dst_ipv4", VALUE)
 #define DP_LOG_SRC_IPV6(VALUE) _DP_LOG_IPV6("src_ipv6", VALUE)
 #define DP_LOG_DST_IPV6(VALUE) _DP_LOG_IPV6("dst_ipv6", VALUE)
+#define DP_LOG_SRC_IPSTR(VALUE) _DP_LOG_STR("src_ip", VALUE)
+#define DP_LOG_DST_IPSTR(VALUE) _DP_LOG_STR("dst_ip", VALUE)
 #define DP_LOG_L4PORT(VALUE) _DP_LOG_UINT("port", VALUE)
 #define DP_LOG_SRC_PORT(VALUE) _DP_LOG_UINT("src_port", VALUE)
 #define DP_LOG_DST_PORT(VALUE) _DP_LOG_UINT("dst_port", VALUE)

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -11,7 +11,6 @@
 #include <rte_flow.h>
 #include "dpdk_layer.h"
 #include "dp_mbuf_dyn.h"
-#include "dp_util.h"
 #include "dp_firewall.h"
 
 #ifdef __cplusplus

--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -58,12 +58,12 @@ struct dp_flow {
 	uint16_t	l3_type;  //layer-3 for inner packets. it can be crafted or extracted from raw frames
 	uint32_t	l3_payload_length;  //layer-3 playload length for inner packets.
 	union {
-		rte_be32_t	dst_addr;
 		uint8_t		dst_addr6[16];
+		rte_be32_t	dst_addr;
 	} dst;
 	union {
-		rte_be32_t	src_addr;
 		uint8_t		src_addr6[16];
+		rte_be32_t	src_addr;
 	} src;
 	rte_be32_t	nat_addr;
 	uint16_t	nat_port;

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -27,8 +27,8 @@ struct nat_key {
 
 typedef struct network_nat_entry {
 	union {
-		uint32_t	nat_ip4;
 		uint8_t		nat_ip6[DP_IPV6_ADDR_SIZE];
+		uint32_t	nat_ip4;
 	} nat_ip;
 	uint16_t	port_range[2];
 	uint32_t	vni;

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -94,7 +94,7 @@ void dp_nat_chg_ip(struct dp_flow *df, struct rte_ipv4_hdr *ipv4_hdr,
 				   struct rte_mbuf *m);
 
 int dp_nat_chg_ipv6_to_ipv4_hdr(struct dp_flow *df, struct rte_mbuf *m, uint32_t nat_ip, rte_be32_t *dest_ip /* out */);
-int dp_nat_chg_ipv4_to_ipv6_hdr(struct dp_flow *df, struct rte_mbuf *m, uint8_t *ipv6_addr);
+int dp_nat_chg_ipv4_to_ipv6_hdr(struct dp_flow *df, struct rte_mbuf *m, const uint8_t *ipv6_addr);
 
 void dp_del_vip_from_dnat(uint32_t d_ip, uint32_t vni);
 

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -54,9 +54,9 @@ struct netnat_portmap_key {
 		uint8_t		src_ipv6[DP_IPV6_ADDR_SIZE];
 		uint32_t	src_ipv4;
 	};
-	uint16_t		src_type;
-	uint16_t		iface_src_port;
 	uint32_t		vni;
+	uint16_t		iface_src_port;
+	bool			src_is_v6;
 } __rte_packed;
 
 struct netnat_portmap_data {

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -9,6 +9,7 @@
 #include <rte_common.h>
 #include <rte_mbuf.h>
 #include "dp_flow.h"
+#include "dp_ipaddr.h"
 #include "grpc/dp_grpc_responder.h"
 
 #ifdef __cplusplus
@@ -49,13 +50,9 @@ struct dnat_data {
 };
 
 struct netnat_portmap_key {
-	union {
-		uint8_t		src_ipv6[DP_IPV6_ADDR_SIZE];
-		uint32_t	src_ipv4;
-	};
-	uint32_t		vni;
-	uint16_t		iface_src_port;
-	bool			src_is_v6;
+	uint32_t				vni;
+	struct dp_ip_addr_key	src_ip;
+	uint16_t				iface_src_port;
 } __rte_packed;
 
 struct netnat_portmap_data {

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -51,7 +51,7 @@ struct dnat_data {
 
 struct netnat_portmap_key {
 	uint32_t				vni;
-	struct dp_ip_addr_key	src_ip;
+	struct dp_ip_address	src_ip;
 	uint16_t				iface_src_port;
 } __rte_packed;
 

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -9,7 +9,6 @@
 #include <rte_common.h>
 #include <rte_mbuf.h>
 #include "dp_flow.h"
-#include "dp_util.h"
 #include "grpc/dp_grpc_responder.h"
 
 #ifdef __cplusplus

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -10,9 +10,9 @@
 #include <rte_pci.h>
 #include <rte_meter.h>
 #include "dp_conf.h"
-#include "dp_util.h"
 #include "dp_firewall.h"
 #include "dp_internal_stats.h"
+#include "dp_util.h"
 #include "dpdk_layer.h"
 
 #ifdef __cplusplus

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -43,8 +43,8 @@ extern "C" {
 struct dp_ip_address {
 	uint16_t		ip_type;
 	union {
-		uint32_t	ipv4;
 		uint8_t		ipv6[DP_IPV6_ADDR_SIZE];
+		uint32_t	ipv4;
 	};
 };
 

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -41,7 +41,7 @@ extern "C" {
 	(((FLAGS) & (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG)) == (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG))
 
 struct dp_ip_address {
-	uint16_t		ip_type;
+	bool			is_v6;
 	union {
 		uint8_t		ipv6[DP_IPV6_ADDR_SIZE];
 		uint32_t	ipv4;

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -18,11 +18,9 @@ extern "C" {
 #include <rte_log.h>
 #include <rte_mbuf.h>
 
-#define DP_FIREWALL_ID_MAX_LEN	64
 #define DP_IFACE_PXE_MAX_LEN	32
 #define DP_LB_ID_MAX_LEN		64
 #define DP_LB_MAX_PORTS			16
-#define DP_IPV6_ADDR_SIZE		16
 
 #define DP_MAC_EQUAL(mac1, mac2) (((mac1)->addr_bytes[0] == (mac2)->addr_bytes[0]) && \
 								((mac1)->addr_bytes[1] == (mac2)->addr_bytes[1]) && \
@@ -40,13 +38,6 @@ extern "C" {
 #define DP_TCP_PKT_FLAG_SYNACK(FLAGS) \
 	(((FLAGS) & (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG)) == (RTE_TCP_SYN_FLAG|RTE_TCP_ACK_FLAG))
 
-struct dp_ip_address {
-	bool			is_v6;
-	union {
-		uint8_t		ipv6[DP_IPV6_ADDR_SIZE];
-		uint32_t	ipv4;
-	};
-};
 
 int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char ifname[IF_NAMESIZE]);
 
@@ -59,24 +50,6 @@ void dp_free_jhash_table(struct rte_hash *table);
 
 int dp_set_vf_rate_limit(uint16_t port_id, uint64_t rate);
 
-
-// inspired by DPDK's RTE_ETHER_ADDR_PRT_FMT and RTE_ETHER_ADDR_BYTES
-// network byte-order!
-#define DP_IPV4_PRINT_FMT       "%u.%u.%u.%u"
-#define DP_IPV4_PRINT_BYTES(ip) (ip) & 0xFF, \
-								((ip) >> 8) & 0xFF, \
-								((ip) >> 16) & 0xFF, \
-								((ip) >> 24) & 0xFF
-
-#define DP_IPV6_PRINT_FMT       "%x:%x:%x:%x:%x:%x:%x:%x"
-#define DP_IPV6_PRINT_BYTES(ip) rte_cpu_to_be_16(((uint16_t *)(ip))[0]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[1]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[2]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[3]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[4]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[5]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[6]), \
-								rte_cpu_to_be_16(((uint16_t *)(ip))[7])
 
 #ifdef __cplusplus
 }

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <rte_common.h>
-#include "dp_util.h"
+#include "dp_ipaddr.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/grpc/dp_grpc_conv.h
+++ b/include/grpc/dp_grpc_conv.h
@@ -19,6 +19,7 @@ namespace GrpcConv
 	bool StrToIpv4(const std::string& str, uint32_t *dst);
 	bool StrToIpv6(const std::string& str, uint8_t *dst);
 
+	bool StrToDpAddress(const std::string& str, struct dp_ip_address *dp_addr, IpVersion ipver);
 	bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr);
 
 	bool GrpcToDpVniType(const VniType& grpc_type, enum dpgrpc_vni_type *dp_type);

--- a/include/rte_flow/dp_rte_flow_helpers.h
+++ b/include/rte_flow/dp_rte_flow_helpers.h
@@ -27,8 +27,8 @@ extern "C"
 										  + sizeof(struct rte_udp_hdr))
 
 union dp_flow_item_l3 {
-	struct rte_flow_item_ipv4 ipv4;
 	struct rte_flow_item_ipv6 ipv6;
+	struct rte_flow_item_ipv4 ipv4;
 };
 
 union dp_flow_item_l4 {

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -162,7 +162,7 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	flow_val->timeout_value = flow_timeout;
 	flow_val->created_port_id = port->port_id;
 
-	pfx_ip.ip_type = RTE_ETHER_TYPE_IPV4;
+	pfx_ip.is_v6 = false;
 	pfx_ip.ipv4 = key->l3_dst.ip4;
 	/* Target ip of the traffic is an alias prefix of a VM in the same VNI on this dp-service */
 	/* This will be an uni-directional traffic, which does not expect its corresponding reverse traffic */
@@ -245,14 +245,15 @@ static __rte_always_inline int dp_get_flow_val(struct rte_mbuf *m, struct dp_flo
 		return ret;
 
 	// highly optimized comparator for a specific key size
-	static_assert(sizeof(struct flow_key) == 44, "struct flow_key changed size");
+	static_assert(sizeof(struct flow_key) == 43, "struct flow_key changed size");
 	if (prev_key
 		&& ((const uint64_t *)curr_key)[0] == ((const uint64_t *)prev_key)[0]
 		&& ((const uint64_t *)curr_key)[1] == ((const uint64_t *)prev_key)[1]
 		&& ((const uint64_t *)curr_key)[2] == ((const uint64_t *)prev_key)[2]
 		&& ((const uint64_t *)curr_key)[3] == ((const uint64_t *)prev_key)[3]
 		&& ((const uint64_t *)curr_key)[4] == ((const uint64_t *)prev_key)[4]
-		&& ((const uint32_t *)curr_key)[20] == ((const uint32_t *)prev_key)[20]
+		&& ((const uint16_t *)curr_key)[20] == ((const uint16_t *)prev_key)[20]
+		&& ((const uint8_t *)curr_key)[42] == ((const uint8_t *)prev_key)[42]
 	) {
 		// flow is the same as it was for the previous packet
 		*p_flow_val = cached_flow_val;

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -190,11 +190,6 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	// Implicit casting from hash_sig_t to uint32_t!
 	df->dp_flow_hash = dp_get_conntrack_flow_hash_value(key);
 
-	/* Zero out the whole address part of the keys for IPv4 as the stack may have garbage in the unused part */
-	if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
-		memset(inverted_key.l3_dst.ip6, 0, sizeof(inverted_key.l3_dst.ip6));
-		memset(inverted_key.l3_src.ip6, 0, sizeof(inverted_key.l3_src.ip6));
-	}
 	dp_invert_flow_key(key, df->l3_type, &inverted_key);
 	flow_val->flow_key[DP_FLOW_DIR_REPLY] = inverted_key;
 	if (DP_FAILED(dp_add_flow(&inverted_key, flow_val)))

--- a/src/dp_firewall.c
+++ b/src/dp_firewall.c
@@ -96,8 +96,10 @@ static __rte_always_inline bool dp_is_rule_matching(const struct dp_fwall_rule *
 	uint8_t protocol = df->l4_type;
 	uint16_t dest_port = 0;
 	uint16_t src_port = 0;
+	uint16_t src_type = rule->src_ip.is_v6 ? RTE_ETHER_TYPE_IPV6 : RTE_ETHER_TYPE_IPV4;
+	uint16_t dest_type = rule->dest_ip.is_v6 ? RTE_ETHER_TYPE_IPV6 : RTE_ETHER_TYPE_IPV4;
 
-	if ((rule->src_ip.ip_type != df->l3_type) && (rule->dest_ip.ip_type != df->l3_type))
+	if (src_type != df->l3_type && dest_type != df->l3_type)
 		return false;
 
 	switch (df->l4_type) {

--- a/src/dp_firewall.c
+++ b/src/dp_firewall.c
@@ -22,7 +22,7 @@ int dp_add_firewall_rule(const struct dp_fwall_rule *new_rule, struct dp_port *p
 	if (!rule)
 		return DP_ERROR;
 
-	*rule = *new_rule;
+	rte_memcpy(rule, new_rule, sizeof(*rule));
 	TAILQ_INSERT_TAIL(&port->iface.fwall_head, rule, next_rule);
 
 	return DP_OK;
@@ -68,7 +68,7 @@ int dp_list_firewall_rules(const struct dp_port *port, struct dp_grpc_responder 
 		reply = dp_grpc_add_reply(responder);
 		if (!reply)
 			return DP_GRPC_ERR_OUT_OF_MEMORY;
-		reply->rule = *rule;
+		rte_memcpy(&reply->rule, rule, sizeof(reply->rule));
 	}
 
 	return DP_GRPC_OK;

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -156,6 +156,7 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 
 	switch (df->l3_type) {
 	case RTE_ETHER_TYPE_IPV4:
+		// TODO could be optimized by only setting the non-ipv4 bytes to zero
 		memset(key->l3_src.ip6, 0, sizeof(key->l3_src.ip6));
 		memset(key->l3_dst.ip6, 0, sizeof(key->l3_dst.ip6));
 		key->l3_dst.ip4 = ntohl(df->dst.dst_addr);
@@ -166,8 +167,8 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 		rte_memcpy(key->l3_src.ip6, df->src.src_addr6, sizeof(key->l3_src.ip6));
 		break;
 	default:
-		key->l3_dst.ip4 = 0;
-		key->l3_src.ip4 = 0;
+		memset(key->l3_src.ip6, 0, sizeof(key->l3_src.ip6));
+		memset(key->l3_dst.ip6, 0, sizeof(key->l3_dst.ip6));
 		break;
 	}
 

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -208,6 +208,9 @@ int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in *
 void dp_invert_flow_key(const struct flow_key *key /* in */, uint16_t l3_type /* in */, struct flow_key *inv_key /* out */)
 {
 	if (l3_type == RTE_ETHER_TYPE_IPV4) {
+		// TODO this could be optimized to just zero the sizeof(ipv6)-sizeof(ipv4) bytes
+		memset(inv_key->l3_dst.ip6, 0, sizeof(inv_key->l3_dst.ip6));
+		memset(inv_key->l3_src.ip6, 0, sizeof(inv_key->l3_src.ip6));
 		inv_key->l3_src.ip4 = key->l3_dst.ip4;
 		inv_key->l3_dst.ip4 = key->l3_src.ip4;
 	} else {

--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -158,11 +158,11 @@ bool dp_is_ip_lb(struct dp_flow *df, uint32_t vni)
 
 	lb_key.vni = vni;
 
-	if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
+	if (df->l3_type == RTE_ETHER_TYPE_IPV4)
 		DP_SET_IPADDR4(lb_key.ip, ntohl(df->dst.dst_addr));
-	} else if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
+	else if (df->l3_type == RTE_ETHER_TYPE_IPV6)
 		DP_SET_IPADDR6(lb_key.ip, df->dst.dst_addr6);
-	} else
+	else
 		return false;
 
 	return !DP_FAILED(rte_hash_lookup(ipv4_lb_tbl, &lb_key));
@@ -277,7 +277,9 @@ int dp_get_lb_back_ips(const void *id_key, struct dp_grpc_responder *responder)
 			reply = dp_grpc_add_reply(responder);
 			if (!reply)
 				return DP_GRPC_ERR_OUT_OF_MEMORY;
-			DP_SET_IPADDR6(reply->addr, lb_val->back_end_ips[i]);
+			// TODO(plague): revisit this after LB algorithm changes, currently fixing this would make a mess
+			rte_memcpy(reply->addr._data, &lb_val->back_end_ips[i][0], DP_IPV6_ADDR_SIZE);
+			reply->addr._is_v6 = true;
 		}
 	}
 

--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -64,11 +64,11 @@ static int dp_map_lb_handle(const void *id_key, const struct lb_key *l_key, stru
 
 int dp_create_lb(struct dpgrpc_lb *lb, const uint8_t *ul_ip)
 {
-	struct lb_value *lb_val = NULL;
+	struct lb_value *lb_val;
 	struct lb_key lb_key;
 
 	lb_key.vni = lb->vni;
-	dp_fill_ipkey(&lb_key.ip, &lb->addr);
+	dp_copy_ipaddr(&lb_key.ip, &lb->addr);
 
 	if (!DP_FAILED(rte_hash_lookup(ipv4_lb_tbl, &lb_key)))
 		return DP_GRPC_ERR_ALREADY_EXISTS;
@@ -109,7 +109,7 @@ int dp_get_lb(const void *id_key, struct dpgrpc_lb *out_lb)
 		return DP_GRPC_ERR_NO_BACKIP;
 
 	out_lb->vni = lb_k->vni;
-	dp_fill_ipaddr(&out_lb->addr, &lb_k->ip);
+	dp_copy_ipaddr(&out_lb->addr, &lb_k->ip);
 	rte_memcpy(out_lb->ul_addr6, lb_val->lb_ul_addr, DP_IPV6_ADDR_SIZE);
 
 	for (i = 0; i < DP_LB_MAX_PORTS; i++) {
@@ -159,9 +159,9 @@ bool dp_is_ip_lb(struct dp_flow *df, uint32_t vni)
 	lb_key.vni = vni;
 
 	if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
-		DP_FILL_IPKEY4(lb_key.ip, ntohl(df->dst.dst_addr));
+		DP_SET_IPADDR4(lb_key.ip, ntohl(df->dst.dst_addr));
 	} else if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
-		DP_FILL_IPKEY6(lb_key.ip, df->dst.dst_addr6);
+		DP_SET_IPADDR6(lb_key.ip, df->dst.dst_addr6);
 	} else
 		return false;
 
@@ -239,7 +239,7 @@ uint8_t *dp_lb_get_backend_ip(struct flow_key *flow_key, uint32_t vni)
 	int pos;
 
 	lb_key.vni = vni;
-	dp_copy_ipkey(&lb_key.ip, &flow_key->l3_dst);
+	dp_copy_ipaddr(&lb_key.ip, &flow_key->l3_dst);
 
 	if (rte_hash_lookup_data(ipv4_lb_tbl, &lb_key, (void **)&lb_val) < 0)
 		return NULL;
@@ -277,7 +277,7 @@ int dp_get_lb_back_ips(const void *id_key, struct dp_grpc_responder *responder)
 			reply = dp_grpc_add_reply(responder);
 			if (!reply)
 				return DP_GRPC_ERR_OUT_OF_MEMORY;
-			rte_memcpy(reply->addr.ipv6, &lb_val->back_end_ips[i][0], sizeof(reply->addr.ipv6));
+			DP_SET_IPADDR6(reply->addr, lb_val->back_end_ips[i]);
 		}
 	}
 

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -175,13 +175,13 @@ static int dp_list_route_entry(struct rte_rib_node *node,
 
 		rte_rib_get_ip(node, &ipv4);
 		rte_rib_get_depth(node, &depth);
-		reply->pfx_addr.ip_type = RTE_ETHER_TYPE_IPV4;
+		reply->pfx_addr.is_v6 = false;
 		reply->pfx_addr.ipv4 = ipv4;
 		reply->pfx_length = depth;
 
 		if (ext_routes) {
 			route = (struct dp_iface_route *)rte_rib_get_ext(node);
-			reply->trgt_addr.ip_type = RTE_ETHER_TYPE_IPV6;
+			reply->trgt_addr.is_v6 = true;
 			reply->trgt_vni = route->vni;
 			rte_memcpy(reply->trgt_addr.ipv6, route->nh_ipv6, sizeof(reply->trgt_addr.ipv6));
 		}

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -175,15 +175,13 @@ static int dp_list_route_entry(struct rte_rib_node *node,
 
 		rte_rib_get_ip(node, &ipv4);
 		rte_rib_get_depth(node, &depth);
-		reply->pfx_addr.is_v6 = false;
-		reply->pfx_addr.ipv4 = ipv4;
+		DP_SET_IPADDR4(reply->pfx_addr, ipv4);
 		reply->pfx_length = depth;
 
 		if (ext_routes) {
 			route = (struct dp_iface_route *)rte_rib_get_ext(node);
-			reply->trgt_addr.is_v6 = true;
+			DP_SET_IPADDR6(reply->trgt_addr, route->nh_ipv6);
 			reply->trgt_vni = route->vni;
-			rte_memcpy(reply->trgt_addr.ipv6, route->nh_ipv6, sizeof(reply->trgt_addr.ipv6));
 		}
 
 	}

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -619,10 +619,10 @@ int dp_allocate_network_snat_port(struct snat_data *snat_data, struct dp_flow *d
 	uint64_t timestamp;
 
 	if (df->l3_type == RTE_ETHER_TYPE_IPV4) {
-		DP_FILL_IPKEY4(portmap_key.src_ip, iface_src_ip);
+		DP_SET_IPADDR4(portmap_key.src_ip, iface_src_ip);
 		portoverload_tbl_key.dst_ip = ntohl(df->dst.dst_addr);
 	} else if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
-		DP_FILL_IPKEY6(portmap_key.src_ip, df->src.src_addr6);
+		DP_SET_IPADDR6(portmap_key.src_ip, df->src.src_addr6);
 		portoverload_tbl_key.dst_ip = ntohl(*(rte_be32_t *)&df->dst.dst_addr6[12]);
 	} else {
 		return DP_GRPC_ERR_BAD_IPVER;
@@ -743,7 +743,7 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 	if (DP_FAILED(ret) && ret != -ENOENT)
 		return ret;
 
-	dp_copy_ipkey(&portmap_key.src_ip, &flow_key_org->l3_src);
+	dp_copy_ipaddr(&portmap_key.src_ip, &flow_key_org->l3_src);
 	portmap_key.iface_src_port = flow_key_org->src.port_src;
 	portmap_key.vni = cntrack->nf_info.vni;
 
@@ -794,8 +794,7 @@ int dp_list_nat_local_entries(uint32_t nat_ip, struct dp_grpc_responder *respond
 				return DP_GRPC_ERR_OUT_OF_MEMORY;
 			reply->min_port = data->nat_port_range[0];
 			reply->max_port = data->nat_port_range[1];
-			reply->addr.is_v6 = false;
-			reply->addr.ipv4 = nkey->ip;
+			DP_SET_IPADDR4(reply->addr, nkey->ip);
 			reply->vni = nkey->vni;
 		}
 	}

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -723,8 +723,12 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 	struct dp_port *created_port;
 	int ret;
 
-	if (flow_key_org->l3_dst.is_v6 || flow_key_reply->l3_dst.is_v6) {
-		DPS_LOG_ERR("NAT flow key with IPv6 addresses");  // TODO log them
+	if (unlikely(flow_key_org->l3_dst.is_v6)) {
+		DPS_LOG_ERR("NAT original flow key with IPv6 address", DP_LOG_IPV6(flow_key_org->l3_dst.ipv6));
+		return DP_ERROR;
+	}
+	if (unlikely(flow_key_reply->l3_dst.is_v6)) {
+		DPS_LOG_ERR("NAT reply flow key with IPv6 address", DP_LOG_IPV6(flow_key_reply->l3_dst.ipv6));
 		return DP_ERROR;
 	}
 

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -723,17 +723,16 @@ int dp_remove_network_snat_port(const struct flow_value *cntrack)
 	struct dp_port *created_port;
 	int ret;
 
-	if (unlikely(flow_key_org->l3_dst.is_v6)) {
-		DPS_LOG_ERR("NAT original flow key with IPv6 address", DP_LOG_IPV6(flow_key_org->l3_dst.ipv6));
-		return DP_ERROR;
-	}
 	if (unlikely(flow_key_reply->l3_dst.is_v6)) {
 		DPS_LOG_ERR("NAT reply flow key with IPv6 address", DP_LOG_IPV6(flow_key_reply->l3_dst.ipv6));
 		return DP_ERROR;
 	}
 
+	if (flow_key_org->l3_dst.is_v6)
+		portoverload_tbl_key.dst_ip = ntohl(*(const rte_be32_t *)&flow_key_org->l3_dst.ipv6[12]);
+	else
+		portoverload_tbl_key.dst_ip = flow_key_org->l3_dst.ipv4;
 	portoverload_tbl_key.nat_ip = flow_key_reply->l3_dst.ipv4;
-	portoverload_tbl_key.dst_ip = flow_key_org->l3_dst.ipv4;
 	portoverload_tbl_key.nat_port = flow_key_reply->port_dst;
 	portoverload_tbl_key.dst_port = flow_key_org->port_dst;
 	portoverload_tbl_key.l4_type = flow_key_org->proto;

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -42,12 +42,12 @@ static inline void dp_vnf_log_warning(const char *message,
 									  enum dp_vnf_type type, uint32_t vni, uint16_t port_id,
 									  const struct dp_ip_address *prefix, uint8_t length)
 {
-	if (prefix->ip_type == RTE_ETHER_TYPE_IPV4)
-		DPS_LOG_WARNING(message, DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
-						DP_LOG_PORTID(port_id), DP_LOG_IPV4(prefix->ipv4), DP_LOG_PREFLEN(length));
-	else
+	if (prefix->is_v6)
 		DPS_LOG_WARNING(message, DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
 						DP_LOG_PORTID(port_id), DP_LOG_IPV6(prefix->ipv6), DP_LOG_PREFLEN(length));
+	else
+		DPS_LOG_WARNING(message, DP_LOG_VNF_TYPE(type), DP_LOG_VNI(vni),
+						DP_LOG_PORTID(port_id), DP_LOG_IPV4(prefix->ipv4), DP_LOG_PREFLEN(length));
 }
 
 static __rte_always_inline
@@ -60,11 +60,12 @@ void dp_fill_vnf_data(struct dp_vnf *vnf, enum dp_vnf_type type, uint16_t port_i
 	vnf->port_id = port_id;
 	vnf->vni = vni;
 	vnf->alias_pfx.length = prefix_len;
-	if (src->ip_type == RTE_ETHER_TYPE_IPV4) {
-		vnf->alias_pfx.ol.ip_type = src->ip_type;
-		vnf->alias_pfx.ol.ipv4 = src->ipv4;
-	} else
+	if (src->is_v6) {
 		vnf->alias_pfx.ol = *src;
+	} else {
+		vnf->alias_pfx.ol.is_v6 = false;
+		vnf->alias_pfx.ol.ipv4 = src->ipv4;
+	}
 }
 
 static int dp_add_vnf_value(const struct dp_vnf *vnf, const uint8_t ul_addr6[DP_IPV6_ADDR_SIZE])

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -44,18 +44,30 @@ bool StrToIpv6(const std::string& str, uint8_t *dst)
 	return inet_pton(AF_INET6, str.c_str(), dst) == 1;
 }
 
-bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr)
+bool StrToDpAddress(const std::string& str, struct dp_ip_address *dp_addr, IpVersion ipver)
 {
-	switch (grpc_addr.ipver()) {
+	uint32_t ipv4;
+	uint8_t ipv6[DP_IPV6_ADDR_SIZE];
+
+	switch (ipver) {
 	case IpVersion::IPV4:
-		dp_addr->is_v6 = false;
-		return StrToIpv4(grpc_addr.address(), &dp_addr->ipv4);
+		if (!StrToIpv4(str, &ipv4))
+			return false;
+		DP_SET_IPADDR4(*dp_addr, ipv4);
+		return true;
 	case IpVersion::IPV6:
-		dp_addr->is_v6 = true;
-		return StrToIpv6(grpc_addr.address(), dp_addr->ipv6);
+		if (!StrToIpv6(str, ipv6))
+			return false;
+		DP_SET_IPADDR6(*dp_addr, ipv6);
+		return true;
 	default:
 		return false;
 	}
+}
+
+bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr)
+{
+	return StrToDpAddress(grpc_addr.address(), dp_addr, grpc_addr.ipver());
 }
 
 bool GrpcToDpVniType(const VniType& grpc_type, enum dpgrpc_vni_type *dp_type)

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -48,10 +48,10 @@ bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr)
 {
 	switch (grpc_addr.ipver()) {
 	case IpVersion::IPV4:
-		dp_addr->ip_type = RTE_ETHER_TYPE_IPV4;
+		dp_addr->is_v6 = false;
 		return StrToIpv4(grpc_addr.address(), &dp_addr->ipv4);
 	case IpVersion::IPV6:
-		dp_addr->ip_type = RTE_ETHER_TYPE_IPV6;
+		dp_addr->is_v6 = true;
 		return StrToIpv6(grpc_addr.address(), dp_addr->ipv6);
 	default:
 		return false;
@@ -211,7 +211,7 @@ void SetupIpAndPrefix(const struct dp_fwall_rule *dp_rule, IpAddress* ip, Prefix
 	auto& rule_ip = is_source ? dp_rule->src_ip : dp_rule->dest_ip;
 	auto& rule_mask = is_source ? dp_rule->src_mask : dp_rule->dest_mask;
 
-	if (rule_ip.ip_type == RTE_ETHER_TYPE_IPV4) {
+	if (!rule_ip.is_v6) {
 		ip->set_ipver(IpVersion::IPV4);
 		ip->set_address(GrpcConv::Ipv4ToStr(rule_ip.ipv4));
 		pfx->set_length(__builtin_popcount(rule_mask.ip4));

--- a/src/grpc/dp_grpc_responder.c
+++ b/src/grpc/dp_grpc_responder.c
@@ -10,7 +10,7 @@ enum dpgrpc_request_type dp_grpc_init_responder(struct dp_grpc_responder *respon
 
 	// request mbuf will be reused to prevent unnecessarry free(request)+alloc(response)
 	// so create a copy of the request first
-	responder->request = *(struct dpgrpc_request *)req_payload;
+	rte_memcpy(&responder->request, (struct dpgrpc_request *)req_payload, sizeof(responder->request));
 	responder->replies[0] = req_mbuf;
 	responder->repcount = 1;
 

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -83,7 +83,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_flags |= DP_FLOW_FLAG_DST_NAT;
 			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-			cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4 = ntohl(ipv4_hdr->dst_addr);
+			DP_FILL_IPKEY4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(ipv4_hdr->dst_addr));
 			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 				return DNAT_NEXT_DROP;
 		}
@@ -101,8 +101,10 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		return DNAT_NEXT_PACKET_RELAY;
 
 	if (DP_FLOW_HAS_FLAG_DST_NAT(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_ORG) {
+		if (cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.is_v6)
+			return DNAT_NEXT_DROP;
 		ipv4_hdr = dp_get_ipv4_hdr(m);
-		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ip4);
+		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src.ipv4);
 		df->nat_type = DP_NAT_CHG_DST_IP;
 		df->nat_addr = df->dst.dst_addr;
 		df->dst.dst_addr = ipv4_hdr->dst_addr;
@@ -111,8 +113,10 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 	/* We already know what to do */
 	if (DP_FLOW_HAS_FLAG_SRC_NAT(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_REPLY) {
+		if (cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.is_v6)
+			return DNAT_NEXT_DROP;
 		ipv4_hdr = dp_get_ipv4_hdr(m);
-		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4);
+		ipv4_hdr->dst_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ipv4);
 		if (cntrack->nf_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
 			if (df->l4_type == IPPROTO_ICMP) {
 				if (df->l4_info.icmp_field.icmp_type == RTE_IP_ICMP_ECHO_REPLY) {
@@ -122,7 +126,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 					dp_get_icmp_err_ip_hdr(m, &icmp_err_ip_info);
 					if (!icmp_err_ip_info.err_ipv4_hdr || !icmp_err_ip_info.l4_src_port || !icmp_err_ip_info.l4_dst_port)
 						return DNAT_NEXT_DROP;
-					icmp_err_ip_info.err_ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip4);
+					icmp_err_ip_info.err_ipv4_hdr->src_addr = htonl(cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ipv4);
 					icmp_err_ip_info.err_ipv4_hdr->hdr_checksum = cntrack->nf_info.icmp_err_ip_cksum;
 					dp_change_icmp_err_l4_src_port(m, &icmp_err_ip_info, cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src);
 				}
@@ -138,8 +142,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 	if (DP_FLOW_HAS_FLAG_SRC_NAT64(cntrack->flow_flags) && df->flow_dir == DP_FLOW_DIR_REPLY) {
 		df->nat_type = DP_NAT_64_CHG_DST_IP;
-		rte_memcpy(df->dst.dst_addr6, cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip6, DP_IPV6_ADDR_SIZE);
 		df->nat_addr = df->dst.dst_addr;
+		// the new dst_addr will be stored in dp_nat_chg_ipv4_to_ipv6_hdr()
 		if (cntrack->nf_info.nat_type == DP_FLOW_NAT_TYPE_NETWORK_LOCAL) {
 			if (df->l4_type == IPPROTO_ICMP) {
 				if (df->l4_info.icmp_field.icmp_type == RTE_IP_ICMP_ECHO_REPLY)
@@ -148,7 +152,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 				dp_change_l4_hdr_port(m, DP_L4_PORT_DIR_DST, cntrack->flow_key[DP_FLOW_DIR_ORG].src.port_src);
 			}
 		}
-		if (DP_FAILED(dp_nat_chg_ipv4_to_ipv6_hdr(df, m, cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ip6)))
+		if (!cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.is_v6
+			|| DP_FAILED(dp_nat_chg_ipv4_to_ipv6_hdr(df, m, cntrack->flow_key[DP_FLOW_DIR_ORG].l3_src.ipv6)))
 			return DNAT_NEXT_DROP;
 
 		return DNAT_NEXT_IPV6_LOOKUP;

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -83,7 +83,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_flags |= DP_FLOW_FLAG_DST_NAT;
 			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-			DP_FILL_IPKEY4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(ipv4_hdr->dst_addr));
+			DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(ipv4_hdr->dst_addr));
 			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 				return DNAT_NEXT_DROP;
 		}

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -133,7 +133,7 @@ static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct 
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst.ip4 = snat64_data.nat_ip;
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].proto = df->l4_type;
-	cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_type = RTE_ETHER_TYPE_IPV4;
+	cntrack->flow_key[DP_FLOW_DIR_REPLY].is_v6 = false;
 
 	if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 		return DP_ERROR;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -65,7 +65,7 @@ static __rte_always_inline int dp_process_ipv4_snat(struct rte_mbuf *m, struct d
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-	DP_FILL_IPKEY4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, ntohl(ipv4_hdr->src_addr));
+	DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, ntohl(ipv4_hdr->src_addr));
 	if (snat_data->nat_ip != 0)
 		cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 
@@ -127,8 +127,8 @@ static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct 
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT64;
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-	DP_FILL_IPKEY4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(dest_ip4));
-	DP_FILL_IPKEY4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, snat64_data.nat_ip);
+	DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(dest_ip4));
+	DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, snat64_data.nat_ip);
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].proto = df->l4_type;
 

--- a/test/test_encap.py
+++ b/test/test_encap.py
@@ -29,7 +29,7 @@ def send_ipv4_icmp(dst_ip, pf_name, responder, vm_ipv6):
 		"Wrong ICMP reply"
 
 def test_ipv4_in_ipv6(prepare_ipv4, port_redundancy):
-	send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.102", PF0.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
+	send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.101", PF0.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
 	if port_redundancy:
 		send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.125", PF1.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
 

--- a/test/test_encap.py
+++ b/test/test_encap.py
@@ -29,7 +29,7 @@ def send_ipv4_icmp(dst_ip, pf_name, responder, vm_ipv6):
 		"Wrong ICMP reply"
 
 def test_ipv4_in_ipv6(prepare_ipv4, port_redundancy):
-	send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.101", PF0.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
+	send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.102", PF0.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
 	if port_redundancy:
 		send_ipv4_icmp(f"{neigh_vni1_ov_ip_prefix}.125", PF1.tap, ipv4_in_ipv6_icmp_responder, VM1.ul_ipv6)
 

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -63,7 +63,7 @@ def test_neighnat_table_flush(prepare_ipv4, grpc_client, port_redundancy):
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 
 	global nat_only_port
-	nat_only_port = nat_local_min_port+1
+	nat_only_port = nat_local_min_port
 	tester = TCPTesterPublic(VM1, 12345, nat_ul_ipv6, PF0, public_ip, 443, server_pkt_check=tcp_server_nat_pkt_check)
 	tester.communicate()
 

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -63,7 +63,7 @@ def test_neighnat_table_flush(prepare_ipv4, grpc_client, port_redundancy):
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 
 	global nat_only_port
-	nat_only_port = nat_local_min_port
+	nat_only_port = nat_local_min_port+1
 	tester = TCPTesterPublic(VM1, 12345, nat_ul_ipv6, PF0, public_ip, 443, server_pkt_check=tcp_server_nat_pkt_check)
 	tester.communicate()
 

--- a/test/test_vf_to_pf.py
+++ b/test/test_vf_to_pf.py
@@ -114,7 +114,9 @@ def test_vf_to_pf_network_nat_max_port_tcp(prepare_ipv4, grpc_client, port_redun
 	grpc_client.delnat(VM1.name)
 
 
-def test_vf_to_pf_network_nat_tcp(prepare_ipv4, grpc_client):
+def test_vf_to_pf_network_nat_tcp(prepare_ipv4, grpc_client, port_redundancy):
+	if port_redundancy:
+		pytest.skip("Port redundancy is not supported")
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 	threading.Thread(target=reply_tcp_pkt_from_vm1, args=(nat_ul_ipv6,)).start()
 	send_tcp_through_port(1246)
@@ -145,7 +147,7 @@ def request_tcp(dport, pf_name, vip_ul_ipv6):
 
 def test_vf_to_pf_vip_snat(prepare_ipv4, grpc_client, port_redundancy):
 	vip_ul_ipv6 = grpc_client.addvip(VM2.name, vip_vip)
-	request_tcp(180, PF0.tap, vip_ul_ipv6)
+	request_tcp(100, PF0.tap, vip_ul_ipv6)
 	if port_redundancy:
 		request_tcp(120, PF1.tap, vip_ul_ipv6)
 	grpc_client.delvip(VM2.name)
@@ -184,7 +186,7 @@ def request_icmperr(dport, pf_name, nat_ul_ipv6):
 
 def test_vm_nat_async_tcp_icmperr(prepare_ipv4, grpc_client, port_redundancy):
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
-	request_icmperr(501, PF0.tap, nat_ul_ipv6)
+	request_icmperr(503, PF0.tap, nat_ul_ipv6)
 	if port_redundancy:
 		request_icmperr(505, PF1.tap, nat_ul_ipv6)
 	grpc_client.delnat(VM1.name)


### PR DESCRIPTION
I have improved the `struct dp_ip_address` to be "read-only" via `.ipv6`, `.ipv4` and `.is_v6`. It is now only writable using macros (inlines are not currently possible due to the need to `static_assert` the size of IPv6 array, there is a possibility of a followup PR to fix this). For example `DP_SET_IPADDR6(the_struct, ul_ipv6);`

The only drawback of this "read-only" behavior is that the usual structure assignment will fail (`*struct_x = *struct_y) and `rte_memcpy()` must be used. This is hidden by an inline function for `dp_ip_address`, but if you need to include it in some hash key, the whole key needs to also use `rte_memcpy()`

The second improvement closely connected to this (thus a single PR) is the use of `dp_ip_address` in hash keys as it is also packed now. This and the provided wrappers now ensure that the hash key is properly initialized and no "random" behavior should be possible (this has been achieved previously by complex code).

Due to the amount of code connected to this structure, I created a new `dp_ipaddr.h` and moved a few lines closely connected to it from various places.

The changes in test suite are only needed due to the fact that hash-keys are now structure differently (e.g. to optimize alignment), thus WCMP has changed.

(checkpatch fails for CPP header)

Fixes #525