### PR TITLE
Rework hw pytest

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -31,6 +31,9 @@ When running `pytest` directly in the `test/` directory, only a specific set of 
 
 If one should want to instead run your own `dpservice-bin` instance (e.g. for running under a debugger), the `--attach` argument connects to an already running service instead of starting its own (which in turn can be started via a helper `dp_service.py` script). This comes with the caveat of ensuring the right arguments are passed to the service at startup.
 
+#### Pytest on Mellanox
+By default, `pytest` runs using virtual intefaces (TAPs). By providing `--hw` command-line option, it can instead use real NIC based on the contents of `/tmp/dp_service.conf`. For more information [see Mellanox testing guide](mellanox.md#two-machine-setup).
+
 ## Docker
 There is a tester image provided by this repo, simply build it using this repo's `Dockerfile` and use `--target tester`. For fully working images a GitHub PAT is needed: `docker build --secret=id=github_token,src=<path/to/github_token> --target tester .`
 

--- a/docs/testing/mellanox.md
+++ b/docs/testing/mellanox.md
@@ -27,7 +27,7 @@ If you set two VMs like this, they should be able to connect to each other (ping
 ### Pytest suite
 As `scapy` cannot directly communicate with VFs, running VMs with two anonymous bridged interfaces are needed. One interface is connected to Mellanox VF using VFIO and the other is a simple TAP device created by KVM. Then dp-service communicates using the VF and test suite uses the TAP device, e.g.
 ```
--net none -device vfio-pci,host=03:00.02 -device e1000,netdev=tap0 -netdev tap,id=tap0,script=no,downscript=no
+qemu-system-x86_64 -enable-kvm -drive media=disk,if=virtio,index=0,file=./kvm/onmetal_tap.qcow2 -m 2G -cpu host -smp 2 -nographic -net none -device vfio-pci,host=03:00.2 -device e1000,netdev=tap2 -netdev tap,id=tap2,script=no,downscript=no
 ```
 
 Tests have been done using basic Debian 11 installation, but any fresh distro should work, just configure interface like this:

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -613,13 +613,8 @@ static int dp_init_port(struct dp_port *port)
 	}
 
 	if (dp_conf_is_offload_enabled()) {
-#ifdef ENABLE_PYTEST
-		if (port->peer_pf_port_id != dp_get_pf1()->port_id)
-#endif
-		{
 		if (DP_FAILED(dp_port_bind_port_hairpins(port)))
 			return DP_ERROR;
-		}
 
 		if (!port->is_pf)
 			if (DP_FAILED(dp_install_vf_init_rte_rules(port)))

--- a/src/dp_service.c
+++ b/src/dp_service.c
@@ -173,17 +173,8 @@ static int init_interfaces(void)
 	if (DP_FAILED(dp_start_port(dp_get_port_by_pf_index(0))))
 		return DP_ERROR;
 
-	// PF1 is always started (can receive from outside) even when not used for Tx
-	// but test suite can use it for monitoring in some setups, so do not bind it then
-#ifdef ENABLE_PYTEST
-#ifndef ENABLE_PF1_PROXY
-	if (dp_conf_is_wcmp_enabled())
-#endif
-#endif
-	{
 	if (DP_FAILED(dp_start_port(dp_get_port_by_pf_index(1))))
 		return DP_ERROR;
-	}
 
 #ifdef ENABLE_PF1_PROXY
 	if (DP_FAILED(dp_start_pf_proxy_tap_port()))

--- a/test/local/dp_service.py
+++ b/test/local/dp_service.py
@@ -24,6 +24,7 @@ class DpService:
 		self.hardware = hardware
 
 		if self.hardware:
+			raise ValueError("Hardware tests are currently not supported")
 			if self.port_redundancy:
 				raise ValueError("Port redundancy is not supported when testing on actual hardware")
 			self.reconfigure_tests(DpService.DP_SERVICE_CONF)

--- a/test/local/dp_service.py
+++ b/test/local/dp_service.py
@@ -24,12 +24,8 @@ class DpService:
 		self.hardware = hardware
 
 		if self.hardware:
-			# TODO test without pf1-tap
-			# if self.port_redundancy:
-				# raise ValueError("Port redundancy is not supported when testing on actual hardware")
 			self.reconfigure_tests(DpService.DP_SERVICE_CONF)
 		else:
-			# TODO needs testing
 			if offloading:
 				raise ValueError("Offloading is only possible when testing on actual hardware")
 

--- a/test/local/reflector.py
+++ b/test/local/reflector.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+import multiprocessing
+import sys
+import time
+from datetime import datetime
+from scapy.all import *
+
+
+def is_ipip_pkt(pkt):
+	return pkt[IPv6].nh == 4 or pkt[IPv6].nh == 41
+
+def is_virtsvc_pkt(pkt):
+	return pkt[IPv6].src in opts.virtsvc or pkt[IPv6].dst in opts.virtsvc
+
+# Filter for underlay packets not sent by this script (marked by the Traffic Class field)
+def is_ul_pkt(pkt):
+	return IPv6 in pkt and pkt[IPv6].tc == 0 and (is_ipip_pkt(pkt) or is_virtsvc_pkt(pkt))
+
+# Sends packets back over the interface
+def sender_loop(q):
+	try:
+		while True:
+			iface, pkt = q.get()
+			# Give receiver time to enter sniff()
+			time.sleep(0.1)
+			sendp(pkt, iface=iface, verbose=opts.verbose > 1)
+	except KeyboardInterrupt:
+		return
+
+# Simply receives all underlay packets and passes them to the sender with appropriate changes
+def receiver_loop(q, iface, mac):
+	if opts.verbose:
+		print(f"Listening on {iface}, mangling packets from {mac}")
+	while True:
+		pkts = sniff(iface=iface, count=1, lfilter=is_ul_pkt)
+		if len(pkts) != 1:
+			print(f"Sniffing on {iface} interrupted", file=sys.stderr)
+			exit(1)
+		pkt = pkts[0]
+		if opts.verbose:
+			summary = f"{pkt.sprintf('%Ether.src% -> %Ether.dst% / %IPv6.src% -> %IPv6.dst%')} / {pkt.summary().split(' / ', 2)[2]}"
+			print(f"{datetime.now()} {iface}: {summary}")
+		# Mark the sent-out packet as to not be sniffed by the receiver
+		pkt[IPv6].tc = 0x0C
+		# For packets originating from PF, change them so they do not pass directly to dpservice
+		# But are caught by pytest instead
+		if pkt[Ether].src == mac:
+			pkt[Ether].type = 0x1337
+		q.put((iface, pkt))
+
+
+class ReflectAction(argparse.Action):
+	def __call__(self, parser, namespace, values, option_string=None):
+		for value in values:
+			spec = value.split(',')
+			if len(spec) != 2:
+				raise argparse.ArgumentError(self, f"Invalid IFACE,MAC tuple given: '{value}'")
+			getattr(namespace, self.dest).append(value)
+
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser(description="Packet reflector for dpservice pytest suite")
+	parser.add_argument('-v', '--verbose', action='count', default=0, help="more verbose output (use multiple times)")
+	parser.add_argument('--virtsvc', action='append', default=[], help="virtual service endpoint(s)")
+	parser.add_argument('reflect', metavar='IFACE,MAC', default=[], nargs='+', action=ReflectAction, help="interface(s) to listen on and *remote* MAC(s) to mangle")
+	opts = parser.parse_args()
+
+	q = multiprocessing.Queue()
+
+	for spec in opts.reflect:
+		iface, mac = spec.split(',')
+		multiprocessing.Process(target=receiver_loop, args=(q, iface, mac)).start()
+
+	sender_loop(q)

--- a/test/local/tcp_tester.py
+++ b/test/local/tcp_tester.py
@@ -66,13 +66,17 @@ class _TCPTester:
 			self.tcp_receiver_seq += 1
 
 		# Application-level reply
-		if pkt[TCP].payload != None and len(pkt[TCP].payload) > 0:
-			if pkt[TCP].payload == Raw(_TCPTester.TCP_RESET_REQUEST):
+		payload = pkt[TCP].payload
+		if payload != None and len(payload) > 0:
+			if Padding in payload:
+				length = len(payload) - len(payload[Padding])
+				payload = payload.__class__(raw(payload)[0:length])
+			if payload == Raw(_TCPTester.TCP_RESET_REQUEST):
 				reply_pkt = (self.get_server_l3_reply(pkt) /
 							 TCP(dport=pkt[TCP].sport, sport=pkt[TCP].dport, seq=self.tcp_receiver_seq, flags="R"))
 				delayed_sendp(reply_pkt, self.server_tap)
 				return
-			elif pkt[TCP].payload == Raw(_TCPTester.TCP_NORMAL_REQUEST):
+			elif payload == Raw(_TCPTester.TCP_NORMAL_REQUEST):
 				reply_pkt = (self.get_server_l3_reply(pkt) /
 							 TCP(dport=pkt[TCP].sport, sport=pkt[TCP].dport, seq=self.tcp_receiver_seq, flags="") /
 							 Raw(_TCPTester.TCP_NORMAL_RESPONSE))

--- a/test/local/test_flows.py
+++ b/test/local/test_flows.py
@@ -49,11 +49,11 @@ def test_nat_table_flush(prepare_ipv4, grpc_client, port_redundancy):
 
 
 def send_bounce_pkt_to_pf(ipv6_nat):
-	bouce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-				 IPv6(dst=ipv6_nat, src=router_ul_ipv6, nh=4) /
-				 IP(dst=nat_vip, src=public_ip) /
-				 TCP(sport=8989, dport=510))
-	delayed_sendp(bouce_pkt, PF0.tap)
+	bounce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
+				  IPv6(dst=ipv6_nat, src=router_ul_ipv6, nh=4) /
+				  IP(dst=nat_vip, src=public_ip) /
+				  TCP(sport=8989, dport=510))
+	delayed_sendp(bounce_pkt, PF0.tap)
 
 def test_neighnat_table_flush(prepare_ipv4, grpc_client, port_redundancy):
 

