### PR TITLE
Remove flows for a loadbalancer target on deletion

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -151,6 +151,7 @@ void dp_free_network_nat_port(const struct flow_value *cntrack);
 void dp_remove_nat_flows(uint16_t port_id, enum dp_flow_nat_type nat_type);
 void dp_remove_neighnat_flows(uint32_t ipv4, uint32_t vni, uint16_t min_port, uint16_t max_port);
 void dp_remove_iface_flows(uint16_t port_id, uint32_t ipv4, uint32_t vni);
+void dp_remove_lbtarget_flows(const uint8_t *ul_addr);
 
 hash_sig_t dp_get_conntrack_flow_hash_value(const struct flow_key *key);
 

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -28,6 +28,12 @@ bool dp_is_ipv6_addr_zero(const uint8_t *addr)
 	return *((const uint64_t *)addr) == 0 && *((const uint64_t *)(addr + sizeof(uint64_t))) == 0;
 }
 
+static __rte_always_inline
+bool dp_ipv6_match(const uint8_t *l, const uint8_t *r)
+{
+	return *((const uint64_t *)l) == *((const uint64_t *)r) && *((const uint64_t *)(l + sizeof(uint64_t))) == *((const uint64_t *)(r + sizeof(uint64_t)));
+}
+
 // structure for holding dual IP addresses
 // made read-only without the right macro to prevent uninitialized bytes due to the the use of this structure in hash keys
 struct dp_ip_address {

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -466,7 +466,7 @@ void dp_remove_neighnat_flows(uint32_t ipv4, uint32_t vni, uint16_t min_port, ui
 
 	while ((ret = rte_hash_iterate(ipv4_flow_tbl, (const void **)&next_key, (void **)&flow_val, &iter)) != -ENOENT) {
 		if (DP_FAILED(ret)) {
-			DPS_LOG_ERR("Iterating flow table failed while removing NAT flows", DP_LOG_RET(ret));
+			DPS_LOG_ERR("Iterating flow table failed while removing neighboring NAT flows", DP_LOG_RET(ret));
 			return;
 		}
 		if (next_key->vni == vni && !next_key->l3_dst.is_v6 && next_key->l3_dst.ipv4 == ipv4
@@ -494,6 +494,23 @@ void dp_remove_iface_flows(uint16_t port_id, uint32_t ipv4, uint32_t vni)
 		) {
 			dp_remove_flow(flow_val);
 		}
+	}
+}
+
+void dp_remove_lbtarget_flows(const uint8_t *ul_addr)
+{
+	struct flow_value *flow_val = NULL;
+	const struct flow_key *next_key;
+	uint32_t iter = 0;
+	int ret;
+
+	while ((ret = rte_hash_iterate(ipv4_flow_tbl, (const void **)&next_key, (void **)&flow_val, &iter)) != -ENOENT) {
+		if (DP_FAILED(ret)) {
+			DPS_LOG_ERR("Iterating flow table failed while removing LB target flows", DP_LOG_RET(ret));
+			return;
+		}
+		if (dp_ipv6_match(flow_val->nf_info.underlay_dst, ul_addr))
+			dp_remove_flow(flow_val);
 	}
 }
 

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -164,6 +164,7 @@ static int dp_process_delete_lbtarget(struct dp_grpc_responder *responder)
 	if (!request->addr.is_v6)
 		return DP_GRPC_ERR_BAD_IPVER;
 
+	dp_remove_lbtarget_flows(request->addr.ipv6);
 	return dp_del_lb_back_ip(request->lb_id, request->addr.ipv6);
 }
 

--- a/test/xtratest_flow_timeout.py
+++ b/test/xtratest_flow_timeout.py
@@ -133,9 +133,6 @@ def test_external_lb_relay_algorithm(prepare_ipv4, grpc_client, fast_flow_timeou
 	if not fast_flow_timeout:
 		pytest.skip("Fast flow timeout needs to be enabled")
 
-	# TODO dellbtarget() is not properly cleanin up so the previous example poisons the result
-	age_out_flows()
-
 	targets = [ f"fc00:2::{i}" for i in range(1, 7) ]
 
 	# Create a lb with multiple targets
@@ -177,8 +174,6 @@ def test_external_lb_relay_algorithm(prepare_ipv4, grpc_client, fast_flow_timeou
 		f"Loadbalancer target selection algorithm did not survive other target deletion"
 
 	# Delete the target itself (no need to age out, should be clean)
-	# TODO this should not be needed, see above
-	age_out_flows()
 	grpc_client.dellbtarget(lb_name, target_ul)
 	targets.remove(target_ul)
 


### PR DESCRIPTION
Similar to other instances (NAT, VIP, neighNAT, VM), there is now a call to prune the flow table.

I chose to simply match the flows using the target's underlay address, which should be unique.

The original idea was to find the right VNI, IP, protocol and port, but that requires not only one hash-table lookup (not a problem in gRPC), but also to match all loadbalanced ports (there can be multiple), etc, only to arrive at the same result.

But I may have overlooked some important detail, as I do not have the connection tracking and flow tables code really thoroughly in my head.

Fixes #534 