### PR TITLE
Create a script to read current version from git, fixes #566

### DIFF
--- a/cli/dpservice-cli/Makefile
+++ b/cli/dpservice-cli/Makefile
@@ -62,7 +62,7 @@ test: fmt vet ## Run tests.
 
 .PHONY: build
 build: fmt vet ## Build binary.
-	go build -ldflags "-X 'main.version=${shell git describe --tags}'" -o bin/dpservice-cli main.go
+	go build -ldflags "-X 'main.version=${shell ../../hack/get_version.sh}'" -o bin/dpservice-cli main.go
 
 .PHONY: install
 install:

--- a/cli/dpservice-exporter/Makefile
+++ b/cli/dpservice-exporter/Makefile
@@ -88,7 +88,7 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 
 .PHONY: build
 build: fmt vet ## Build binary.
-	go build -ldflags "-X 'main.version=${shell git describe --tags}'" -o bin/dpservice-exporter main.go
+	go build -ldflags "-X 'main.version=${shell ../../hack/get_version.sh}'" -o bin/dpservice-exporter main.go
 
 .PHONY: install
 install:

--- a/go/dpservice-go/hack/generate-proto.sh
+++ b/go/dpservice-go/hack/generate-proto.sh
@@ -11,7 +11,7 @@ BASEDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 DPSERVICE_DIR="../.."
 cd "$DPSERVICE_DIR"
-git describe --tags > ./go/dpservice-go/proto/generated_from.txt
+./hack/get_version.sh > ./go/dpservice-go/proto/generated_from.txt
 cd ./go/dpservice-go/
 
 echo "Generating protobuf"

--- a/hack/get_version.sh
+++ b/hack/get_version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# For non-tagged commits, this is a simple "vX.X.X-XX-gXXXXXXX"
+# For dpservice-bin tagged commits, this is "vX.X.X"
+# For dpservice-go tagged commits, this is "go/dpservice-go/vX.X.X-XX-gXXXXXXX"
+GITVER=$(git describe --tags)
+
+# The solution is to simply print the last item of an array created by splitting the Git version
+ARRAY=(${GITVER//\// })
+echo ${ARRAY[*]: -1}

--- a/include/meson.build
+++ b/include/meson.build
@@ -8,7 +8,7 @@ version_h = configure_file(
 # This should be working in itself, but for some reason, dump/ directory gets built *before* this,
 # therefore the above configure phase ensures a valid version.h
 version_h = vcs_tag(
-  command: ['git', 'describe', '--tags'],
+  command: './hack/get_version.sh',
   input: 'dp_version.h.in',
   output: 'dp_version.h',
   replace_string: '@dpservice_version@'

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('dp_service', 'c', 'cpp',
-  version: run_command('git', 'describe', '--tags').stdout().strip(),
+  version: run_command('./hack/get_version.sh').stdout().strip(),
   license: 'MIT',
   default_options: ['warning_level=2', 'werror=true'])
 


### PR DESCRIPTION
Instead of manually calling `git describe --tags` in multiple places, there is a script that does it, so any changes are now centralized.

The script only takes the version suffix from git, i.e. everything after the last `/`