--- a/test/local/test_lb.py
+++ b/test/local/test_lb.py
@@ -5,24 +5,13 @@ import pytest
 
 from helpers import *
 
-def network_lb_external_icmpv4_ping(lb_ul_ipv6):
-	icmp_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-				IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6, nh=4) /
-				IP(dst=lb_ip, src=public_ip) /
-				ICMP(type=8, id=0x0040))
-	answer = srp1(icmp_pkt, iface=PF0.tap, timeout=sniff_timeout)
-	validate_checksums(answer)
-	assert answer and is_icmp_pkt(answer), \
-		"No ECHO reply"
 
 def test_network_lb_external_icmp_echo(prepare_ipv4, grpc_client):
-
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
-
-	network_lb_external_icmpv4_ping(lb_ul_ipv6)
-	network_lb_external_icmpv4_ping(lb_ul_ipv6)
-
+	external_ping(lb_ip, lb_ul_ipv6)
+	external_ping(lb_ip, lb_ul_ipv6)
 	grpc_client.dellb(lb_name)
+
 
 def router_loopback(dst_ipv6, check_ipv4_src, check_ipv4_dst):
 	pkt = sniff_packet(PF0.tap, is_tcp_pkt)
@@ -63,12 +52,11 @@ def communicate_vip_lb(vm, lb_ipv6, src_ipv6, src_ipv4, vf_tap, sport):
 	assert vm_reply[TCP].sport == 80, \
 		f"Invalid server reply port {vm_reply[TCP].sport}"
 
