### PR TITLE
Add hash table fullness telemetry

### DIFF
--- a/cli/dpservice-exporter/main.go
+++ b/cli/dpservice-exporter/main.go
@@ -63,6 +63,7 @@ func main() {
 	r.MustRegister(metrics.InterfaceStat)
 	r.MustRegister(metrics.CallCount)
 	r.MustRegister(metrics.HeapInfo)
+	r.MustRegister(metrics.HashTableSaturation)
 
 	http.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
 

--- a/cli/dpservice-exporter/metrics/metrics.go
+++ b/cli/dpservice-exporter/metrics/metrics.go
@@ -87,4 +87,12 @@ func Update(conn net.Conn, hostname string, log *logrus.Logger) {
 	for graphNodeName, callCount := range dpserviceCallCount.GraphCallCnt.Node_0_to_255 {
 		CallCount.With(prometheus.Labels{"node_name": hostname, "graph_node": graphNodeName}).Set(callCount)
 	}
+
+	var dpServiceHashTableSaturation DpServiceHashTableSaturation
+	queryTelemetry(conn, log, "/dp_service/table/saturation", &dpServiceHashTableSaturation)
+
+	for table, saturation := range dpServiceHashTableSaturation.Value {
+		HashTableSaturation.With(prometheus.Labels{"table_name": table, "stat_name": "capacity"}).Set(saturation.Capacity)
+		HashTableSaturation.With(prometheus.Labels{"table_name": table, "stat_name": "entries"}).Set(saturation.Entries)
+	}
 }

--- a/cli/dpservice-exporter/metrics/types.go
+++ b/cli/dpservice-exporter/metrics/types.go
@@ -29,6 +29,14 @@ var (
 		},
 		[]string{"node_name", "info"},
 	)
+
+	HashTableSaturation = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "hash_table_saturation",
+			Help: "Dp-Service hash table saturation",
+		},
+		[]string{"table_name", "stat_name"},
+	)
 )
 
 type EthdevList struct {
@@ -65,4 +73,13 @@ type DpServiceGraphCallCount struct {
 
 type DpServiceHeapInfo struct {
 	Value map[string]any `json:"/eal/heap_info"`
+}
+
+type DpServiceHashTableSaturation struct {
+	Value map[string]HashTable `json:"/dp_service/table/saturation"`
+}
+
+type HashTable struct {
+	Capacity float64 `json:"capacity"`
+	Entries  float64 `json:"entries"`
 }

--- a/include/dp_telemetry.h
+++ b/include/dp_telemetry.h
@@ -13,6 +13,8 @@ extern "C" {
 int dp_telemetry_init(void);
 void dp_telemetry_free(void);
 
+int dp_telemetry_register_htable(const struct rte_hash *htable, const char name[RTE_HASH_NAMESIZE], int capacity);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -44,7 +44,7 @@ int dp_get_dev_info(uint16_t port_id, struct rte_eth_dev_info *dev_info, char if
 int dp_get_num_of_vfs(void);
 
 
-struct rte_hash *dp_create_jhash_table(int entries, size_t key_len, const char *name, int socket_id);
+struct rte_hash *dp_create_jhash_table(int capacity, size_t key_len, const char *name, int socket_id);
 
 void dp_free_jhash_table(struct rte_hash *table);
 

--- a/src/dp_iface.c
+++ b/src/dp_iface.c
@@ -9,7 +9,7 @@ static struct rte_hash *iface_id_table = NULL;
 int dp_ifaces_init(int socket_id)
 {
 	iface_id_table = dp_create_jhash_table(DP_MAX_PORTS, DP_IFACE_ID_MAX_LEN,
-										   "iface_id_table", socket_id);
+										   "interface_table", socket_id);
 	if (!iface_id_table)
 		return DP_ERROR;
 

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -40,23 +40,23 @@ static uint64_t dp_nat_full_log_delay;
 int dp_nat_init(int socket_id)
 {
 	ipv4_snat_tbl = dp_create_jhash_table(DP_NAT_TABLE_MAX, sizeof(struct nat_key),
-										  "ipv4_snat_table", socket_id);
+										  "snat_table", socket_id);
 	if (!ipv4_snat_tbl)
 		return DP_ERROR;
 
 	ipv4_dnat_tbl = dp_create_jhash_table(DP_NAT_TABLE_MAX, sizeof(struct nat_key),
-										  "ipv4_dnat_table", socket_id);
+										  "dnat_table", socket_id);
 	if (!ipv4_dnat_tbl)
 		return DP_ERROR;
 
 	ipv4_netnat_portmap_tbl = dp_create_jhash_table(DP_FLOW_TABLE_MAX, sizeof(struct netnat_portmap_key),
-												  "ipv4_netnat_portmap_table", socket_id);
+													"nat_portmap_table", socket_id);
 
 	if (!ipv4_netnat_portmap_tbl)
 		return DP_ERROR;
 
 	ipv4_netnat_portoverload_tbl = dp_create_jhash_table(DP_FLOW_TABLE_MAX, sizeof(struct netnat_portoverload_tbl_key),
-												  "ipv4_netnat_portoverload_tbl", socket_id);
+														 "nat_portoverload_table", socket_id);
 
 	if (!ipv4_netnat_portoverload_tbl)
 		return DP_ERROR;

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -19,12 +19,12 @@ static struct rte_hash *vnf_value_tbl = NULL;
 int dp_vnf_init(int socket_id)
 {
 	vnf_handle_tbl = dp_create_jhash_table(DP_VNF_MAX_TABLE_SIZE, sizeof(union dp_ipv6),
-										   "vnf_handle_table", socket_id);
+										   "vnf_table", socket_id);
 	if (!vnf_handle_tbl)
 		return DP_ERROR;
 
 	vnf_value_tbl = dp_create_jhash_table(DP_VNF_MAX_TABLE_SIZE, sizeof(struct dp_vnf),
-										  "vnf_value_table", socket_id);
+										  "reverse_vnf_table", socket_id);
 	if (!vnf_value_tbl) {
 		dp_free_jhash_table(vnf_handle_tbl);
 		return DP_ERROR;

--- a/src/dp_vni.c
+++ b/src/dp_vni.c
@@ -11,7 +11,7 @@ struct rte_hash *vni_handle_tbl = NULL;
 int dp_vni_init(int socket_id)
 {
 	vni_handle_tbl = dp_create_jhash_table(DP_VNI_MAX_TABLE_SIZE, sizeof(struct dp_vni_key),
-										     "vni_handle_table", socket_id);
+										   "vni_table", socket_id);
 	if (!vni_handle_tbl)
 		return DP_ERROR;
 


### PR DESCRIPTION
Adds a general telemetry for all hash tables to monitor the saturation/fullness.

Due to the names of tables being visible in Prometheus output, most have been renamed based on a suggestion from Guvenc. In a few case the variables themselves got renamed, mostly due to the fact that they are no longer `ipv4_` only variables, since there is now an IPv6 overlay.

This PR also includes changes to the exporter and tests.