### PR TITLE
Remove Rx RSS

### DIFF
--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -40,12 +40,6 @@ static const struct rte_eth_conf port_conf_default = {
 			RTE_ETH_TX_OFFLOAD_TCP_CKSUM |
 			RTE_ETH_TX_OFFLOAD_IP_TNL_TSO
 	},
-	.rx_adv_conf = {
-		.rss_conf = {
-			.rss_key = NULL,
-			.rss_hf = RTE_ETH_RSS_IP,
-		},
-	},
 	.intr_conf = {
 		.lsc = 1, /**< lsc interrupt feature enabled */
 	},


### PR DESCRIPTION
When implementing pf1-proxy over MLX5-bound VF on PF1 (i.e. setting `sriov_numvfs` to `1` for PF1), maximum throughput on PF0 goes from 24.7Gbps to 12.5Gbps if there is also any VM-VM traffic. Such traffic is also 0.8Gbps.

By removing Rx RSS, PF0 throughput is back to maximum and VM-VM if done in parallel is up to 4Gbps.

Part of #606 

---
I have not made this part of the pf1-proxy PR since this change would be easy to miss and I think it should be tracked separately.