### PR TITLE
Fix version template to re-generate during build instead of configure phase

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -3,5 +3,13 @@ version_data.set('dpservice_version', meson.project_version())
 version_h = configure_file(
   input: 'dp_version.h.in',
   output: 'dp_version.h',
-  configuration: version_data
+  configuration: version_data,
+)
+# This should be working in itself, but for some reason, dump/ directory gets built *before* this,
+# therefore the above configure phase ensures a valid version.h
+version_h = vcs_tag(
+  command: ['git', 'describe', '--tags'],
+  input: 'dp_version.h.in',
+  output: 'dp_version.h',
+  replace_string: '@dpservice_version@'
 )


### PR DESCRIPTION
Only after merging dpservice-cli and creating a test for proper version matching with dpservice-bin, a flaw got noticed.

Currently dpservice uses Git commit ID as version, but does so only during configure phase. Which is fine for CICD, but when developing, this version almost never gets updated when switching branches.

The client correctly applies the version every build, so now the test sometimes fails.

I changed meson to update VCS tags during build instead.