+
 def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 
 	if port_redundancy:
 		pytest.skip("Port redundancy is not supported for NAT <-> LB+NAT test")
-	if request.config.getoption("--hw"):
-		pytest.skip("Hardware testing is not supported for NAT <-> LB+NAT test")
 
 	# Create a VM on VNI1 under a loadbalancer and NAT
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/80")
@@ -78,18 +66,16 @@ def test_nat_to_lb_nat(request, prepare_ipv4, grpc_client, port_redundancy):
 	grpc_client.addfwallrule(VM1.name, "fw0-vm1", proto="tcp", dst_port_min=80, dst_port_max=80)
 
 	# Create another VM on the same VNI behind the same NAT and communicate
-	VM4.ul_ipv6 = grpc_client.addinterface(VM4.name, VM4.pci, VM4.vni, VM4.ip, VM4.ipv6)
-	request_ip(VM4)
-	nat3_ipv6 = grpc_client.addnat(VM4.name, nat_vip, 400, 401)
-	communicate_vip_lb(VM4, lb_ul_ipv6, nat3_ipv6, nat_vip, VM1.tap, 2400)
-	grpc_client.delnat(VM4.name)
-	grpc_client.delinterface(VM4.name)
+	nat2_ipv6 = grpc_client.addnat(VM2.name, nat_vip, 400, 401)
+	communicate_vip_lb(VM2, lb_ul_ipv6, nat2_ipv6, nat_vip, VM1.tap, 2400)
+	grpc_client.delnat(VM2.name)
 
 	grpc_client.delfwallrule(VM1.name, "fw0-vm1")
 	grpc_client.delnat(VM1.name)
 	grpc_client.dellbtarget(lb_name, lb_vm1_ul_ipv6)
 	grpc_client.dellbprefix(VM1.name, lb_pfx)
 	grpc_client.dellb(lb_name)
