### PR TITLE
Update docs and fix links after merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dataplane Service in short form dp-service is a L3 virtual router with basic L2 
 - [rte_flow](https://doc.dpdk.org/guides/prog_guide/rte_flow.html) offloading between the Virtual Machines(VMs) on a single hypervisor and ip in ipv6 decap/encap offloading between hypervisors.
 - GRPC support to add virtual network interfaces and routes. There is a C++ based GRPC
   test client (CLI) which can connect to the GRPC server. See the examples under [docs](/docs).
-- There is also a golang based [GRPC client](https://github.com/ironcore-dev/dpservice/cli/dpservice-cli) which is easier to used.
+- There is also a golang based [GRPC client](https://github.com/ironcore-dev/dpservice/tree/main/cli/dpservice-cli) which is easier to used.
 - A kubernetes controller abstraction on top of the provided GRPC interface is availiable as well. It is called [metalnet](https://github.com/ironcore-dev/metalnet).
 - DHCPv4, DHCPv6, Neighbour Discovery, ARP protocols supported (Sub-set implementations.).
 - IPv4 and limited IPv6 overlay support.
@@ -32,7 +32,7 @@ For more details please refer to documentation folder [docs](/docs)
 ## Contributing
 
 We`d love to get a feedback from you.
-Please report bugs, suggestions or post question by opening a [Github issue](https://github.com/ironcore-dev/dpservice/pulls)
+Please report bugs, suggestions or post question by opening a [Github issue](https://github.com/ironcore-dev/dpservice/issues)
 
 ## License
 

--- a/cli/dpservice-cli/docs/commands/README.md
+++ b/cli/dpservice-cli/docs/commands/README.md
@@ -1,6 +1,6 @@
 # dpservice-cli commands:
 
-You can browse help for all commands starting in the main command [here](/docs/commands/dpservice-cli.md)](/docs/commands/dpservice-cli.md)
+You can browse help for all commands starting in the main command [here](./dpservice-cli.md)
 
 # Available commands:
 

--- a/cli/dpservice-cli/docs/development/add_new_subcommand.md
+++ b/cli/dpservice-cli/docs/development/add_new_subcommand.md
@@ -16,18 +16,18 @@ This will generate a whole series of files, one for each command in the tree, in
 
 # Steps to add a new subcommand
 Basic steps when implementing new type (similar to Interface, Route, LoadBalancer, ...):
-- Create new type in [/dpdk/api/types.go](/dpdk/api/types.go):
+- Create new type in [/go/dpservice-go/api/types.go](/go/dpservice-go/api/types.go):
     - create structs and methods
 	- at the bottom add new \<type\>Kind variable
-- Create new [create|get|list|delete]\<type\>.go file in /cmd/ folder and implement the logic
+- Create new [create|get|list|delete]\<type\>.go file in [cmd](../../cmd/) folder and implement the logic
 - Add new command function to subcommands of matching parent command in /cmd/[create|get|list|delete].go
-- If needed add aliases for \<type\> at the bottom of [/cmd/common.go](/cmd/common.go)
-- Add new function to [/dpdk/api/client.go](/dpdk/api/client.go):
+- If needed add aliases for \<type\> at the bottom of [/cmd/common.go](../../cmd/common.go)
+- Add new function to [/go/dpservice-go/client/client.go](/go/dpservice-go/client/client.go):
     - add function to Client interface
     - implement the function
-- Add new \<type\> to DefaultScheme in [/dpdk/api/register.go](/dpdk/api/register.go)
-- Add new \<type\>Key structs and methods in [/dpdk/client/dynamic/dynamic.go](/dpdk/client/dynamic/dynamic.go) and add new \<type\> to switch in Create and Delete methods
-- If needed create new conversion function(s) between dpdk struct and local struct in [/dpdk/api/conversion.go](/dpdk/api/conversion.go)
-- Add new function to show \<type\> as table in [/renderer/renderer.go](/renderer/renderer.go)
+- Add new \<type\> to DefaultScheme in [/dpdk/runtime/register.go](../../dpdk/runtime/register.go)
+- Add new \<type\>Key structs and methods in [/dpdk/client/dynamic/dynamic.go](../../dpdk/client/dynamic/dynamic.go) and add new \<type\> to switch in Create and Delete methods
+- If needed create new conversion function(s) between dpdk struct and local struct in [/go/dpservice-go/api/conversion.go](/go/dpservice-go/api/conversion.go)
+- Add new function to show \<type\> as table in [/renderer/renderer.go](../../renderer/renderer.go)
     - add new \<type\> to ConvertToTable method
     - implement function to show new \<type\>

--- a/cli/dpservice-cli/docs/development/install.md
+++ b/cli/dpservice-cli/docs/development/install.md
@@ -31,7 +31,7 @@ dpservice-cli completion -h
 ```
 
 # Dependency
-This client uses golang bindings from module [/go/dpservice-go](https://github.com/ironcore-dev/dpservice/go/dpservice-go).
+This client uses golang bindings from module [/go/dpservice-go](https://github.com/ironcore-dev/dpservice/tree/main/go/dpservice-go).
 
 Definition go files in [proto](https://github.com/ironcore-dev/dpservice/tree/main/go/dpservice-go/proto) folder are auto-generated from [dpdk.proto](https://github.com/ironcore-dev/dpservice/blob/main/proto/dpdk.proto) file in [dpservice](https://github.com/ironcore-dev/dpservice/) repo.
 

--- a/cli/dpservice-cli/docs/development/usage.md
+++ b/cli/dpservice-cli/docs/development/usage.md
@@ -75,4 +75,4 @@ One file can contain multiple objects of any kind, example file:
 ```
 
 **Note**
-All available commands can be found [here](/docs/commands/README.md).
+All available commands can be found [here](../commands/README.md).

--- a/cli/dpservice-exporter/README.md
+++ b/cli/dpservice-exporter/README.md
@@ -13,7 +13,7 @@ Also specified port (by default 8080) on which we want to run `dpservice-exporte
 
 ## Support, Feedback, Contributing
 
-This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/ironcore/dpservice/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information.
+This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/ironcore-dev/dpservice/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information.
 
 ## License
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -8,4 +8,4 @@ For development, direct use of dp-service is covered by the [development section
 ## Command-line tools
 All tool binaries are designed to be prefixed with `dpservice-` to enable the operator to simply type `dps<TAB>` for list of possible tools.
 
-The provided Docker image contains `dpservice-bin` as the main process (already started by being the entrypoint), `dpservice-cli` to gRPC communication with the main process, and `dpservice-dump` to provide a way to see the actual traffic handled by dp-service.
+The provided Docker image contains `dpservice-bin` as the main process (already started by being the entrypoint), `dpservice-cli` to gRPC communication with the main process, and `dpservice-dump` to provide a way to see the actual traffic handled by dp-service. Also included is `dpservice-exporter`, a Prometheus exporter that can export various statistics about dpservice (interface stats, NAT port usage, hash table fullness, ...)

--- a/docs/deployment/capture_offloaded_rx_pkts.md
+++ b/docs/deployment/capture_offloaded_rx_pkts.md
@@ -59,4 +59,4 @@ Offloaded packets are captured by using special rte flow rules, especially the o
 | Outer Ether header | Outer IPv6 header | UDP header | Captured Ether frame |
 ```
 
-[Figure1](docs/sys_design/pkt_capture_flow_rules-VF.drawio.png) and [Figure2](docs/sys_design/pkt_capture_flow_rules-PF.drawio.png) illustrate the organization of flow rules for VF and PF. The differences between handling VF and PF are empirical.
+[Figure1](../sys_design/pkt_capture_flow_rules-VF.drawio.png) and [Figure2](../sys_design/pkt_capture_flow_rules-PF.drawio.png) illustrate the organization of flow rules for VF and PF. The differences between handling VF and PF are empirical.

--- a/docs/deployment/telemetry.md
+++ b/docs/deployment/telemetry.md
@@ -13,3 +13,6 @@ To send telemetry requests, a node name with a parameter (must be zero if not pr
 ```
 
 For the complete list of commands (telemetry nodes), send `/,0`.
+
+## Prometheus exporter
+`dpservice-exporter` is used for monitoring and exposing `dpservice-bin` statistics from DPDK telemetry. It is included in `dpservice` repository and more details can be found [here](https://github.com/ironcore-dev/dpservice/blob/main/cli/dpservice-exporter).

--- a/docs/development/design.md
+++ b/docs/development/design.md
@@ -1,4 +1,4 @@
 # Design
 The Dataplane Service is built upon the DPDK library. At the heart of the functionality, there is the  [Graph Architecture](http://doc.dpdk.org/guides/prog_guide/graph_lib.html) for data processing. The dataplane based on the graph architecture looks like the following:
 
-![DP-Service dataplane](../sys_design/dp_service_dataplane.drawio.png)
+![DP-Service dataplane](../sys_design/dpservice_dataplane.drawio.png)

--- a/docs/development/design.md
+++ b/docs/development/design.md
@@ -1,4 +1,4 @@
 # Design
 The Dataplane Service is built upon the DPDK library. At the heart of the functionality, there is the  [Graph Architecture](http://doc.dpdk.org/guides/prog_guide/graph_lib.html) for data processing. The dataplane based on the graph architecture looks like the following:
 
-![DP-Service dataplane](dp_service_dataplane.drawio.png)
+![DP-Service dataplane](../sys_design/dp_service_dataplane.drawio.png)

--- a/docs/testing/grpc_client.md
+++ b/docs/testing/grpc_client.md
@@ -2,7 +2,7 @@
 
 To communicate with the `dpservice-bin` process, you need to use GRPC (running on localhost at default port 1337).
 
-There is a golang command-line client [dpservice-cli](https://github.com/ironcore-dev/dpservice/cli/dpservice-cli/), with full [command-line documentation](https://github.com/ironcore-dev/dpservice/cli/dpservice-cli/tree/osc-main/docs/commands#dpservice-cli-commands).
+There is a golang command-line client [dpservice-cli](https://github.com/ironcore-dev/dpservice/tree/main/cli/dpservice-cli), with full [command-line documentation](https://github.com/ironcore-dev/dpservice/tree/main/cli/dpservice-cli/docs/commands).
 
 
 ## Sample commands for testing
@@ -58,6 +58,12 @@ $ dpservice-cli list lbtargets --lb-id=my_lb
  IpVersion  Address
       IPv6  fc00:1::30:0:7
       IPv6  fc00:1::30:0:8
+```
+List all loadbalancers:
+```bash
+$ dpservice-cli list lb
+ ID  VNI  LbVipIP      Lbports           UnderlayRoute
+ 4   100  10.20.30.40  [TCP/443 UDP/53]  fc00:1::f1:0:95
 ```
 Get info on the loadbalancer setting:
 ```bash


### PR DESCRIPTION
Update docs and fix links after merger of repos.
MD files in dpservice and other subdirectories were checked and fixed.
