### PR TITLE
Implement a custom type for IPv6

### DIFF
--- a/include/dp_conf.h
+++ b/include/dp_conf.h
@@ -11,25 +11,26 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 #include <rte_byteorder.h>
+#include "dp_ipaddr.h"
 
 #ifdef ENABLE_VIRTSVC
 struct dp_conf_virtsvc {
-	uint8_t    proto;
-	rte_be32_t virtual_addr;
-	rte_be16_t virtual_port;
-	uint8_t    service_addr[16];
-	rte_be16_t service_port;
+	uint8_t			proto;
+	rte_be32_t		virtual_addr;
+	rte_be16_t		virtual_port;
+	union dp_ipv6	service_addr;
+	rte_be16_t		service_port;
 };
 
 struct dp_conf_virtual_services {
-	int nb_entries;
-	struct dp_conf_virtsvc *entries;
+	int						nb_entries;
+	struct dp_conf_virtsvc	*entries;
 };
 #endif
 
 struct dp_conf_dhcp_dns {
-	uint8_t len;
-	uint8_t *array;
+	uint8_t	len;
+	uint8_t	*array;
 };
 
 int dp_conf_parse_file(const char *filename);
@@ -43,7 +44,7 @@ void dp_conf_free(void);
 int dp_conf_is_wcmp_enabled(void);
 const char *dp_conf_get_eal_a_pf0(void);
 const char *dp_conf_get_eal_a_pf1(void);
-const uint8_t *dp_conf_get_underlay_ip(void);
+const union dp_ipv6 *dp_conf_get_underlay_ip(void);
 const struct dp_conf_dhcp_dns *dp_conf_get_dhcp_dns(void);
 const struct dp_conf_dhcp_dns *dp_conf_get_dhcpv6_dns(void);
 #ifdef ENABLE_VIRTSVC

--- a/include/dp_firewall.h
+++ b/include/dp_firewall.h
@@ -50,8 +50,8 @@ struct dp_port_filter {
 
 struct dp_ip_mask {
 	union {
-		uint8_t  ip6[DP_IPV6_ADDR_SIZE];
-		uint32_t ip4;
+		union dp_ipv6 ip6;
+		uint32_t      ip4;
 	};
 };
 

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -87,11 +87,9 @@ struct flow_nf_info {
 	uint32_t vni;
 	uint16_t icmp_err_ip_cksum;
 	enum dp_flow_nat_type nat_type;
-	uint8_t underlay_dst[16];
+	union dp_ipv6 underlay_dst;
 	uint8_t l4_type;
-} __rte_packed;
-static_assert(sizeof(((struct flow_nf_info *)0)->nat_type) == 1,
-			  "enum dp_flow_nat_type is unnecessarily big");
+};
 
 struct flow_value {
 	struct flow_key	flow_key[DP_FLOW_DIR_CAPACITY];
@@ -151,7 +149,7 @@ void dp_free_network_nat_port(const struct flow_value *cntrack);
 void dp_remove_nat_flows(uint16_t port_id, enum dp_flow_nat_type nat_type);
 void dp_remove_neighnat_flows(uint32_t ipv4, uint32_t vni, uint16_t min_port, uint16_t max_port);
 void dp_remove_iface_flows(uint16_t port_id, uint32_t ipv4, uint32_t vni);
-void dp_remove_lbtarget_flows(const uint8_t *ul_addr);
+void dp_remove_lbtarget_flows(const union dp_ipv6 *ul_addr);
 
 hash_sig_t dp_get_conntrack_flow_hash_value(const struct flow_key *key);
 

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -31,6 +31,13 @@ union dp_ipv6 {
 		uint8_t		prefix[DP_IPV6_ADDR_SIZE - sizeof(rte_be32_t)];
 		rte_be32_t	ipv4;
 	} _nat64;
+	struct __rte_packed {
+		rte_be64_t	prefix;
+		rte_be16_t	kernel;
+		uint8_t		reserved;
+		uint8_t		random;
+		rte_be32_t	local;
+	} _ul;
 };
 static_assert(sizeof(union dp_ipv6) == DP_IPV6_ADDR_SIZE, "union dp_ipv6 has padding");
 
@@ -49,7 +56,6 @@ void dp_copy_ipv6(union dp_ipv6 *dst, const union dp_ipv6 *src)
 	dst->_suffix = src->_suffix;
 }
 
-// TODO reduce use of these as much as possible (re-check at the end
 #define DP_IPV6_FROM_ARRAY(IPV6, ARRAY) do { \
 	static_assert(sizeof(ARRAY) == sizeof(union dp_ipv6), "Invalid array size for DP_SET_IPV6"); \
 	dp_copy_ipv6((IPV6), (const union dp_ipv6 *)(ARRAY)); \
@@ -140,6 +146,8 @@ int dp_ipv4_to_str(uint32_t ipv4, char *dest, int dest_len);
 
 int dp_str_to_ipv4(const char *src, uint32_t *dest);
 int dp_str_to_ipv6(const char *src, union dp_ipv6 *dest);
+
+void dp_generate_ul_ipv6(union dp_ipv6 *dest);
 
 
 // structure for holding dual IP addresses

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -10,87 +10,160 @@ extern "C" {
 
 #include <arpa/inet.h>
 #include <assert.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <rte_ip.h>
 #include "dp_error.h"
 
 #define DP_IPV6_ADDR_SIZE 16
-static_assert(sizeof(uint64_t) * 2 == DP_IPV6_ADDR_SIZE, "DP_IPV6_ADDR_SIZE is invalid");
+static_assert(sizeof(rte_be64_t) * 2 == DP_IPV6_ADDR_SIZE, "DP_IPV6_ADDR_SIZE is invalid");
 
-// TODO(plague): do something for naked ipv6, that uses uint8_t, thus cannot check size properly
+// structure for holding IPv6 addresses
+// this way sizeof(dp_ipv6 *) is a meaningful value and passing the pointer only is safe
+union dp_ipv6 {
+	struct {
+		rte_be64_t	_prefix;
+		rte_be64_t	_suffix;
+	};
+	const uint8_t	bytes[DP_IPV6_ADDR_SIZE];
+};
+static_assert(sizeof(union dp_ipv6) == DP_IPV6_ADDR_SIZE, "union dp_ipv6 has padding");
+
+static __rte_always_inline
+void dp_copy_ipv6(union dp_ipv6 *dst, const union dp_ipv6 *src)
+{
+	dst->_prefix = src->_prefix;
+	dst->_suffix = src->_suffix;
+}
+
+// TODO reduce use of these as much as possible (re-check at the end
+#define DP_IPV6_FROM_ARRAY(IPV6, ARRAY) do { \
+	static_assert(sizeof(ARRAY) == sizeof(union dp_ipv6), "Invalid array size for DP_SET_IPV6"); \
+	dp_copy_ipv6((IPV6), (const union dp_ipv6 *)(ARRAY)); \
+} while (0)
+
+#define DP_ARRAY_FROM_IPV6(ARRAY, IPV6) do { \
+	static_assert(sizeof(ARRAY) == sizeof(union dp_ipv6), "Invalid array size for DP_IPV6_TO_ARRAY"); \
+	dp_copy_ipv6((union dp_ipv6 *)(ARRAY), (IPV6)); \
+} while (0)
+
+static __rte_always_inline
+const union dp_ipv6 *dp_get_src_ipv6(const struct rte_ipv6_hdr *ipv6_hdr)
+{
+	static_assert(sizeof(ipv6_hdr->src_addr) == sizeof(union dp_ipv6), "Structure dp_ipv6 is not compatible with IPv6 source address");
+	return (const union dp_ipv6 *)&ipv6_hdr->src_addr;
+}
+static __rte_always_inline
+const union dp_ipv6 *dp_get_dst_ipv6(const struct rte_ipv6_hdr *ipv6_hdr)
+{
+	static_assert(sizeof(ipv6_hdr->dst_addr) == sizeof(union dp_ipv6), "Structure dp_ipv6 is not compatible with IPv6 destination address");
+	return (const union dp_ipv6 *)&ipv6_hdr->dst_addr;
+}
+
+static __rte_always_inline
+void dp_set_src_ipv6(struct rte_ipv6_hdr *ipv6_hdr, const union dp_ipv6 *ipv6)
+{
+	static_assert(sizeof(ipv6_hdr->src_addr) == sizeof(union dp_ipv6), "Structure dp_ipv6 is not compatible with IPv6 source address");
+	dp_copy_ipv6((union dp_ipv6 *)ipv6_hdr->src_addr, ipv6);
+}
+static __rte_always_inline
+void dp_set_dst_ipv6(struct rte_ipv6_hdr *ipv6_hdr, const union dp_ipv6 *ipv6)
+{
+	static_assert(sizeof(ipv6_hdr->dst_addr) == sizeof(union dp_ipv6), "Structure dp_ipv6 is not compatible with IPv6 destination address");
+	dp_copy_ipv6((union dp_ipv6 *)ipv6_hdr->dst_addr, ipv6);
+}
+
+static __rte_always_inline
+bool dp_is_ipv6_zero(const union dp_ipv6 *ipv6)
+{
+	return ipv6->_prefix == 0 && ipv6->_suffix == 0;
+}
+
+static __rte_always_inline
+bool dp_ipv6_match(const union dp_ipv6 *l, const union dp_ipv6 *r)
+{
+	return l->_prefix == r->_prefix && l->_suffix == r->_suffix;
+}
+
+int dp_ipv6_to_str(const union dp_ipv6 *ipv6, char *dest, int dest_len);
+#define DP_IPV6_TO_STR(IPV6, DST) do { \
+	static_assert(sizeof(DST) >= INET6_ADDRSTRLEN, "Insufficient buffer size for DP_IPV6_TO_STR()"); \
+	dp_ipv6_to_str((IPV6), (DST), sizeof(DST)); \
+	/* No return needed, all checks done statically. */ \
+} while (0)
+
+int dp_ipv4_to_str(uint32_t ipv4, char *dest, int dest_len);
+#define DP_IPV4_TO_STR(IPV4, DST) do { \
+	static_assert(sizeof(DST) >= INET_ADDRSTRLEN, "Insufficient buffer size for DP_IPV4_TO_STR()"); \
+	dp_ipv4_to_str((IPV4), (DST), sizeof(DST)); \
+	/* No return needed, all checks done statically. */ \
+} while (0)
+
+int dp_str_to_ipv4(const char *src, uint32_t *dest);
+int dp_str_to_ipv6(const char *src, union dp_ipv6 *dest);
 
 // TODO(plague): move NAT64 handling here (part of the above) + grep for [12] which means NAT64 ipv6 -> ipv4 conversion and wrap it
 
