### PR TITLE
Fix conntrack reference count causing double free

### DIFF
--- a/cli/dp_grpc_client/meson.build
+++ b/cli/dp_grpc_client/meson.build
@@ -1,4 +1,4 @@
-grpc_client_sources = ['dp_grpc_client.cpp']
+grpc_client_sources = ['dp_grpc_client.cpp', version_h]
 
 executable('dp_grpc_client', grpc_client_sources, grpc_generated,
   dependencies: [proto_dep, grpc_dep, grpccpp_dep] )

--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -137,7 +137,7 @@ bool dp_are_flows_identical(const struct flow_key *key1, const struct flow_key *
 
 int dp_get_flow(const struct flow_key *key, struct flow_value **p_flow_val);
 int dp_add_flow(const struct flow_key *key, struct flow_value *flow_val);
-void dp_delete_flow(const struct flow_key *key);
+void dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val);
 int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(const struct flow_key *key /* in */, struct flow_key *inv_key /* out */);
 int dp_flow_init(int socket_id);

--- a/include/dp_refcount.h
+++ b/include/dp_refcount.h
@@ -14,28 +14,33 @@ extern "C" {
 struct dp_ref {
 	rte_atomic32_t refcount;
 	void (*release)(struct dp_ref *dpref);
+	bool valid;
 };
 
 static inline void dp_ref_init(struct dp_ref *ref, void (*release)(struct dp_ref *dpref))
 {
 	rte_atomic32_set(&ref->refcount, 1);
 	ref->release = release;
+	ref->valid = true;
 }
 
 static inline void dp_ref_inc(struct dp_ref *ref)
 {
+	RTE_VERIFY(ref->valid);
 	RTE_VERIFY(rte_atomic32_read(&ref->refcount));
 	rte_atomic32_add(&ref->refcount, 1);
 }
 
 static inline void dp_ref_dec(struct dp_ref *ref)
 {
+	RTE_VERIFY(ref->valid);
 	if (rte_atomic32_dec_and_test(&ref->refcount))
 		ref->release(ref);
 }
 
 static inline bool dp_ref_dec_and_chk_freed(struct dp_ref *ref)
 {
+	RTE_VERIFY(ref->valid);
 	if (rte_atomic32_dec_and_test(&ref->refcount)) {
 		ref->release(ref);
 		return true;

--- a/include/dp_refcount.h
+++ b/include/dp_refcount.h
@@ -14,33 +14,43 @@ extern "C" {
 struct dp_ref {
 	rte_atomic32_t refcount;
 	void (*release)(struct dp_ref *dpref);
+#ifdef ENABLE_PYTEST
 	bool valid;
+#endif
 };
 
 static inline void dp_ref_init(struct dp_ref *ref, void (*release)(struct dp_ref *dpref))
 {
 	rte_atomic32_set(&ref->refcount, 1);
 	ref->release = release;
+#ifdef ENABLE_PYTEST
 	ref->valid = true;
+#endif
 }
 
 static inline void dp_ref_inc(struct dp_ref *ref)
 {
+#ifdef ENABLE_PYTEST
 	RTE_VERIFY(ref->valid);
+#endif
 	RTE_VERIFY(rte_atomic32_read(&ref->refcount));
 	rte_atomic32_add(&ref->refcount, 1);
 }
 
 static inline void dp_ref_dec(struct dp_ref *ref)
 {
+#ifdef ENABLE_PYTEST
 	RTE_VERIFY(ref->valid);
+#endif
 	if (rte_atomic32_dec_and_test(&ref->refcount))
 		ref->release(ref);
 }
 
 static inline bool dp_ref_dec_and_chk_freed(struct dp_ref *ref)
 {
+#ifdef ENABLE_PYTEST
 	RTE_VERIFY(ref->valid);
+#endif
 	if (rte_atomic32_dec_and_test(&ref->refcount)) {
 		ref->release(ref);
 		return true;

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -192,11 +192,12 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	rte_memcpy(&flow_val->flow_key[DP_FLOW_DIR_REPLY], &inverted_key, sizeof(inverted_key));
 	if (DP_FAILED(dp_add_flow(&inverted_key, flow_val)))
 		goto error_add_inv;
+	dp_ref_inc(&flow_val->ref_count);
 
 	return flow_val;
 
 error_add_inv:
-	dp_delete_flow(key);
+	dp_delete_flow(key, flow_val);
 error_add:
 	rte_free(flow_val);
 error_alloc:

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -58,7 +58,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 					cntrack->nf_info.l4_type = df->l4_type;
 					dp_copy_ipv6(&cntrack->nf_info.underlay_dst, underlay_dst);
 
-					dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]); // no reverse traffic for relaying pkts
+					dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack); // no reverse traffic for relaying pkts
 					return DNAT_NEXT_PACKET_RELAY;
 				}
 
@@ -79,10 +79,11 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_flags |= DP_FLOW_FLAG_DST_NAT;
-			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
 			dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(ipv4_hdr->dst_addr));
 			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 				return DNAT_NEXT_DROP;
+			dp_ref_inc(&cntrack->ref_count);
 		}
 		return DNAT_NEXT_IPV4_LOOKUP;
 	}

--- a/src/nodes/lb_node.c
+++ b/src/nodes/lb_node.c
@@ -79,7 +79,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 		if (df->nat_type != DP_LB_RECIRC) {
 			cntrack->nf_info.nat_type = DP_FLOW_LB_TYPE_FORWARD;
-			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]); // no reverse traffic for relaying pkts
+			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack); // no reverse traffic for relaying pkts
 		} else
 			cntrack->nf_info.nat_type = DP_FLOW_LB_TYPE_RECIRC;
 

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -64,13 +64,14 @@ static __rte_always_inline int dp_process_ipv4_snat(struct rte_mbuf *m, struct d
 
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
-	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
 	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, ntohl(ipv4_hdr->src_addr));
 	if (snat_data->nat_ip != 0)
 		cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
 
 	if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 		return DP_ERROR;
+	dp_ref_inc(&cntrack->ref_count);
 
 	return DP_OK;
 }
@@ -126,7 +127,7 @@ static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct 
 
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT64;
-	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY]);
+	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
 	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(dest_ip4));
 	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, snat64_data.nat_ip);
 	cntrack->flow_key[DP_FLOW_DIR_REPLY].port_dst = df->nat_port;
@@ -134,6 +135,7 @@ static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct 
 
 	if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))
 		return DP_ERROR;
+	dp_ref_inc(&cntrack->ref_count);
 
 	return DP_OK;
 }


### PR DESCRIPTION
In conntrack hashtable each conntrack entry has two keys pointing to it. (Flow 5-Tuple and Inverted Flow 5-Tuple)
Therefore a better approach to delete the conntrack entry is to reference count for each pointing hashtable key and 
delete the conntrack entry only when there arent any keys pointing to it.

Current approach tried to delete the both keys at once when the conntrack entry was supposed to be deleted. This caused double free under some circumstances.

Fixes #583 
Probably related to #513 