+
 
 def send_bounce_pkt_to_pf(ipv6_lb):
 	bouce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
@@ -113,6 +99,7 @@ def test_external_lb_relay(prepare_ipv4, grpc_client):
 	grpc_client.dellbtarget(lb_name, neigh_ul_ipv6)
 	grpc_client.dellb(lb_name)
 
+
 def send_bounce_icmp_pkt_to_pf(ipv6_lb):
 	bounce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac) /
 				IPv6(dst=ipv6_lb, src=local_ul_ipv6, nh=4) /
@@ -128,7 +115,6 @@ def test_external_lb_icmp_error_relay(prepare_ipv4, grpc_client):
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip, "tcp/8080")
 	grpc_client.addlbtarget(lb_name, neigh_ul_ipv6)
 
-
 	threading.Thread(target=send_bounce_icmp_pkt_to_pf, args=(lb_ul_ipv6,)).start()
 	pkt = sniff_packet(PF0.tap, is_icmp_pkt, skip=1)
 
@@ -139,24 +125,13 @@ def test_external_lb_icmp_error_relay(prepare_ipv4, grpc_client):
 	grpc_client.dellbtarget(lb_name, neigh_ul_ipv6)
 	grpc_client.dellb(lb_name)
 
-def network_lb_external_icmpv6_ping(lb_ul_ipv6):
-	icmp_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-				IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6, nh=0x29) /
-				IPv6(dst=lb_ip6, src=public_ipv6, nh=58) /
-				ICMPv6EchoRequest())
-	answer = srp1(icmp_pkt, iface=PF0.tap, timeout=sniff_timeout)
-	validate_checksums(answer)
-	assert answer and is_icmpv6echo_reply_pkt(answer), \
-		"No ECHO reply"
 
 def test_network_lb_external_icmpv6_echo(prepare_ipv4, grpc_client):
-
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip6, "tcp/443")
-
-	network_lb_external_icmpv6_ping(lb_ul_ipv6)
-	network_lb_external_icmpv6_ping(lb_ul_ipv6)
-
+	external_ping6(lb_ip6, lb_ul_ipv6)
+	external_ping6(lb_ip6, lb_ul_ipv6)
 	grpc_client.dellb(lb_name)
+
 
 def send_bounce_ipv6_pkt_to_pf(ipv6_lb):
 	bounce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
@@ -170,7 +145,6 @@ def test_external_lb_relay_ipv6(prepare_ipv4, grpc_client):
 	lb_ul_ipv6 = grpc_client.createlb(lb_name, vni1, lb_ip6, "tcp/8080")
 	grpc_client.addlbtarget(lb_name, neigh_ul_ipv6)
 
-
 	threading.Thread(target=send_bounce_ipv6_pkt_to_pf, args=(lb_ul_ipv6,)).start()
 	pkt = sniff_packet(PF0.tap, is_ipv6_tcp_pkt, skip=1)
 
@@ -178,6 +152,7 @@ def test_external_lb_relay_ipv6(prepare_ipv4, grpc_client):
 	assert dst_ip == neigh_ul_ipv6, \
 		f"Wrong network-lb relayed packet (outer dst ipv6: {dst_ip})"
 	grpc_client.dellb(lb_name)
+
 
 def test_vip_nat_to_lb_on_another_vni(prepare_ipv4, grpc_client, port_redundancy):
 

--- a/test/local/test_nat.py
+++ b/test/local/test_nat.py
@@ -6,16 +6,10 @@ import threading
 
 from helpers import *
 