-// TODO(plague): This either needs to be a macro to enable checking for sizeof(addr) (or see above for the proposed ipv6 type)
-static __rte_always_inline
-bool dp_is_ipv6_addr_zero(const uint8_t *addr)
-{
-	return *((const uint64_t *)addr) == 0 && *((const uint64_t *)(addr + sizeof(uint64_t))) == 0;
-}
-
-static __rte_always_inline
-bool dp_ipv6_match(const uint8_t *l, const uint8_t *r)
-{
-	return *((const uint64_t *)l) == *((const uint64_t *)r) && *((const uint64_t *)(l + sizeof(uint64_t))) == *((const uint64_t *)(r + sizeof(uint64_t)));
-}
 
 // structure for holding dual IP addresses
 // made read-only without the right macro to prevent uninitialized bytes due to the the use of this structure in hash keys
 struct dp_ip_address {
 	union {
-		uint8_t			_data[DP_IPV6_ADDR_SIZE];
-		const uint8_t	ipv6[DP_IPV6_ADDR_SIZE];
-		const uint32_t	ipv4;
+		union dp_ipv6		_ipv6;
+		uint32_t			_ipv4;
+		const union dp_ipv6	ipv6;
+		const uint32_t		ipv4;
 	};
 	union {
-		bool			_is_v6;
-		const bool		is_v6;
+		bool				_is_v6;
+		const bool			is_v6;
 	};
 } __rte_packed;
 
-static inline void _dp_ipaddr_to_str_unsafe(const struct dp_ip_address *addr, char *dest)
+static __rte_always_inline
+int dp_ipv6_from_ipaddr(union dp_ipv6 *ipv6, const struct dp_ip_address *addr)
 {
-	uint32_t net_ipv4;
+	if (!addr->is_v6)
+		return DP_ERROR;
 
-	// inet_ntop() can only fail on invalid AF_ (constant here) and insufficient buffer size (checked in the macro)
-	if (addr->is_v6) {
-		inet_ntop(AF_INET6, &addr->ipv6, dest, INET6_ADDRSTRLEN);
-	} else {
-		net_ipv4 = htonl(addr->ipv4);
-		inet_ntop(AF_INET, &net_ipv4, dest, INET_ADDRSTRLEN);
-	}
+	ipv6->_prefix = addr->ipv6._prefix;
+	ipv6->_suffix = addr->ipv6._suffix;
+	return DP_OK;
 }
-#define DP_IPADDR_TO_STR(KEY, DST) do { \
-	static_assert(sizeof(DST) >= INET6_ADDRSTRLEN, "Insufficient buffer size for DP_IPADDR_TO_STR()"); \
-	_dp_ipaddr_to_str_unsafe((KEY), (DST)); \
-} while (0)
 
 static __rte_always_inline
 void dp_copy_ipaddr(struct dp_ip_address *dst, const struct dp_ip_address *src)
 {
 	dst->_is_v6 = src->_is_v6;
-	((uint64_t *)dst->_data)[0] = ((const uint64_t *)src->_data)[0];
-	((uint64_t *)dst->_data)[1] = ((const uint64_t *)src->_data)[1];
+	dst->_ipv6._prefix = src->ipv6._prefix;
+	dst->_ipv6._suffix = src->ipv6._suffix;
 }
 
-// These cannot be inlines due to sizeof() being checked for IPv6
-#define DP_SET_IPADDR6(ADDR, IPV6) do { \
-	static_assert(sizeof(IPV6) == DP_IPV6_ADDR_SIZE, "Invalid IPv6 byte array passed to DP_FILL_IPADDR6()"); \
-	DP_SET_IPADDR6_UNSAFE((ADDR), (IPV6)); \
-} while (0)
-#define DP_SET_IPADDR6_UNSAFE(ADDR, IPV6) do { \
-	(ADDR)._is_v6 = true; \
-	((uint64_t *)(ADDR)._data)[0] = ((const uint64_t *)(IPV6))[0]; \
-	((uint64_t *)(ADDR)._data)[1] = ((const uint64_t *)(IPV6))[1]; \
+static __rte_always_inline
+void dp_set_ipaddr6(struct dp_ip_address *addr, const union dp_ipv6 *ipv6)
+{
+	addr->_is_v6 = true;
+	addr->_ipv6._prefix = ipv6->_prefix;
+	addr->_ipv6._suffix = ipv6->_suffix;
+}
+
+static __rte_always_inline
+void dp_set_ipaddr4(struct dp_ip_address *addr, uint32_t ipv4)
+{
+	addr->_is_v6 = false;
+	addr->_ipv6._prefix = addr->_ipv6._suffix = 0;
+	addr->_ipv4 = ipv4;
+}
+
+int dp_ipaddr_to_str(const struct dp_ip_address *addr, char *dest, int dest_len);
+#define DP_IPADDR_TO_STR(ADDR, DST) do { \
+	static_assert(sizeof(DST) >= INET6_ADDRSTRLEN, "Insufficient buffer size for DP_IPADDR_TO_STR()"); \
+	dp_ipaddr_to_str((ADDR), (DST), sizeof(DST)); \
 } while (0)
 
-#define DP_SET_IPADDR4(ADDR, IPV4) do { \
-	(ADDR)._is_v6 = false; \
-	((uint64_t *)(ADDR)._data)[0] = ((uint64_t *)(ADDR)._data)[1] = 0; \
-	((uint32_t *)(ADDR)._data)[0] = (IPV4); \
-} while (0)
 
-
+// TODO(plague): I think this is broken for ARM
 // inspired by DPDK's RTE_ETHER_ADDR_PRT_FMT and RTE_ETHER_ADDR_BYTES
 // network byte-order!
 #define DP_IPV4_PRINT_FMT       "%u.%u.%u.%u"

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -109,6 +109,12 @@ bool dp_masked_ipv6_match(const union dp_ipv6 *l, const union dp_ipv6 *r, const 
 }
 
 static __rte_always_inline
+int dp_ipv6_popcount(const union dp_ipv6 *ipv6)
+{
+	return __builtin_popcountll(ipv6->_prefix) + __builtin_popcountll(ipv6->_suffix);
+}
+
+static __rte_always_inline
 bool dp_is_ipv6_nat64(const union dp_ipv6 *ipv6)
 {
 	return dp_masked_ipv6_match(&dp_nat64_prefix, ipv6, &dp_nat64_mask);

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -86,6 +86,13 @@ bool dp_ipv6_match(const union dp_ipv6 *l, const union dp_ipv6 *r)
 	return l->_prefix == r->_prefix && l->_suffix == r->_suffix;
 }
 
+static __rte_always_inline
+bool dp_masked_ipv6_match(const union dp_ipv6 *l, const union dp_ipv6 *r, const union dp_ipv6 *mask)
+{
+	return (l->_prefix & mask->_prefix) == (r->_prefix & mask->_prefix)
+		&& (l->_suffix & mask->_suffix) == (r->_suffix & mask->_suffix);
+}
+
 int dp_ipv6_to_str(const union dp_ipv6 *ipv6, char *dest, int dest_len);
 #define DP_IPV6_TO_STR(IPV6, DST) do { \
 	static_assert(sizeof(DST) >= INET6_ADDRSTRLEN, "Insufficient buffer size for DP_IPV6_TO_STR()"); \

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -41,13 +41,10 @@ union dp_ipv6 {
 };
 static_assert(sizeof(union dp_ipv6) == DP_IPV6_ADDR_SIZE, "union dp_ipv6 has padding");
 
-static const union dp_ipv6 dp_nat64_prefix = {
-	.bytes = { 0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
-};
-
-static const union dp_ipv6 dp_nat64_mask = {
-	.bytes = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0 }
-};
+extern const union dp_ipv6 dp_empty_ipv6;
+extern const union dp_ipv6 dp_multicast_ipv6;
+extern const union dp_ipv6 dp_nat64_prefix;
+extern const union dp_ipv6 dp_nat64_mask;
 
 static __rte_always_inline
 void dp_copy_ipv6(union dp_ipv6 *dst, const union dp_ipv6 *src)

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -29,21 +29,21 @@ struct lb_port {
 struct lb_value {
 	uint8_t				lb_id[DP_LB_ID_MAX_LEN];
 	struct lb_port		ports[DP_LB_MAX_PORTS];
-	uint8_t				back_end_ips[DP_LB_MAX_IPS_PER_VIP][DP_IPV6_ADDR_SIZE];
+	union dp_ipv6		back_end_ips[DP_LB_MAX_IPS_PER_VIP];
 	int16_t				maglev_hash[DP_LB_MAGLEV_LOOKUP_SIZE];
 	uint16_t			back_end_cnt;
-	uint8_t				lb_ul_addr[DP_IPV6_ADDR_SIZE];
+	union dp_ipv6		lb_ul_addr;
 };
 
 int dp_lb_init(int socket_id);
 void dp_lb_free(void);
 bool dp_is_ip_lb(struct dp_flow *df, uint32_t vni);
-uint8_t *dp_lb_get_backend_ip(struct flow_key *flow_key, uint32_t vni);
+const union dp_ipv6 *dp_lb_get_backend_ip(struct flow_key *flow_key, uint32_t vni);
 bool dp_is_lb_enabled(void);
-int dp_del_lb_back_ip(const void *id_key, const uint8_t *back_ip);
-int dp_add_lb_back_ip(const void *id_key, const uint8_t *back_ip);
+int dp_del_lb_back_ip(const void *id_key, const union dp_ipv6 *back_ip);
+int dp_add_lb_back_ip(const void *id_key, const union dp_ipv6 *back_ip);
 int dp_get_lb_back_ips(const void *id_key, struct dp_grpc_responder *responder);
-int dp_create_lb(struct dpgrpc_lb *lb, const uint8_t *ul_ip);
+int dp_create_lb(struct dpgrpc_lb *lb, const union dp_ipv6 *ul_ip);
 int dp_delete_lb(const void *id_key);
 int dp_get_lb(const void *id_key, struct dpgrpc_lb *out_lb);
 

--- a/include/dp_log.h
+++ b/include/dp_log.h
@@ -33,7 +33,7 @@ extern "C" {
 #define _DP_LOG_INT(KEY, VALUE) KEY, _DP_LOG_FMT_INT, VALUE
 #define _DP_LOG_UINT(KEY, VALUE) KEY, _DP_LOG_FMT_UINT, VALUE
 #define _DP_LOG_IPV4(KEY, VALUE) KEY, _DP_LOG_FMT_IPV4, VALUE
-#define _DP_LOG_IPV6(KEY, VALUE) KEY, _DP_LOG_FMT_IPV6, VALUE
+#define _DP_LOG_IPV6(KEY, VALUE) KEY, _DP_LOG_FMT_IPV6, (VALUE).bytes
 #define _DP_LOG_PTR(KEY, VALUE) KEY, _DP_LOG_FMT_PTR, VALUE
 
 // Macros to generate key-value pairs for structured logging

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -35,8 +35,8 @@ extern "C" {
 #define DP_LIST_INT_ROUTES false
 
 struct dp_iface_route {
-	uint32_t vni;
-	uint8_t  nh_ipv6[16];
+	uint32_t		vni;
+	union dp_ipv6	nh_ipv6;
 };
 
 const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
@@ -49,16 +49,16 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint8_t route_key[DP_IPV6_ADDR_SIZE]);
+										  uint8_t route_key[DP_IPV6_ADDR_SIZE]);  // TODO migrate in separate commit
 uint32_t dp_get_gw_ip4(void);
-const uint8_t *dp_get_gw_ip6(void);
+const union dp_ipv6 *dp_get_gw_ip6(void);
 
 int dp_add_route(const struct dp_port *port, uint32_t vni, uint32_t t_vni, uint32_t ip,
-				 const uint8_t *t_ip6, uint8_t depth);
+				 const union dp_ipv6 *t_ip6, uint8_t depth);
 int dp_del_route(const struct dp_port *port, uint32_t vni, uint32_t ip, uint8_t depth);
