### PR TITLE
Small LB fixes

### DIFF
--- a/go/dpservice-go/client/client_test.go
+++ b/go/dpservice-go/client/client_test.go
@@ -702,10 +702,9 @@ var _ = Describe("loadbalancer related", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(lbtargets.Items)).To(Equal(0))
 
-			//TODO: currently not working properly, will be fixed in separate PR
-			/*res, err = dpdkClient.DeleteLoadBalancerTarget(ctx, lbtarget.LoadbalancerID, lbtarget.Spec.TargetIP)
+			res, err = dpdkClient.DeleteLoadBalancerTarget(ctx, lbtarget.LoadbalancerID, lbtarget.Spec.TargetIP)
 			Expect(err).To(HaveOccurred())
-			Expect(res.Status.Code).To(Equal(uint32(errors.NOT_FOUND)))*/
+			Expect(res.Status.Code).To(Equal(uint32(errors.NOT_FOUND)))
 
 			_, err = dpdkClient.DeleteLoadBalancer(ctx, lb.ID)
 			Expect(err).ToNot(HaveOccurred())

--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -303,8 +303,5 @@ int dp_del_lb_back_ip(const void *id_key, const union dp_ipv6 *back_ip)
 	if (DP_FAILED(rte_hash_lookup_data(ipv4_lb_tbl, lb_k, (void **)&lb_val)))
 		return DP_GRPC_ERR_NO_BACKIP;
 
-	if (DP_FAILED(dp_delete_maglev_backend(lb_val, back_ip)))
-		return DP_GRPC_ERR_BACKIP_DEL;
-
-	return DP_GRPC_OK;
+	return dp_delete_maglev_backend(lb_val, back_ip);
 }

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -138,12 +138,17 @@ static int dp_process_delete_lbtarget(struct dp_grpc_responder *responder)
 {
 	struct dpgrpc_lb_target *request = &responder->request.del_lbtrgt;
 	union dp_ipv6 ipv6;
+	int ret;
 
 	if (DP_FAILED(dp_ipv6_from_ipaddr(&ipv6, &request->addr)))
 		return DP_GRPC_ERR_BAD_IPVER;
 
+	ret = dp_del_lb_back_ip(request->lb_id, &ipv6);
+	if (DP_FAILED(ret))
+		return ret;
+
 	dp_remove_lbtarget_flows(&ipv6);
-	return dp_del_lb_back_ip(request->lb_id, &ipv6);
+	return DP_GRPC_OK;
 }
 
 static int dp_process_initialize(__rte_unused struct dp_grpc_responder *responder)

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -327,8 +327,7 @@ def test_grpc_lbtarget(prepare_ifaces, grpc_client):
 	grpc_client.addlbtarget(lb_name, target_ul)
 	grpc_client.expect_error(202).addlbtarget(lb_name, target_ul)
 	grpc_client.dellbtarget(lb_name, target_ul)
-	# TODO not failing atm.
-	grpc_client.dellbtarget(lb_name, target_ul)
+	grpc_client.expect_error(201).dellbtarget(lb_name, target_ul)
 	grpc_client.addlbtarget(lb_name, target_ul)
 	grpc_client.dellbtarget(lb_name, target_ul)
 	grpc_client.dellb(lb_name)

--- a/test/test_zzz_grpc.py
+++ b/test/test_zzz_grpc.py
@@ -314,9 +314,7 @@ def test_grpc_lb_errors(prepare_ifaces, grpc_client):
 	grpc_client.expect_failure().createlb(lb_name, vni1, lb_ip, "icmp/22")
 	grpc_client.expect_failure().createlb(lb_name, vni1, lb_ip, "udp/65536")
 	# Try to use duplicate port specification
-	grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80,tcp/80")
-	# TODO not failing atm.
-	grpc_client.dellb(lb_name)
+	grpc_client.expect_failure().createlb(lb_name, vni1, lb_ip, "tcp/80,tcp/80")
 	# Try same port with different protocol both at once
 	grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80,udp/80")
 	grpc_client.dellb(lb_name)


### PR DESCRIPTION
There were two small problems in LB gRPC. Nothing that happened in the production environment as the caller did not cause the situation/require such response. But dpservice should have the protocol robust on its own.

One is for LB target returning an error when it does not exist, the other for LB creation with duplicate ports.