### PR TITLE
Make ND protocol neighbour advertisement flags RFC conform.

### DIFF
--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -156,7 +156,6 @@ void trigger_nd_unsol_adv(void)
 	icmp6_hdr->icmp6_solicited = 0;
 	icmp6_hdr->icmp6_override = 1;
 	icmp6_hdr->icmp6_router = 1;
-	icmp6_hdr->icmp6_hop_limit = 255;
 
 	DP_ARRAY_FROM_IPV6(ns_msg->target, gw_ip);
 	pkt_size = sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv6_hdr) +

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -81,6 +81,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
 		req_icmp6_hdr->icmp6_solicited = 1;
 		req_icmp6_hdr->icmp6_override = 1;
+		req_icmp6_hdr->icmp6_router = 1;
 		// set target lladdr option and MAC
 		nd_msg->opt[0] = ND_OPT_TARGET_LL_ADDR;
 		nd_msg->opt[1] = ND_OPT_LEN_OCTET_1;


### PR DESCRIPTION
Solicited neighbour advertisement messages need to set router flag

As dpservice acts as a router on its VF ports. Router flag needs to be set to the solicited neighbour discovery messages as well.
https://datatracker.ietf.org/doc/html/rfc4861#section-7.2.4

Unsolicited neighbour advertisement hop limit was accidently filled. Neighbour advertisements do not have this field and filling this field sets some flags accidently in the neighbour advertisement packet.