### PR TITLE
Proper fix for version.h generation

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,14 +1,5 @@
-version_data = configuration_data()
-version_data.set('dpservice_version', meson.project_version())
-version_h = configure_file(
-  input: 'dp_version.h.in',
-  output: 'dp_version.h',
-  configuration: version_data,
-)
-# This should be working in itself, but for some reason, dump/ directory gets built *before* this,
-# therefore the above configure phase ensures a valid version.h
 version_h = vcs_tag(
-  command: './hack/get_version.sh',
+  command: '../hack/get_version.sh',
   input: 'dp_version.h.in',
   output: 'dp_version.h',
   replace_string: '@dpservice_version@'

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,7 +72,7 @@ if get_option('enable_virtual_services')
 endif
 
 exe = executable('dpservice-bin',
-  sources: [ dp_sources, grpc_generated ],
+  sources: [ dp_sources, grpc_generated, version_h ],
   include_directories: [ includes ],
   dependencies: [ dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep, libuuid_dep, pcap_dep ]
 )

--- a/tools/dump/meson.build
+++ b/tools/dump/meson.build
@@ -5,6 +5,7 @@ dpservice_dump_sources = [
   '../../src/monitoring/dp_pcap.c',
 ]
 
-executable('dpservice-dump', dpservice_dump_sources,
+executable('dpservice-dump',
+  sources: [ dpservice_dump_sources, version_h ],
   include_directories: [includes],
   dependencies: [dpdk_dep, pcap_dep] )


### PR DESCRIPTION
There was still one issue with `dp_version.h` generation. When changing something not related to `dpservice-bin` and creating a new commit, the commit-id changes, `dp_version.h` is regenerated, but `dpservice-bin` does not get rebuilt.

This causes a problem in tests.

By fixing it (adding `version.h` as a source dependency for the executable, as per meson docs), this also fixes the strange behavior previously mentioned and solved by pre-generating the version header file in configuration step. This is now not needed.

There was also a wrong path to the new version getter script, but for some reason it still worked partially (?).