-int dp_add_route6(const struct dp_port *port, uint32_t vni, uint32_t t_vni, const uint8_t *ipv6,
-				  const uint8_t *t_ip6, uint8_t depth);
-int dp_del_route6(const struct dp_port *port, uint32_t vni, const uint8_t *ipv6, uint8_t depth);
+int dp_add_route6(const struct dp_port *port, uint32_t vni, uint32_t t_vni, const union dp_ipv6 *ipv6,
+				  const union dp_ipv6 *t_ip6, uint8_t depth);
+int dp_del_route6(const struct dp_port *port, uint32_t vni, const union dp_ipv6 *ipv6, uint8_t depth);
 int dp_list_routes(const struct dp_port *port, uint32_t vni, bool ext_routes, struct dp_grpc_responder *responder);
 
 int dp_lpm_reset_all_route_tables(void);

--- a/include/dp_lpm.h
+++ b/include/dp_lpm.h
@@ -43,13 +43,13 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint32_t *route_key);
+										  uint32_t *p_ip);
 
 const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint8_t route_key[DP_IPV6_ADDR_SIZE]);  // TODO migrate in separate commit
+										  union dp_ipv6 *p_ipv6);
 uint32_t dp_get_gw_ip4(void);
 const union dp_ipv6 *dp_get_gw_ip6(void);
 

--- a/include/dp_maglev.h
+++ b/include/dp_maglev.h
@@ -11,8 +11,8 @@ extern "C" {
 #include "dp_util.h"
 #include "dp_lb.h"
 
-int dp_delete_maglev_backend(struct lb_value *lbval, const uint8_t *back_ip);
-int dp_add_maglev_backend(struct lb_value *lbval, const uint8_t *back_ip);
+int dp_delete_maglev_backend(struct lb_value *lbval, const union dp_ipv6 *back_ip);
+int dp_add_maglev_backend(struct lb_value *lbval, const union dp_ipv6 *back_ip);
 
 #ifdef __cplusplus
 }

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -23,17 +23,13 @@ struct nat_key {
 	uint32_t	vni;
 } __rte_packed;
 