+
 def test_network_nat_external_icmp_echo(prepare_ipv4, grpc_client):
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
-	icmp_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-			    IPv6(dst=nat_ul_ipv6, src=router_ul_ipv6, nh=4) /
-			    IP(dst=nat_vip, src=public_ip) /
-			    ICMP(type=8, id=0x0040))
-	answer = srp1(icmp_pkt, iface=PF0.tap, timeout=sniff_timeout)
-	validate_checksums(answer)
-	assert answer and is_icmp_pkt(answer), \
-		"No ECHO reply"
+	external_ping(nat_vip, nat_ul_ipv6)
 	grpc_client.delnat(VM1.name)
 
 def send_bounce_pkt_to_pf(ipv6_nat):

--- a/test/local/test_virtsvc.py
+++ b/test/local/test_virtsvc.py
@@ -47,10 +47,17 @@ def test_virtsvc_udp(request, prepare_ipv4, port_redundancy):
 	if not request.config.getoption("--virtsvc"):
 		pytest.skip("Virtual services not enabled")
 	# port numbers chosen so that they cause the right redirection
-	for port in [ 12345, 12346, 12347, 12349, 12350 ]:
+	# (port numbers are part of the hash here, so pf1-proxy changes everything)
+	pf0_ports = [ 12345, 12346, 12347, 12349, 12350 ]
+	if request.config.getoption("--hw") and PF1.tap != "pf1-tap":
+		pf0_ports = [ 12352, 12355, 12360, 12361, 12362 ]
+	for port in pf0_ports:
 		request_udp(port, PF0.tap)
 	if port_redundancy:
-		for port in [ 12348, 12351, 12354, 12355, 12357 ]:
+		pf1_ports = [ 12348, 12351, 12354, 12355, 12357 ]
+		if request.config.getoption("--hw") and PF1.tap != "pf1-tap":
+			pf1_ports = [ 12345, 12346, 12347, 12348, 12349 ]
+		for port in pf1_ports:
 			request_udp(port, PF1.tap)
 
 
@@ -64,7 +71,8 @@ def test_virtsvc_tcp(request, prepare_ipv4, port_redundancy):
 	if not request.config.getoption("--virtsvc"):
 		pytest.skip("Virtual services not enabled")
 
-	tester = TCPTesterVirtsvc(VM1, 12345, PF0, virtsvc_tcp_virtual_ip, virtsvc_tcp_virtual_port, server_pkt_check=tcp_server_virtsvc_pkt_check)
+	port = 12352 if request.config.getoption("--hw") and PF1.tap != "pf1-tap" else 12345
+	tester = TCPTesterVirtsvc(VM1, port, PF0, virtsvc_tcp_virtual_ip, virtsvc_tcp_virtual_port, server_pkt_check=tcp_server_virtsvc_pkt_check)
 	tester.communicate()
 
 	# port number chosen so that they cause the right redirection


### PR DESCRIPTION
There was a switch to run pytest suite using actual hardware (Mellanox NIC). It was highly specific to a setup with corsslinked ports and could not thus cover everything.

I created a better implementation where the Mellanox NIC is connected to another machine (or another NIC on the same machine with network namespace isolation). Then a special `scapy` script is run on the remote machine to reflect underlay packets back to the test suite (it needs to mangle some of them to prevent isolation rule from firing).

Currently this needs a directly connected machine with no switch in between, as the MAC addresses used would cause the traffic to be dropped I believe. But this is something I want to address later so this test can be run in other environments.

This is also capable of testing the multiport setup and pf1-proxy functionality (as the pytest suite needs to listen on the proxy port)

---

The change to dpservice C code is actually just a cleanup of a hack to make the previous HW test work.

As for the test suite itself, almost all calls to `send()` and `sniff()` were already encapsulated, so adding the de-mangling of packets (for isolation rule prevention) is centralized. There were a few instances of a naked call to `send()` and `sniff()` which I encapsulated and it even cleaned the code up.

There is a bit of a messy change to telemetry tests (due to the fact that we change the graph for pf1-proxy, etc.), but this will be fixed once we either remove or rework the way pf1-proxy is implemented.

Apart from the above, the tests themselves are oblivious to this change.