### PR TITLE
Fix main build workflow

### DIFF
--- a/hack/get_version.sh
+++ b/hack/get_version.sh
@@ -3,7 +3,7 @@
 # For non-tagged commits, this is a simple "vX.X.X-XX-gXXXXXXX"
 # For dpservice-bin tagged commits, this is "vX.X.X"
 # For dpservice-go tagged commits, this is "go/dpservice-go/vX.X.X-XX-gXXXXXXX"
-GITVER=$(git describe --tags)
+GITVER=$(git describe --tags --always)
 
 # The solution is to simply print the last item of an array created by splitting the Git version
 ARRAY=(${GITVER//\// })

--- a/src/dp_telemetry.c
+++ b/src/dp_telemetry.c
@@ -5,6 +5,7 @@
 
 #include <rte_telemetry.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "dp_error.h"


### PR DESCRIPTION
There was a missing `#include <stdlib.h>` for ARM  that broke the build.

There was also a "fatal error" that was actually not treated as an error, but indicated an empty version string when building main with no tags n the current commit (This is caused by the fact that main build uses `git clone --depth 1`).

So now version string gets always populated, even if that means it does not contain any version, but at least it is a commit-id instead of an empty string.

This is not just a cosmetic change, because for `dpservice-cli` this actually caused `dpservice-cli -v` to not work at all (the switch never gets compiled-in in that case)