-typedef struct network_nat_entry {
-	// TODO(plague) struct dp_ip_address! migrate
-	union {
-		uint8_t		nat_ip6[DP_IPV6_ADDR_SIZE];
-		uint32_t	nat_ip4;
-	} nat_ip;
-	uint16_t	port_range[2];
-	uint32_t	vni;
+struct nat_entry {
+	uint32_t		nat_ip;
+	uint16_t		port_range[2];
+	uint32_t		vni;
 	union dp_ipv6	dst_ipv6;
-	TAILQ_ENTRY(network_nat_entry) entries;
-} network_nat_entry;
+	TAILQ_ENTRY(nat_entry) entries;
+};
 
 struct snat_data {
 	uint32_t		vip_ip;
@@ -97,14 +93,14 @@ int dp_nat_chg_ipv4_to_ipv6_hdr(struct dp_flow *df, struct rte_mbuf *m, const un
 
 void dp_del_vip_from_dnat(uint32_t d_ip, uint32_t vni);
 
-int dp_add_network_nat_entry(uint32_t nat_ipv4, const uint8_t nat_ipv6[DP_IPV6_ADDR_SIZE],
+int dp_add_network_nat_entry(uint32_t nat_ipv4,
 							 uint32_t vni, uint16_t min_port, uint16_t max_port,
 							 const union dp_ipv6 *ul_ipv6);
 
-int dp_del_network_nat_entry(uint32_t nat_ipv4, const uint8_t nat_ipv6[DP_IPV6_ADDR_SIZE],
+int dp_del_network_nat_entry(uint32_t nat_ipv4,
 							 uint32_t vni, uint16_t min_port, uint16_t max_port);
 
-const union dp_ipv6 *dp_get_network_nat_underlay_ip(uint32_t nat_ipv4, const uint8_t nat_ipv6[DP_IPV6_ADDR_SIZE],
+const union dp_ipv6 *dp_get_network_nat_underlay_ip(uint32_t nat_ipv4,
 													uint32_t vni, uint16_t min_port, uint16_t max_port);
 
 int dp_allocate_network_snat_port(struct snat_data *snat_data, struct dp_flow *df, uint32_t vni);

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -16,8 +16,6 @@
 extern "C" {
 #endif
 
-#define DP_NAT64_PREFIX		"\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00"
-
 #define DP_NETWORK_NAT_ALL_VNI		0
 
 struct nat_key {
@@ -117,11 +115,6 @@ int dp_list_nat_local_entries(uint32_t nat_ip, struct dp_grpc_responder *respond
 int dp_list_nat_neigh_entries(uint32_t nat_ip, struct dp_grpc_responder *responder);
 struct snat_data *dp_get_iface_snat_data(uint32_t iface_ip, uint32_t vni);
 void dp_del_all_neigh_nat_entries_in_vni(uint32_t vni);
-
-static __rte_always_inline bool dp_is_ip6_in_nat64_range(const uint8_t *ipv6_addr)
-{
-	return memcmp(ipv6_addr, DP_NAT64_PREFIX, 12) == 0;  // TODO migrate NAT64
-}
 
 #ifdef __cplusplus
 }

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -25,8 +25,8 @@ struct dp_iface_cfg {
 	uint32_t				own_ip;
 	uint32_t				neigh_ip;
 	uint8_t					ip_depth;
-	uint8_t					dhcp_ipv6[DP_IPV6_ADDR_SIZE];
-	uint8_t					own_ipv6[DP_IPV6_ADDR_SIZE];
+	union dp_ipv6			dhcp_ipv6;
+	union dp_ipv6			own_ipv6;
 	uint8_t					ip6_depth;
 	struct dp_ip_address	pxe_ip;
 	char					pxe_str[DP_IFACE_PXE_MAX_LEN];
@@ -37,7 +37,7 @@ struct dp_port_iface {
 	struct dp_iface_cfg		cfg;
 	uint32_t				vni;
 	char					id[DP_IFACE_ID_MAX_LEN];
-	uint8_t					ul_ipv6[DP_IPV6_ADDR_SIZE];
+	union dp_ipv6			ul_ipv6;
 	uint32_t				nat_ip;
 	uint16_t				nat_port_range[2];
 	bool					ready;
@@ -95,9 +95,9 @@ int dp_load_mac(struct dp_port *port)
 }
 
 static __rte_always_inline
-const uint8_t *dp_get_port_ul_ipv6(const struct dp_port *port)
+const union dp_ipv6 *dp_get_port_ul_ipv6(const struct dp_port *port)
 {
-	return port->iface.ready ? port->iface.ul_ipv6 : dp_conf_get_underlay_ip();
+	return port->iface.ready ? &port->iface.ul_ipv6 : dp_conf_get_underlay_ip();
 }
 
 static __rte_always_inline

--- a/include/dp_virtsvc.h
+++ b/include/dp_virtsvc.h
@@ -11,6 +11,7 @@ extern "C" {
 #include <rte_byteorder.h>
 #include <rte_hash.h>
 #include <rte_telemetry.h>
+#include "dp_ipaddr.h"
 
 // limit number of services to one byte due to various implementation reasons
 #define DP_VIRTSVC_MAX 256
@@ -37,13 +38,13 @@ struct dp_virtsvc_conn {
 };
 
 struct dp_virtsvc {
-	rte_be32_t virtual_addr;
-	uint8_t    service_addr[16];
-	rte_be16_t virtual_port;
-	rte_be16_t service_port;
-	uint8_t    proto;
-	uint16_t   last_assigned_port;
-	struct rte_hash *open_ports;
+	rte_be32_t		virtual_addr;
+	union dp_ipv6	service_addr;
+	rte_be16_t		virtual_port;
+	rte_be16_t		service_port;
+	uint8_t			proto;
+	uint16_t		last_assigned_port;
+	struct rte_hash	*open_ports;
 	struct dp_virtsvc_conn connections[DP_VIRTSVC_PORTCOUNT];
 };
 
@@ -78,8 +79,8 @@ int dp_virtsvc_ipv4_cmp(uint8_t proto1, rte_be32_t addr1, rte_be16_t port1,
 }
 
 static __rte_always_inline
-int dp_virtsvc_ipv6_cmp(uint8_t proto1, const uint8_t addr1[16], rte_be16_t port1,
-						uint8_t proto2, const uint8_t addr2[16], rte_be16_t port2)
+int dp_virtsvc_ipv6_cmp(uint8_t proto1, const union dp_ipv6 *addr1, rte_be16_t port1,
+						uint8_t proto2, const union dp_ipv6 *addr2, rte_be16_t port2)
 {
 	int diff;
 	// dtto, see above

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -29,8 +29,8 @@ enum dp_vnf_type {
 } __rte_packed;  // for 'struct dp_flow' and 'struct flow_key'
 
 struct dp_vnf_prefix {
-	struct dp_ip_address ol;
-	uint8_t				  length;
+	struct dp_ip_address	ol;
+	uint8_t					length;
 };
 
 struct dp_vnf {
@@ -43,10 +43,10 @@ struct dp_vnf {
 int dp_vnf_init(int socket_id);
 void dp_vnf_free(void);
 
-int dp_add_vnf(const uint8_t ul_addr6[DP_IPV6_ADDR_SIZE], enum dp_vnf_type type,
+int dp_add_vnf(const union dp_ipv6 *ul_addr6, enum dp_vnf_type type,
 			   uint16_t port_id, uint32_t vni, const struct dp_ip_address *pfx_ip, uint8_t prefix_len);
-const struct dp_vnf *dp_get_vnf(const uint8_t ul_addr6[DP_IPV6_ADDR_SIZE]);
-int dp_del_vnf(const uint8_t ul_addr6[DP_IPV6_ADDR_SIZE]);
+const struct dp_vnf *dp_get_vnf(const union dp_ipv6 *ul_addr6);
+int dp_del_vnf(const union dp_ipv6 *ul_addr6);
 
 bool dp_vnf_lbprefix_exists(uint16_t port_id, uint32_t vni, const struct dp_ip_address *prefix_ip, uint8_t prefix_len);
 

--- a/include/grpc/dp_grpc_api.h
+++ b/include/grpc/dp_grpc_api.h
@@ -77,12 +77,12 @@ enum dpgrpc_capture_iface_type {
 struct dpgrpc_iface {
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
 	uint32_t				ip4_addr;
-	uint8_t					ip6_addr[DP_IPV6_ADDR_SIZE];
+	union dp_ipv6			ip6_addr;
 	uint32_t				vni;
 	struct dp_ip_address	pxe_addr;							// request (create) only
 	char					pxe_str[DP_IFACE_PXE_MAX_LEN];		// request (create) only
 	char					pci_name[RTE_ETH_NAME_MAX_LEN];
-	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
+	union dp_ipv6			ul_addr6;							// reply only
 	uint64_t				total_flow_rate_cap;
 	uint64_t				public_flow_rate_cap;
 };
@@ -108,17 +108,17 @@ struct dpgrpc_route {
 struct dpgrpc_vip {
 	struct dp_ip_address	addr;
 	char					iface_id[DP_IFACE_ID_MAX_LEN];
-	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
+	union dp_ipv6			ul_addr6;						// reply only
 };
 
 struct dpgrpc_nat {
-	char					iface_id[DP_IFACE_ID_MAX_LEN];		// local only
+	char					iface_id[DP_IFACE_ID_MAX_LEN];	// local only
 	struct dp_ip_address	addr;
 	uint16_t				min_port;
 	uint16_t				max_port;
-	uint32_t				vni;								// neighnat or reply only
-	uint8_t					neigh_addr6[DP_IPV6_ADDR_SIZE];	// neighnat only
-	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
+	uint32_t				vni;							// neighnat or reply only
+	union dp_ipv6			neigh_addr6;					// neighnat only
+	union dp_ipv6			ul_addr6;						// reply only
 };
 
 struct dpgrpc_lb_port {
@@ -127,11 +127,11 @@ struct dpgrpc_lb_port {
 };
 
 struct dpgrpc_lb {
-	char					lb_id[DP_LB_ID_MAX_LEN];			// request only
+	char					lb_id[DP_LB_ID_MAX_LEN];		// request only
 	struct dp_ip_address	addr;
 	uint32_t				vni;
 	struct dpgrpc_lb_port	lbports[DP_LB_MAX_PORTS];
-	uint8_t					ul_addr6[DP_IPV6_ADDR_SIZE];	// reply only
+	union dp_ipv6			ul_addr6;						// reply only
 };
 
 struct dpgrpc_lb_id {
@@ -167,13 +167,13 @@ struct dpgrpc_versions {
 struct dpgrpc_capture_interface {
 	enum dpgrpc_capture_iface_type	type;
 	union {
-		char	iface_id[DP_IFACE_ID_MAX_LEN];
-		uint8_t pf_index;
+		char		iface_id[DP_IFACE_ID_MAX_LEN];
+		uint8_t		pf_index;
 	} spec;
 };
 
 struct dpgrpc_capture {
-	uint8_t			dst_addr6[DP_IPV6_ADDR_SIZE];
+	union dp_ipv6	dst_addr6;
 	uint8_t			interface_count;
 	uint16_t		udp_src_port;
 	uint16_t		udp_dst_port;
@@ -182,7 +182,7 @@ struct dpgrpc_capture {
 };
 
 struct dpgrpc_capture_stop {
-	uint16_t						port_cnt;
+	uint16_t		port_cnt;
 };
 
 struct dpgrpc_request {
@@ -228,20 +228,20 @@ struct dpgrpc_request {
 };
 
 struct dpgrpc_vf_pci {
-	char		name[RTE_ETH_NAME_MAX_LEN];
-	uint8_t		ul_addr6[DP_IPV6_ADDR_SIZE];
+	char			name[RTE_ETH_NAME_MAX_LEN];
+	union dp_ipv6	ul_addr6;
 };
 
 struct dpgrpc_ul_addr {
-	uint8_t		addr6[DP_IPV6_ADDR_SIZE];
+	union dp_ipv6	addr6;
 };
 
 struct dpgrpc_fwrule_info {
-	struct dp_fwall_rule rule;
+	struct dp_fwall_rule	rule;
 };
 
 struct dpgrpc_vni_in_use {
-	uint8_t		in_use;
+	uint8_t			in_use;
 };
 
 struct dpgrpc_reply {

--- a/include/grpc/dp_grpc_conv.h
+++ b/include/grpc/dp_grpc_conv.h
@@ -17,7 +17,7 @@ namespace GrpcConv
 	bool IsInterfaceIdValid(const std::string& id);
 
 	bool StrToIpv4(const std::string& str, uint32_t *dst);
-	bool StrToIpv6(const std::string& str, uint8_t *dst);
+	bool StrToIpv6(const std::string& str, union dp_ipv6 *dst);
 
 	bool StrToDpAddress(const std::string& str, struct dp_ip_address *dp_addr, IpVersion ipver);
 	bool GrpcToDpAddress(const IpAddress& grpc_addr, struct dp_ip_address *dp_addr);
@@ -31,11 +31,11 @@ namespace GrpcConv
 	bool GrpcToDpCaptureInterfaceType(const CaptureInterfaceType & grpc_type, enum dpgrpc_capture_iface_type *dp_capture_iface_type);
 	CaptureInterfaceType CaptureInterfaceTypeToGrpc(enum dpgrpc_capture_iface_type dp_capture_iface_type);
 
-	const char *Ipv4ToStr(uint32_t ipv4);
+	bool Ipv4PrefixLenToMask(uint32_t prefix_length, struct dp_ip_mask *mask);
 
-	bool Ipv4PrefixLenToMask(uint32_t prefix_length, uint32_t *mask);
+	bool Ipv6PrefixLenToMask(uint32_t prefix_length, struct dp_ip_mask *mask);
 
-	bool Ipv6PrefixLenToMask(uint32_t prefix_length, uint8_t *mask);
+	void DpToGrpcAddress(const struct dp_ip_address *dp_addr, IpAddress *grpc_addr);
 
 	void DpToGrpcInterface(const struct dpgrpc_iface *dp_iface, Interface *grpc_iface);
 

--- a/include/monitoring/dp_monitoring.h
+++ b/include/monitoring/dp_monitoring.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <rte_mbuf.h>
+#include "dp_ipaddr.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +36,7 @@ struct dp_event_msg {
 };
 
 struct dp_capture_hdr_config {
-	uint8_t capture_node_ipv6_addr[16];
+	union dp_ipv6 capture_node_ipv6_addr;
 	uint16_t capture_udp_src_port;
 	uint16_t capture_udp_dst_port;
 };
@@ -43,7 +44,7 @@ struct dp_capture_hdr_config {
 void dp_process_event_msg(struct rte_mbuf *m);
 
 
-void dp_set_capture_hdr_config(uint8_t *addr, uint16_t udp_src_port, uint16_t udp_dst_port);
+void dp_set_capture_hdr_config(const union dp_ipv6 *addr, uint16_t udp_src_port, uint16_t udp_dst_port);
 const struct dp_capture_hdr_config *dp_get_capture_hdr_config(void);
 
 void dp_set_capture_enabled(bool enabled);

--- a/include/nodes/ipv6_nd_node.h
+++ b/include/nodes/ipv6_nd_node.h
@@ -5,7 +5,6 @@
 #define __INCLUDE_IPV6_ND_NODE_H__
 
 #include <stdint.h>
-#include <netinet/in.h>
 #include <rte_ip.h>
 
 #ifdef __cplusplus
@@ -75,7 +74,7 @@ struct icmp6hdr {
 
 struct nd_msg {
 	struct icmp6hdr	icmph;
-	struct in6_addr	target;
+	uint8_t	target[16];
 	uint8_t	opt[];
 };
 

--- a/include/rte_flow/dp_rte_flow_helpers.h
+++ b/include/rte_flow/dp_rte_flow_helpers.h
@@ -171,10 +171,10 @@ void dp_set_ipv6_flow_item(struct rte_flow_item *item,
 static __rte_always_inline
 void dp_set_ipv6_src_flow_item(struct rte_flow_item *item,
 							   struct rte_flow_item_ipv6 *ipv6_spec,
-							   const uint8_t *src,
+							   const union dp_ipv6 *src,
 							   uint8_t proto)
 {
-	memcpy(ipv6_spec->hdr.src_addr, src, 16);
+	dp_set_src_ipv6(&ipv6_spec->hdr, src);
 	ipv6_spec->hdr.proto = proto;
 	item->type = RTE_FLOW_ITEM_TYPE_IPV6;
 	item->spec = ipv6_spec;
@@ -185,10 +185,10 @@ void dp_set_ipv6_src_flow_item(struct rte_flow_item *item,
 static __rte_always_inline
 void dp_set_ipv6_dst_flow_item(struct rte_flow_item *item,
 							   struct rte_flow_item_ipv6 *ipv6_spec,
-							   const uint8_t *dst,
+							   const union dp_ipv6 *dst,
 							   uint8_t proto)
 {
-	memcpy(ipv6_spec->hdr.dst_addr, dst, 16);
+	dp_set_dst_ipv6(&ipv6_spec->hdr, dst);
 	ipv6_spec->hdr.proto = proto;
 	item->type = RTE_FLOW_ITEM_TYPE_IPV6;
 	item->spec = ipv6_spec;
@@ -464,9 +464,9 @@ void dp_set_ipv4_set_dst_action(struct rte_flow_action *action,
 static __rte_always_inline
 void dp_set_ipv6_set_src_action(struct rte_flow_action *action,
 								struct rte_flow_action_set_ipv6 *ipv6_action,
-								const uint8_t *ipv6)
+								const union dp_ipv6 *ipv6)
 {
-	memcpy(ipv6_action->ipv6_addr, ipv6, sizeof(ipv6_action->ipv6_addr));
+	DP_ARRAY_FROM_IPV6(ipv6_action->ipv6_addr, ipv6);
 	action->type = RTE_FLOW_ACTION_TYPE_SET_IPV6_SRC;
 	action->conf = ipv6_action;
 }
@@ -474,9 +474,9 @@ void dp_set_ipv6_set_src_action(struct rte_flow_action *action,
 static __rte_always_inline
 void dp_set_ipv6_set_dst_action(struct rte_flow_action *action,
 								struct rte_flow_action_set_ipv6 *ipv6_action,
-								const uint8_t *ipv6)
+								const union dp_ipv6 *ipv6)
 {
-	memcpy(ipv6_action->ipv6_addr, ipv6, sizeof(ipv6_action->ipv6_addr));
+	DP_ARRAY_FROM_IPV6(ipv6_action->ipv6_addr, ipv6);
 	action->type = RTE_FLOW_ACTION_TYPE_SET_IPV6_DST;
 	action->conf = ipv6_action;
 }

--- a/include/rte_flow/dp_rte_flow_init.h
+++ b/include/rte_flow/dp_rte_flow_init.h
@@ -16,7 +16,7 @@ extern "C" {
 int dp_install_isolated_mode_ipip(uint16_t port_id, uint8_t proto_id);
 
 #ifdef ENABLE_VIRTSVC
-int dp_install_isolated_mode_virtsvc(uint16_t port_id, uint8_t proto_id, const uint8_t svc_ipv6[16], uint16_t svc_port);
+int dp_install_isolated_mode_virtsvc(uint16_t port_id, uint8_t proto_id, const union dp_ipv6 *svc_ipv6, uint16_t svc_port);
 #endif
 
 #ifdef __cplusplus

--- a/src/dp_firewall.c
+++ b/src/dp_firewall.c
@@ -135,13 +135,13 @@ static __rte_always_inline bool dp_is_rule_matching(const struct dp_fwall_rule *
 			(dest_ip & rule->dest_mask.ip4) == (r_dest_ip & rule->dest_mask.ip4)))
 			return false;
 	} else if (df->l3_type == RTE_ETHER_TYPE_IPV6) {
-		dp_apply_ipv6_mask(df->src.src_addr6, rule->src_mask.ip6, masked_src_ip6);
-		dp_apply_ipv6_mask(df->dst.dst_addr6, rule->dest_mask.ip6, masked_dest_ip6);
-		dp_apply_ipv6_mask(rule->src_ip.ipv6, rule->src_mask.ip6, masked_r_src_ip6);
-		dp_apply_ipv6_mask(rule->dest_ip.ipv6, rule->dest_mask.ip6, masked_r_dest_ip6);
+		dp_apply_ipv6_mask(df->src.src_addr6.bytes, rule->src_mask.ip6.bytes, masked_src_ip6);  // TODO Migrate as separate commit
+		dp_apply_ipv6_mask(df->dst.dst_addr6.bytes, rule->dest_mask.ip6.bytes, masked_dest_ip6);  // TODO Migrate as separate commit
+		dp_apply_ipv6_mask(rule->src_ip.ipv6.bytes, rule->src_mask.ip6.bytes, masked_r_src_ip6);  // TODO accept dp_ipv6 as separate commit
+		dp_apply_ipv6_mask(rule->dest_ip.ipv6.bytes, rule->dest_mask.ip6.bytes, masked_r_dest_ip6);  // TODO accept dp_ipv6 as separate commit
 
 		if (!(rte_rib6_is_equal(masked_src_ip6, masked_r_src_ip6) &&
-					rte_rib6_is_equal(masked_dest_ip6, masked_r_dest_ip6)))
+					rte_rib6_is_equal(masked_dest_ip6, masked_r_dest_ip6)))  // TODO migrate as separate commit
 			return false;
 	} else {
 		return false;

--- a/src/dp_iface.c
+++ b/src/dp_iface.c
@@ -84,7 +84,7 @@ void dp_delete_iface(struct dp_port *port)
 	uint32_t vni = port->iface.vni;
 
 	dp_del_route(port, vni, port->iface.cfg.own_ip, 32);
-	dp_del_route6(port, vni, port->iface.cfg.dhcp_ipv6, 128);
+	dp_del_route6(port, vni, &port->iface.cfg.dhcp_ipv6, 128);
 
 	if (DP_FAILED(dp_delete_vni_route_tables(vni)))
 		DPS_LOG_WARNING("Unable to delete route tables", DP_LOG_VNI(vni));

--- a/src/dp_ipaddr.c
+++ b/src/dp_ipaddr.c
@@ -1,6 +1,23 @@
 #include "dp_ipaddr.h"
 #include "dp_conf.h"
 
+
+const union dp_ipv6 dp_empty_ipv6 = {
+	.bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+};
+
+const union dp_ipv6 dp_multicast_ipv6 = {
+	.bytes = { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 }
+};
+
+const union dp_ipv6 dp_nat64_prefix = {
+	.bytes = { 0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+};
+const union dp_ipv6 dp_nat64_mask = {
+	.bytes = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0 }
+};
+
+
 int dp_str_to_ipv4(const char *src, uint32_t *dest)
 {
 	struct in_addr addr;

--- a/src/dp_ipaddr.c
+++ b/src/dp_ipaddr.c
@@ -1,4 +1,5 @@
 #include "dp_ipaddr.h"
+#include "dp_conf.h"
 
 int dp_str_to_ipv4(const char *src, uint32_t *dest)
 {
@@ -45,4 +46,23 @@ int dp_ipaddr_to_str(const struct dp_ip_address *addr, char *dest, int dest_len)
 		return dp_ipv4_to_str(addr->ipv4, dest, dest_len);
 
 	return dp_ipv6_to_str(&ipv6, dest, dest_len);
+}
+
+
+void dp_generate_ul_ipv6(union dp_ipv6 *dest)
+{
+	static uint32_t ul_counter = 0;
+
+	dest->_ul.prefix = dp_conf_get_underlay_ip()->_prefix;  // Use the same prefix as the host
+	dest->_ul.kernel = dest->_ul.reserved = 0;
+#ifdef ENABLE_STATIC_UNDERLAY_IP
+	dest->_ul.random = 1;
+#else
+	dest->_ul.random = (uint8_t)(rand() % 256);
+
+	// Start the counter from a random value to increase the randomness of dpservice startup
+	if (ul_counter == 0)
+		ul_counter = rand() % 256;
+#endif
+	dest->_ul.local = htonl(++ul_counter);
 }

--- a/src/dp_ipaddr.c
+++ b/src/dp_ipaddr.c
@@ -1,0 +1,48 @@
+#include "dp_ipaddr.h"
+
+int dp_str_to_ipv4(const char *src, uint32_t *dest)
+{
+	struct in_addr addr;
+
+	if (inet_pton(AF_INET, src, &addr) != 1)
+		return DP_ERROR;
+
+	*dest = ntohl(addr.s_addr);
+	return DP_OK;
+}
+
+int dp_str_to_ipv6(const char *src, union dp_ipv6 *dest)
+{
+	// man(3): The address is converted to a struct in6_addr and copied to dst, which must be sizeof(struct in6_addr) (16) bytes (128 bits) long.
+	// man(3): inet_pton() returns 1 on success
+	static_assert(sizeof(struct in6_addr) == sizeof(*dest), "union dp_ipv6 is not compatible with inet_pton() requirements");
+	return inet_pton(AF_INET6, src, dest) == 1 ? DP_OK : DP_ERROR;
+}
+
+int dp_ipv6_to_str(const union dp_ipv6 *ipv6, char *dest, int dest_len)
+{
+	if (!inet_ntop(AF_INET6, &ipv6->bytes, dest, dest_len))
+		return -errno;
+
+	return DP_OK;
+}
+
+int dp_ipv4_to_str(uint32_t ipv4, char *dest, int dest_len)
+{
+	rte_be32_t net_ipv4 = htonl(ipv4);
+
+	if (!inet_ntop(AF_INET, &net_ipv4, dest, dest_len))
+		return -errno;
+
+	return DP_OK;
+}
+
+int dp_ipaddr_to_str(const struct dp_ip_address *addr, char *dest, int dest_len)
+{
+	union dp_ipv6 ipv6;
+
+	if (DP_FAILED(dp_ipv6_from_ipaddr(&ipv6, addr)))
+		return dp_ipv4_to_str(addr->ipv4, dest, dest_len);
+
+	return dp_ipv6_to_str(&ipv6, dest, dest_len);
+}

--- a/src/dp_log.c
+++ b/src/dp_log.c
@@ -218,7 +218,7 @@ void _dp_log(unsigned int level, unsigned int logtype,
 	int format;
 	char escaped[3072];  // worst-case: 512 encoded characters (\u1234)
 	const char *str_value;
-	rte_be32_t ipv4_value;
+	uint32_t ipv4_value;
 
 	if (!rte_log_can_log(logtype, level))
 		return;
@@ -269,7 +269,7 @@ void _dp_log(unsigned int level, unsigned int logtype,
 			fprintf(f, FORMAT_UINT, key, va_arg(args, unsigned int));
 			break;
 		case _DP_LOG_FMT_IPV4:
-			ipv4_value = va_arg(args, rte_be32_t);
+			ipv4_value = va_arg(args, uint32_t);
 			fprintf(f, FORMAT_IPV4, key, ((ipv4_value) >> 24) & 0xFF,
 										 ((ipv4_value) >> 16) & 0xFF,
 										 ((ipv4_value) >> 8) & 0xFF,
@@ -277,8 +277,8 @@ void _dp_log(unsigned int level, unsigned int logtype,
 			break;
 		case _DP_LOG_FMT_IPV6:
 			// re-use the escaping buffer for IP conversion
-			str_value = inet_ntop(AF_INET6, va_arg(args, const uint8_t *), escaped, INET6_ADDRSTRLEN);
-			fprintf(f, FORMAT_STR, key, str_value);
+			DP_IPV6_TO_STR(va_arg(args, const union dp_ipv6 *), escaped);
+			fprintf(f, FORMAT_STR, key, escaped);
 			break;
 		case _DP_LOG_FMT_PTR:
 			fprintf(f, FORMAT_PTR, key, va_arg(args, const void *));

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -278,7 +278,7 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint32_t *route_key)
+										  uint32_t *p_ip)
 {
 	uint32_t dst_ip = ntohl(df->dst.dst_addr);
 	struct rte_rib_node *node;
@@ -307,7 +307,7 @@ const struct dp_port *dp_get_ip4_out_port(const struct dp_port *in_port,
 	if (dst_port->is_pf)
 		rte_memcpy(route, rte_rib_get_ext(node), sizeof(*route));
 
-	if (DP_FAILED(rte_rib_get_ip(node, route_key)))
+	if (DP_FAILED(rte_rib_get_ip(node, p_ip)))
 		return NULL;
 
 	return dst_port;
@@ -317,12 +317,13 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 										  uint32_t t_vni,
 										  const struct dp_flow *df,
 										  struct dp_iface_route *route,
-										  uint8_t route_key[DP_IPV6_ADDR_SIZE])
+										  union dp_ipv6 *p_ipv6)
 {
 	struct rte_rib6_node *node;
 	struct rte_rib6 *root;
 	uint64_t next_hop;
 	struct dp_port *dst_port;
+	uint8_t ip[RTE_RIB6_IPV6_ADDR_SIZE];
 
 	if (t_vni == 0)
 		t_vni = in_port->iface.vni;
@@ -345,8 +346,9 @@ const struct dp_port *dp_get_ip6_out_port(const struct dp_port *in_port,
 	if (dst_port->is_pf)
 		rte_memcpy(route, rte_rib6_get_ext(node), sizeof(*route));
 
-	if (DP_FAILED(rte_rib6_get_ip(node, route_key)))
+	if (DP_FAILED(rte_rib6_get_ip(node, ip)))
 		return NULL;
 
+	DP_IPV6_FROM_ARRAY(p_ipv6, ip);
 	return dst_port;
 }

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -22,11 +22,11 @@ static __rte_always_inline int dp_lpm_fill_route_tables(const struct dp_port *po
 {
 	int ret;
 
-	ret = dp_add_route(port, port->iface.vni, 0, port->iface.cfg.own_ip, NULL, 32);
+	ret = dp_add_route(port, port->iface.vni, 0, port->iface.cfg.own_ip, &dp_empty_ipv6, 32);
 	if (DP_FAILED(ret))
 		return ret;
 
-	ret = dp_add_route6(port, port->iface.vni, 0, &port->iface.cfg.dhcp_ipv6, NULL, 128);
+	ret = dp_add_route6(port, port->iface.vni, 0, &port->iface.cfg.dhcp_ipv6, &dp_empty_ipv6, 128);
 	if (DP_FAILED(ret))
 		return ret;
 
@@ -86,7 +86,7 @@ const union dp_ipv6 *dp_get_gw_ip6(void)
 int dp_add_route(const struct dp_port *port, uint32_t vni, uint32_t t_vni, uint32_t ip,
 				 const union dp_ipv6 *t_ip6, uint8_t depth)
 {
-	struct dp_iface_route *route = NULL;
+	struct dp_iface_route *route;
 	struct rte_rib_node *node;
 	struct rte_rib *root;
 
@@ -193,7 +193,7 @@ static int dp_list_route_entry(struct rte_rib_node *node,
 int dp_list_routes(const struct dp_port *port, uint32_t vni, bool ext_routes,
 				   struct dp_grpc_responder *responder)
 {
-	struct rte_rib_node *node = NULL;
+	struct rte_rib_node *node;
 	struct rte_rib *root;
 	int ret;
 
@@ -223,7 +223,7 @@ int dp_list_routes(const struct dp_port *port, uint32_t vni, bool ext_routes,
 int dp_add_route6(const struct dp_port *port, uint32_t vni, uint32_t t_vni, const union dp_ipv6 *ipv6,
 				  const union dp_ipv6 *t_ip6, uint8_t depth)
 {
-	struct dp_iface_route *route = NULL;
+	struct dp_iface_route *route;
 	struct rte_rib6_node *node;
 	struct rte_rib6 *root;
 

--- a/src/dp_maglev.c
+++ b/src/dp_maglev.c
@@ -63,12 +63,9 @@ static uint32_t dp_murmur_hash2(const union dp_ipv6 *ipv6)
 static uint32_t dp_djb_hash(const union dp_ipv6 *ipv6)
 {
 	uint32_t hash = DP_DJB_HASH_MAGIC;
-	const uint8_t *byte = ipv6->bytes;
-	int c;
 
-	// TODO FIX in separate commit
-	while ((c = *byte++))
-		hash = ((hash << 5) + hash) + c;
+	for (size_t i = 0; i < sizeof(ipv6->bytes); ++i)
+		hash = ((hash << 5) + hash) + ipv6->bytes[i];
 
 	hash &= ~(1 << 31);
 	return hash;

--- a/src/dp_maglev.c
+++ b/src/dp_maglev.c
@@ -205,13 +205,12 @@ int dp_add_maglev_backend(struct lb_value *lbval, const union dp_ipv6 *back_ip)
 
 int dp_delete_maglev_backend(struct lb_value *lbval, const union dp_ipv6 *back_ip)
 {
-	static const union dp_ipv6 zero_ipv6 = { 0, };
 	int i;
 
 	for (i = 0; i < lbval->back_end_cnt; i++) {
 		if (dp_ipv6_match(&lbval->back_end_ips[i], back_ip)) {
 			dp_shift_back_end_ips(lbval->back_end_ips, i, lbval->back_end_cnt - 1, DP_SHIFT_DOWN);
-			dp_copy_ipv6(&lbval->back_end_ips[lbval->back_end_cnt - 1], &zero_ipv6);
+			dp_copy_ipv6(&lbval->back_end_ips[lbval->back_end_cnt - 1], &dp_empty_ipv6);
 			lbval->back_end_cnt--;
 			break;
 		}

--- a/src/dp_maglev.c
+++ b/src/dp_maglev.c
@@ -205,7 +205,7 @@ int dp_add_maglev_backend(struct lb_value *lbval, const union dp_ipv6 *back_ip)
 
 int dp_delete_maglev_backend(struct lb_value *lbval, const union dp_ipv6 *back_ip)
 {
-	static union dp_ipv6 zero_ipv6 = { 0, };
+	static const union dp_ipv6 zero_ipv6 = { 0, };
 	int i;
 
 	for (i = 0; i < lbval->back_end_cnt; i++) {

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -12,9 +12,6 @@
 #include "nodes/arp_node.h"
 #include "nodes/ipv6_nd_node.h"
 
-static const union dp_ipv6 dp_multicast_ipv6 = {
-	.bytes = { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 }
-};
 static const struct rte_ether_addr dp_mc_mac = {
 	.addr_bytes = { 0x33, 0x33, 0x00, 0x00, 0x00, 0x01 }
 };

--- a/src/dp_virtsvc.c
+++ b/src/dp_virtsvc.c
@@ -103,8 +103,8 @@ static int dp_virtsvc_ipv6_comparator(const void *p1, const void *p2)
 	const struct dp_virtsvc *l = *(const struct dp_virtsvc * const *)p1;
 	const struct dp_virtsvc *r = *(const struct dp_virtsvc * const *)p2;
 
-	return dp_virtsvc_ipv6_cmp(l->proto, l->service_addr, l->service_port,
-							   r->proto, r->service_addr, r->service_port);
+	return dp_virtsvc_ipv6_cmp(l->proto, &l->service_addr, l->service_port,
+							   r->proto, &r->service_addr, r->service_port);
 }
 
 static int dp_virtsvc_create_trees(void)
@@ -166,7 +166,7 @@ int dp_virtsvc_init(int socket_id)
 		dp_virtservices_end->virtual_addr = rule->virtual_addr;
 		dp_virtservices_end->virtual_port = rule->virtual_port;
 		dp_virtservices_end->service_port = rule->service_port;
-		rte_memcpy(dp_virtservices_end->service_addr, rule->service_addr, sizeof(rule->service_addr));
+		dp_copy_ipv6(&dp_virtservices_end->service_addr, &rule->service_addr);
 		// last_assigned_port is 0 due to zmalloc()
 		snprintf(hashtable_name, sizeof(hashtable_name), "virtsvc_table_%u", i);
 		dp_virtservices_end->open_ports = dp_create_jhash_table(DP_VIRTSVC_PORTCOUNT,
@@ -229,7 +229,7 @@ int dp_virtsvc_install_isolation_rules(uint16_t port_id)
 	DP_FOREACH_VIRTSVC(&dp_virtservices, service) {
 		ret = dp_install_isolated_mode_virtsvc(port_id,
 											   service->proto,
-											   service->service_addr,
+											   &service->service_addr,
 											   service->service_port);
 		if (DP_FAILED(ret)) {
 			DPS_LOG_ERR("Cannot create isolation rule", DP_LOG_VIRTSVC(service), DP_LOG_RET(ret));

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -217,10 +217,9 @@ static void SetupIpAndPrefix(const struct dp_fwall_rule *dp_rule, IpAddress* ip,
 	// NOTE: This assumes the mask is valid (i.e. starting from the left, no holes)
 	GrpcConv::DpToGrpcAddress(&rule_ip, ip);
 	if (!rule_ip.is_v6)
-		pfx->set_length(__builtin_popcount(rule_mask.ip4));
+		pfx->set_length(dp_ipv6_popcount(&rule_mask.ip6));
 	else
-		// TODO (plague): migrate; revisit after dp_generate_underlay_ipv6() uses prefix/suffix
-		pfx->set_length(__builtin_popcountll(rule_mask.ip6._prefix) + __builtin_popcountll(rule_mask.ip6._suffix));
+		pfx->set_length(__builtin_popcount(rule_mask.ip4));
 	pfx->set_allocated_ip(ip);
 }
 

--- a/src/grpc/dp_grpc_conv.cpp
+++ b/src/grpc/dp_grpc_conv.cpp
@@ -175,7 +175,7 @@ bool Ipv6PrefixLenToMask(uint32_t prefix_length, struct dp_ip_mask *mask)
 		ipv6[i / 8] |= (uint8_t)(1 << (7 - (i % 8)));
 	}
 
-	DP_IPV6_FROM_ARRAY(&mask->ip6, ipv6);  // TODO migrate mask
+	DP_IPV6_FROM_ARRAY(&mask->ip6, ipv6);
 	return true;
 }
 

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -382,7 +382,7 @@ static int dp_process_create_prefix(struct dp_grpc_responder *responder)
 		return DP_GRPC_ERR_NO_VM;
 
 	iface_vni = port->iface.vni;
-	ret = dp_grpc_add_route(port, iface_vni, 0, &request->addr, NULL, request->length);
+	ret = dp_grpc_add_route(port, iface_vni, 0, &request->addr, &dp_empty_ipv6, request->length);
 	if (DP_FAILED(ret))
 		return ret;
 
@@ -457,12 +457,12 @@ static int dp_process_create_interface(struct dp_grpc_responder *responder)
 
 	/* Do not install routes for an empty(zero) IP, as zero ip is just a marker for showing the disabled IPv4/IPv6 machinery */
 	if (request->ip4_addr != 0) {
-		ret = dp_add_route(port, request->vni, 0, request->ip4_addr, NULL, 32);
+		ret = dp_add_route(port, request->vni, 0, request->ip4_addr, &dp_empty_ipv6, 32);
 		if (DP_FAILED(ret))
 			goto iface_err;
 	}
 	if (!dp_is_ipv6_zero(&request->ip6_addr)) {
-		ret = dp_add_route6(port, request->vni, 0, &request->ip6_addr, NULL, 128);
+		ret = dp_add_route6(port, request->vni, 0, &request->ip6_addr, &dp_empty_ipv6, 128);
 		if (DP_FAILED(ret))
 			goto route_err;
 	}

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,6 +45,7 @@ dp_sources = [
   'dp_hairpin.c',
   'dp_iface.c',
   'dp_internal_stats.c',
+  'dp_ipaddr.c',
   'dp_lb.c',
   'dp_log.c',
   'dp_lpm.c',

--- a/src/monitoring/dp_monitoring.c
+++ b/src/monitoring/dp_monitoring.c
@@ -26,9 +26,9 @@ void dp_process_event_msg(struct rte_mbuf *m)
 	rte_pktmbuf_free(m);
 }
 
-void dp_set_capture_hdr_config(uint8_t *addr, uint16_t udp_src_port, uint16_t udp_dst_port)
+void dp_set_capture_hdr_config(const union dp_ipv6 *addr, uint16_t udp_src_port, uint16_t udp_dst_port)
 {
-	rte_memcpy(capture_hdr_config.capture_node_ipv6_addr, addr, sizeof(capture_hdr_config.capture_node_ipv6_addr));
+	dp_copy_ipv6(&capture_hdr_config.capture_node_ipv6_addr, addr);
 	capture_hdr_config.capture_udp_src_port = udp_src_port;
 	capture_hdr_config.capture_udp_dst_port = udp_dst_port;
 }

--- a/src/nodes/cls_node.c
+++ b/src/nodes/cls_node.c
@@ -94,7 +94,7 @@ static __rte_always_inline struct dp_virtsvc *get_outgoing_virtsvc(const struct 
 
 static __rte_always_inline struct dp_virtsvc *get_incoming_virtsvc(const struct rte_ipv6_hdr *ipv6_hdr)
 {
-	const uint8_t *addr = ipv6_hdr->src_addr;
+	const union dp_ipv6 *src_ipv6 = dp_get_src_ipv6(ipv6_hdr);
 	uint8_t proto = ipv6_hdr->proto;
 	rte_be16_t port;
 	const struct dp_virtsvc_lookup_entry *entry;
@@ -109,8 +109,8 @@ static __rte_always_inline struct dp_virtsvc *get_incoming_virtsvc(const struct 
 
 	entry = virtsvc_ipv6_tree;
 	while (entry) {
-		diff = dp_virtsvc_ipv6_cmp(proto, addr, port,
-								   entry->virtsvc->proto, entry->virtsvc->service_addr, entry->virtsvc->service_port);
+		diff = dp_virtsvc_ipv6_cmp(proto, src_ipv6, port,
+								   entry->virtsvc->proto, &entry->virtsvc->service_addr, entry->virtsvc->service_port);
 		if (!diff)
 			return entry->virtsvc;
 		entry = diff < 0 ? entry->left : entry->right;

--- a/src/nodes/ipip_decap_node.c
+++ b/src/nodes/ipip_decap_node.c
@@ -23,7 +23,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	struct dp_port *dst_port;
 	uint32_t l3_type;
 
-	vnf = dp_get_vnf(df->tun_info.ul_dst_addr6);
+	vnf = dp_get_vnf(&df->tun_info.ul_dst_addr6);
 	if (!vnf)
 		return IPIP_DECAP_NEXT_DROP;
 

--- a/src/nodes/ipip_encap_node.c
+++ b/src/nodes/ipip_encap_node.c
@@ -64,11 +64,11 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 
 	if (df->nat_type == DP_LB_RECIRC)
 		// store the original ipv6 dst address in the packet
-		rte_memcpy(ipv6_hdr->src_addr, df->tun_info.ul_src_addr6, sizeof(ipv6_hdr->src_addr));
+		dp_set_src_ipv6(ipv6_hdr, &df->tun_info.ul_src_addr6);
 	else
-		rte_memcpy(ipv6_hdr->src_addr, dp_get_port_ul_ipv6(dp_get_in_port(m)), sizeof(ipv6_hdr->src_addr));
+		dp_set_src_ipv6(ipv6_hdr, dp_get_port_ul_ipv6(dp_get_in_port(m)));
 
-	rte_memcpy(ipv6_hdr->dst_addr, df->tun_info.ul_dst_addr6, sizeof(ipv6_hdr->dst_addr));
+	dp_set_dst_ipv6(ipv6_hdr, &df->tun_info.ul_dst_addr6);
 	ipv6_hdr->proto = df->tun_info.proto_id;
 
 	m->packet_type = packet_type;

--- a/src/nodes/ipv4_lookup_node.c
+++ b/src/nodes/ipv4_lookup_node.c
@@ -27,7 +27,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 {
 	struct dp_flow *df = dp_get_flow_ptr(m);
 	struct dp_iface_route route;
-	uint32_t route_key = 0;
+	uint32_t ip = 0;
 	const struct dp_port *in_port = dp_get_in_port(m);
 	const struct dp_port *out_port;
 
@@ -35,7 +35,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (df->l4_type == IPPROTO_UDP && df->l4_info.trans_port.dst_port == htons(DP_BOOTP_SRV_PORT))
 		return IPV4_LOOKUP_NEXT_DHCP;
 
-	out_port = dp_get_ip4_out_port(in_port, df->tun_info.dst_vni, df, &route, &route_key);
+	out_port = dp_get_ip4_out_port(in_port, df->tun_info.dst_vni, df, &route, &ip);
 	if (!out_port)
 		return IPV4_LOOKUP_NEXT_DROP;
 
@@ -53,7 +53,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (!in_port->is_pf)
 		df->tun_info.dst_vni = route.vni;
 
-	df->flow_type = route_key == 0 ? DP_FLOW_SOUTH_NORTH : DP_FLOW_WEST_EAST;
+	df->flow_type = ip == 0 ? DP_FLOW_SOUTH_NORTH : DP_FLOW_WEST_EAST;
 	df->nxt_hop = out_port->port_id;  // always valid since coming from struct dp_port
 
 	return IPV4_LOOKUP_NEXT_NAT;

--- a/src/nodes/ipv4_lookup_node.c
+++ b/src/nodes/ipv4_lookup_node.c
@@ -42,7 +42,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (out_port->is_pf) {
 		if (in_port->is_pf)
 			return IPV4_LOOKUP_NEXT_DROP;
-		rte_memcpy(df->tun_info.ul_dst_addr6, route.nh_ipv6, sizeof(df->tun_info.ul_dst_addr6));
+		dp_copy_ipv6(&df->tun_info.ul_dst_addr6, &route.nh_ipv6);
 		out_port = dp_multipath_get_pf(df->dp_flow_hash);
 	} else {
 		// next hop is known, fill in Ether header

--- a/src/nodes/ipv6_lookup_node.c
+++ b/src/nodes/ipv6_lookup_node.c
@@ -25,8 +25,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	struct dp_iface_route route;
 	const struct dp_port *in_port = dp_get_in_port(m);
 	const struct dp_port *out_port;
-	uint8_t route_key[DP_IPV6_ADDR_SIZE] = {0};
-	uint8_t cmp_key[DP_IPV6_ADDR_SIZE] = {0};
+	uint8_t route_key[DP_IPV6_ADDR_SIZE] = {0};  // TODO migrate as separate commit
+	uint8_t cmp_key[DP_IPV6_ADDR_SIZE] = {0};  // TODO migrate as separate commit
 	int t_vni;
 
 	t_vni = in_port->is_pf ? df->tun_info.dst_vni : 0;
@@ -38,7 +38,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (out_port->is_pf) {
 		if (in_port->is_pf)
 			return IPV6_LOOKUP_NEXT_DROP;
-		rte_memcpy(df->tun_info.ul_dst_addr6, route.nh_ipv6, sizeof(df->tun_info.ul_dst_addr6));
+		dp_copy_ipv6(&df->tun_info.ul_dst_addr6, &route.nh_ipv6);
 	} else {
 		// next hop is known, fill in Ether header
 		// (PF egress goes through a tunnel that destroys Ether header)
@@ -48,7 +48,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (!in_port->is_pf)
 		df->tun_info.dst_vni = route.vni;
 
-	df->flow_type = rte_rib6_is_equal(route_key, cmp_key) ? DP_FLOW_SOUTH_NORTH : DP_FLOW_WEST_EAST;
+	df->flow_type = rte_rib6_is_equal(route_key, cmp_key) ? DP_FLOW_SOUTH_NORTH : DP_FLOW_WEST_EAST;  // TODO migrate as separate commit
 	df->nxt_hop = out_port->port_id;  // always valid since coming from struct dp_port
 
 	return IPV6_LOOKUP_NEXT_SNAT;

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -20,13 +20,6 @@ int ipv6_nd_node_append_vf_tx(uint16_t port_id, const char *tx_node_name)
 	return dp_node_append_vf_tx(DP_NODE_GET_SELF(ipv6_nd), next_tx_index, port_id, tx_node_name);
 }
 
-static const union dp_ipv6 dp_unspecified_ipv6 = {
-	.bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
-};
-static const union dp_ipv6 dp_multicast_ipv6 = {
-	.bytes = { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 }
-};
-
 uint16_t dp_ipv6_fill_ra(struct rte_ipv6_hdr *ipv6_hdr, struct ra_msg *ra_msg, const uint8_t *src_mac_addr)
 {
 	struct icmp6hdr *icmp6_hdr = &(ra_msg->icmph);
@@ -68,7 +61,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	rte_ether_addr_copy(&req_eth_hdr->src_addr, &req_eth_hdr->dst_addr);
 	rte_ether_addr_copy(&port->own_mac, &req_eth_hdr->src_addr);
 
-	if (dp_ipv6_match(src_ipv6, &dp_unspecified_ipv6))
+	if (dp_ipv6_match(src_ipv6, &dp_empty_ipv6))
 		dp_set_dst_ipv6(req_ipv6_hdr, &dp_multicast_ipv6);
 	else
 		dp_set_dst_ipv6(req_ipv6_hdr, src_ipv6);

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -20,8 +20,12 @@ int ipv6_nd_node_append_vf_tx(uint16_t port_id, const char *tx_node_name)
 	return dp_node_append_vf_tx(DP_NODE_GET_SELF(ipv6_nd), next_tx_index, port_id, tx_node_name);
 }
 
-static const uint8_t dp_unspecified_ipv6[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-static const uint8_t dp_multicast_ipv6[16] = { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 };
+static const union dp_ipv6 dp_unspecified_ipv6 = {
+	.bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+};
+static const union dp_ipv6 dp_multicast_ipv6 = {
+	.bytes = { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 }
+};
 
 uint16_t dp_ipv6_fill_ra(struct rte_ipv6_hdr *ipv6_hdr, struct ra_msg *ra_msg, const uint8_t *src_mac_addr)
 {
@@ -55,37 +59,39 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	struct rte_ipv6_hdr *req_ipv6_hdr = (struct rte_ipv6_hdr *)(req_eth_hdr + 1);
 	struct icmp6hdr *req_icmp6_hdr = (struct icmp6hdr *)(req_ipv6_hdr + 1);
 	uint8_t icmp_type = req_icmp6_hdr->icmp6_type;
-	const uint8_t *rt_ip = dp_get_gw_ip6();
+	const union dp_ipv6 *gw_ip = dp_get_gw_ip6();
 	struct nd_msg *nd_msg;
 	struct ra_msg *req_ra_msg;
 	struct dp_port *port = dp_get_in_port(m);
+	const union dp_ipv6 *src_ipv6 = dp_get_src_ipv6(req_ipv6_hdr);
 
 	rte_ether_addr_copy(&req_eth_hdr->src_addr, &req_eth_hdr->dst_addr);
 	rte_ether_addr_copy(&port->own_mac, &req_eth_hdr->src_addr);
 
-	if (!memcmp(req_ipv6_hdr->src_addr, dp_unspecified_ipv6, sizeof(req_ipv6_hdr->src_addr)))
-		rte_memcpy(req_ipv6_hdr->dst_addr, dp_multicast_ipv6, sizeof(req_ipv6_hdr->dst_addr));
+	if (dp_ipv6_match(src_ipv6, &dp_unspecified_ipv6))
+		dp_set_dst_ipv6(req_ipv6_hdr, &dp_multicast_ipv6);
 	else
-		rte_memcpy(req_ipv6_hdr->dst_addr, req_ipv6_hdr->src_addr, sizeof(req_ipv6_hdr->dst_addr));
+		dp_set_dst_ipv6(req_ipv6_hdr, src_ipv6);
 
-	rte_memcpy(req_ipv6_hdr->src_addr, rt_ip, sizeof(req_ipv6_hdr->src_addr));
+	dp_set_src_ipv6(req_ipv6_hdr, gw_ip);
 
 	if (icmp_type != NDISC_NEIGHBOUR_SOLICITATION && icmp_type != NDISC_ROUTER_SOLICITATION)
 		return IPV6_ND_NEXT_DROP;
 
 	if (icmp_type == NDISC_NEIGHBOUR_SOLICITATION) {
 		nd_msg = (struct nd_msg *)(req_ipv6_hdr + 1);
-		if (memcmp(&nd_msg->target, rt_ip, sizeof(nd_msg->target)))
+		static_assert(sizeof(nd_msg->target) == sizeof(gw_ip->bytes), "Incompatible IPv6 format in ND message structure");
+		if (memcmp(nd_msg->target, gw_ip->bytes, sizeof(nd_msg->target)))
 			return IPV6_ND_NEXT_DROP;
 		rte_ether_addr_copy(&req_eth_hdr->dst_addr, &port->neigh_mac);
-		rte_memcpy(port->iface.cfg.own_ipv6, req_ipv6_hdr->dst_addr, sizeof(port->iface.cfg.own_ipv6));
+		dp_copy_ipv6(&port->iface.cfg.own_ipv6, dp_get_dst_ipv6(req_ipv6_hdr));
 		req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
 		req_icmp6_hdr->icmp6_solicited = 1;
 		req_icmp6_hdr->icmp6_override = 1;
 		// set target lladdr option and MAC
 		nd_msg->opt[0] = ND_OPT_TARGET_LL_ADDR;
 		nd_msg->opt[1] = ND_OPT_LEN_OCTET_1;
-		rte_memcpy(&nd_msg->opt[2], req_eth_hdr->src_addr.addr_bytes, 6);
+		rte_ether_addr_copy(&req_eth_hdr->src_addr, (struct rte_ether_addr *)&nd_msg->opt[2]);
 	} else if (icmp_type == NDISC_ROUTER_SOLICITATION) {
 		req_ra_msg = (struct ra_msg *)(req_ipv6_hdr + 1);
 		m->data_len = dp_ipv6_fill_ra(req_ipv6_hdr, req_ra_msg, port->own_mac.addr_bytes);

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -65,7 +65,7 @@ static __rte_always_inline int dp_process_ipv4_snat(struct rte_mbuf *m, struct d
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-	DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, ntohl(ipv4_hdr->src_addr));
+	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, ntohl(ipv4_hdr->src_addr));
 	if (snat_data->nat_ip != 0)
 		cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 
@@ -127,8 +127,8 @@ static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct 
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT64;
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
-	DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(dest_ip4));
-	DP_SET_IPADDR4(cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, snat64_data.nat_ip);
+	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(dest_ip4));
+	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, snat64_data.nat_ip);
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].proto = df->l4_type;
 
@@ -174,7 +174,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 				return SNAT_NEXT_DROP;
 		}
 
-		if (df->l3_type == RTE_ETHER_TYPE_IPV6 && port->iface.nat_ip && dp_is_ip6_in_nat64_range(df->dst.dst_addr6)
+		if (df->l3_type == RTE_ETHER_TYPE_IPV6 && port->iface.nat_ip && dp_is_ip6_in_nat64_range(df->dst.dst_addr6.bytes)  // TODO migrate NAT64
 		    && df->flow_type == DP_FLOW_SOUTH_NORTH) {
 			if (DP_FAILED(dp_process_ipv6_nat64(m, df, cntrack, port)))
 				return SNAT_NEXT_DROP;

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -174,8 +174,11 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 				return SNAT_NEXT_DROP;
 		}
 
-		if (df->l3_type == RTE_ETHER_TYPE_IPV6 && port->iface.nat_ip && dp_is_ip6_in_nat64_range(df->dst.dst_addr6.bytes)  // TODO migrate NAT64
-		    && df->flow_type == DP_FLOW_SOUTH_NORTH) {
+		if (df->l3_type == RTE_ETHER_TYPE_IPV6
+			&& port->iface.nat_ip
+			&& df->flow_type == DP_FLOW_SOUTH_NORTH
+			&& dp_is_ipv6_nat64(&df->dst.dst_addr6)
+		) {
 			if (DP_FAILED(dp_process_ipv6_nat64(m, df, cntrack, port)))
 				return SNAT_NEXT_DROP;
 

--- a/src/nodes/virtsvc_node.c
+++ b/src/nodes/virtsvc_node.c
@@ -26,7 +26,7 @@ int virtsvc_node_append_tx(uint16_t port_id, const char *tx_node_name)
 }
 
 // runtime constant, precompute
-static const uint8_t *service_ul_ip;
+static const union dp_ipv6 *service_ul_ip;
 
 static int virtsvc_node_init(__rte_unused const struct rte_graph *graph, __rte_unused struct rte_node *node)
 {
@@ -102,8 +102,8 @@ static __rte_always_inline uint16_t virtsvc_request_next(struct rte_node *node,
 	ipv6_hdr->payload_len = htons((uint16_t)(hdr_total_len - sizeof(struct rte_ipv4_hdr)));
 	ipv6_hdr->proto = proto;
 	ipv6_hdr->hop_limits = ttl;
-	rte_memcpy(ipv6_hdr->src_addr, service_ul_ip, sizeof(ipv6_hdr->src_addr));
-	rte_memcpy(ipv6_hdr->dst_addr, virtsvc->service_addr, sizeof(virtsvc->service_addr));
+	dp_set_src_ipv6(ipv6_hdr, service_ul_ip);
+	dp_set_dst_ipv6(ipv6_hdr, &virtsvc->service_addr);
 	m->ol_flags |= RTE_MBUF_F_TX_IPV6;
 	m->tx_offload = 0;
 	m->l2_len = sizeof(struct rte_ether_hdr);

--- a/src/rte_flow/dp_rte_flow_capture.c
+++ b/src/rte_flow/dp_rte_flow_capture.c
@@ -78,8 +78,8 @@ void dp_configure_pkt_capture_action(uint8_t *encaped_mirror_hdr,
 	rte_ether_addr_copy(&outgoing_port->own_mac, &encap_eth_hdr->src_addr);
 	encap_eth_hdr->ether_type = htons(RTE_ETHER_TYPE_IPV6);
 
-	rte_memcpy(new_ipv6_hdr->src_addr, dp_conf_get_underlay_ip(), sizeof(new_ipv6_hdr->src_addr));
-	rte_memcpy(new_ipv6_hdr->dst_addr, capture_hdr_config->capture_node_ipv6_addr, sizeof(new_ipv6_hdr->dst_addr));
+	dp_set_src_ipv6(new_ipv6_hdr, dp_conf_get_underlay_ip());
+	dp_set_dst_ipv6(new_ipv6_hdr, &capture_hdr_config->capture_node_ipv6_addr);
 	new_ipv6_hdr->vtc_flow = htonl(DP_IP6_VTC_FLOW);
 	new_ipv6_hdr->payload_len = 0;
 	new_ipv6_hdr->proto = IPPROTO_UDP;

--- a/src/rte_flow/dp_rte_flow_init.c
+++ b/src/rte_flow/dp_rte_flow_init.c
@@ -45,7 +45,7 @@ int dp_install_isolated_mode_ipip(uint16_t port_id, uint8_t proto_id)
 }
 
 #ifdef ENABLE_VIRTSVC
-int dp_install_isolated_mode_virtsvc(uint16_t port_id, uint8_t proto_id, const uint8_t svc_ipv6[16], rte_be16_t svc_port)
+int dp_install_isolated_mode_virtsvc(uint16_t port_id, uint8_t proto_id, const union dp_ipv6 *svc_ipv6, rte_be16_t svc_port)
 {
 	struct rte_flow_item_eth eth_spec;   // #1
 	struct rte_flow_item_ipv6 ipv6_spec; // #2


### PR DESCRIPTION
Based on #541, all uses of IPv6 are now represented by a custom `union` which provides type-safety. Operations are done via inline wrappers that use optimized memory access.

Since the change affects the whole codebase, I was able to fund some small connected issues that are also included here (as the same lines would have to be changed twice if the PR got separated), but separate issues have been created and marked fixed by the appropriate commit.

Codecheck fails because of C++ and it also is not ready for `TAILQ` in structures.