### PR TITLE
Do not run/fail gRPC GetInit test when attaching to a running service

### DIFF
--- a/test/local/test_zzz_grpc.py
+++ b/test/local/test_zzz_grpc.py
@@ -9,7 +9,9 @@ def test_grpc_init(prepare_ifaces, grpc_client):
 	# Already initialized
 	grpc_client.expect_failure().init()
 
-def test_grpc_getinit(prepare_ifaces, grpc_client):
+def test_grpc_getinit(prepare_ifaces, grpc_client, request):
+	if request.config.getoption("--attach"):
+		pytest.skip("gRPC GetInit not available when attaching to an already running service")
 	spec = grpc_client.getinit()
 	assert spec['uuid'] == grpc_client.uuid, \
 		f"UUID mismatch: {spec['uuid']} (get init) vs. {grpc_client.uuid} (init)"


### PR DESCRIPTION
As noticed by those debugging the service over the last few weeks, pytest `test_grpc_getinit` fails when attaching to a running service. That's because the test actually checks the UUID of the service against the one obtained from running it. But when attaching to a running service, pytest was not the one to run it, thus has no UUID to compare to.

I made pytest simply skip this test when `--attach` is used.