### PR TITLE
Adjust packet mbuf size to reflect MTU

### DIFF
--- a/include/dpdk_layer.h
+++ b/include/dpdk_layer.h
@@ -37,16 +37,25 @@ extern "C" {
 // there are three periodic messages (ARP, ND, ND-RA) that could be sent at once
 #define DP_PERIODIC_Q_SIZE	(DP_MAX_PORTS * 3)
 
-// 40Gb/s with 1500B packets means ~9M packets/s
-// assuming 0.1s delay in processing means ~900k mbufs needed
+// 40Gb/s with 1500B packets means ~3.3M packets/s
+// assuming 0.1s delay in processing means ~350k mbufs needed
 #ifdef ENABLE_PYTEST
 #define DP_MBUF_POOL_SIZE	(50*1024)
 #else
-#define DP_MBUF_POOL_SIZE	(900*1024)
+#define DP_MBUF_POOL_SIZE	(350*1024)
+#endif
+#define DP_MBUF_BUF_SIZE	(1518 + RTE_PKTMBUF_HEADROOM)
+
+#ifdef ENABLE_PF1_PROXY
+#define DP_JUMBO_MBUF_POOL_SIZE	(50*1024)
+#define DP_JUMBO_MBUF_BUF_SIZE	(9118 + RTE_PKTMBUF_HEADROOM)
 #endif
 
 struct dp_dpdk_layer {
 	struct rte_mempool	*rte_mempool;
+#ifdef ENABLE_PF1_PROXY
+	struct rte_mempool	*rte_jumbo_mempool;
+#endif
 	struct rte_ring		*grpc_tx_queue;
 	struct rte_ring		*grpc_rx_queue;
 	struct rte_ring		*periodic_msg_queue;

--- a/meson.build
+++ b/meson.build
@@ -51,13 +51,13 @@ if get_option('enable_virtual_services')
   add_global_arguments('-DENABLE_VIRTSVC', language: ['c', 'cpp'])
 endif
 if get_option('enable_static_underlay_ip')
-  add_global_arguments('-DENABLE_STATIC_UNDERLAY_IP', language: 'c')
+  add_global_arguments('-DENABLE_STATIC_UNDERLAY_IP', language: ['c', 'cpp'])
 endif
 if get_option('enable_tests')
-  add_global_arguments('-DENABLE_PYTEST', language: 'c')
+  add_global_arguments('-DENABLE_PYTEST', language: ['c', 'cpp'])
 endif
 if get_option('enable_pf1_proxy')
-  add_global_arguments('-DENABLE_PF1_PROXY', language: 'c')
+  add_global_arguments('-DENABLE_PF1_PROXY', language: ['c', 'cpp'])
 endif
 
 dpdk_dep = dependency('libdpdk', version: '>=21.11.0')

--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -3,6 +3,7 @@
 
 #include "dpdk_layer.h"
 #include <rte_graph_worker.h>
+#include "dp_conf.h"
 #include "dp_error.h"
 #include "dp_graph.h"
 #include "dp_log.h"
@@ -35,12 +36,25 @@ static int dp_dpdk_layer_init_unsafe(void)
 {
 	dp_layer.rte_mempool = rte_pktmbuf_pool_create("mbuf_pool", DP_MBUF_POOL_SIZE,
 												   DP_MEMPOOL_CACHE_SIZE, DP_MBUF_PRIV_DATA_SIZE,
-												   RTE_MBUF_DEFAULT_BUF_SIZE,
+												   DP_MBUF_BUF_SIZE,
 												   rte_socket_id());
 	if (!dp_layer.rte_mempool) {
 		DPS_LOG_ERR("Cannot create mbuf pool", DP_LOG_RET(rte_errno));
 		return DP_ERROR;
 	}
+
+#ifdef ENABLE_PF1_PROXY
+	if (dp_conf_is_pf1_proxy_enabled()) {
+		dp_layer.rte_jumbo_mempool = rte_pktmbuf_pool_create("jumbo_mbuf_pool", DP_JUMBO_MBUF_POOL_SIZE,
+													DP_MEMPOOL_CACHE_SIZE, DP_MBUF_PRIV_DATA_SIZE,
+													DP_JUMBO_MBUF_BUF_SIZE,
+													rte_socket_id());
+		if (!dp_layer.rte_jumbo_mempool) {
+			DPS_LOG_ERR("Cannot create jumbo mbuf pool", DP_LOG_RET(rte_errno));
+			return DP_ERROR;
+		}
+	}
+#endif
 
 	dp_layer.num_of_vfs = dp_get_num_of_vfs();
 	if (DP_FAILED(dp_layer.num_of_vfs))
@@ -80,6 +94,9 @@ void dp_dpdk_layer_free(void)
 	ring_free(dp_layer.periodic_msg_queue);
 	ring_free(dp_layer.grpc_rx_queue);
 	ring_free(dp_layer.grpc_tx_queue);
+#ifdef ENABLE_PF1_PROXY
+	rte_mempool_free(dp_layer.rte_jumbo_mempool);
+#endif
 	rte_mempool_free(dp_layer.rte_mempool);
 }
 

--- a/src/monitoring/dp_graphtrace.c
+++ b/src/monitoring/dp_graphtrace.c
@@ -38,9 +38,14 @@ static int dp_graphtrace_init_memory(void)
 	// So using ringbuffer size minus one, when the ring buffer is (almost) full, allocation will start failing
 	// (this is intentional, see below)
 	graphtrace.mempool = rte_pktmbuf_pool_create(DP_GRAPHTRACE_MEMPOOL_NAME, DP_GRAPHTRACE_RINGBUF_SIZE-1,
-											 DP_MEMPOOL_CACHE_SIZE, DP_MBUF_PRIV_DATA_SIZE + sizeof(struct dp_graphtrace_pktinfo),
-											 RTE_MBUF_DEFAULT_BUF_SIZE,
-											 rte_socket_id());
+												 DP_MEMPOOL_CACHE_SIZE,
+												 DP_MBUF_PRIV_DATA_SIZE + sizeof(struct dp_graphtrace_pktinfo),
+#ifdef ENABLE_PF1_PROXY
+												 DP_JUMBO_MBUF_BUF_SIZE,
+#else
+												 DP_MBUF_BUF_SIZE,
+#endif
+												 rte_socket_id());
 	if (!graphtrace.mempool) {
 		DPS_LOG_ERR("Cannot allocate graphtrace pool", DP_LOG_RET(rte_errno));
 		return DP_ERROR;


### PR DESCRIPTION
Due to #606 we needed to increase the packet buffer size to adjust for Jumbo frames as that is what host-host communication is using. This in turn raised the required number of hugepages for dpservice pod from 4G to 16G on our compute nodes.

So instead I created two memory pools, one for 1500 MTU, the other for 9100 MTU.

In normal operation, dpservice only encounters 1500 MTU packets, yet the packet buffer size is set to `RTE_MBUF_DEFAULT_BUF_SIZE` (rte_mbuf.h):
```
#define RTE_MBUF_DEFAULT_DATAROOM       2048
#define RTE_MBUF_DEFAULT_BUF_SIZE       \
         (RTE_MBUF_DEFAULT_DATAROOM + RTE_PKTMBUF_HEADROOM)
```

So this PR lowers the buffer size to decrease memory requirements in normal mode and uses jumbo frames in pf1-proxy mode. Unfortunately `dpservice-dump` does not know which mode is active so it needs to use the bigger variant always, though it only uses a small ring buffer, so the allocation is not huge.

I have deployed the 1518 size on an OSC cluster and it has been running for two weeks now without visible problems.

The 9118 pool is tested in OSC, but not in the current state (i.e. using TAP device), I chose to do it this way to separate this PR from the big changes to the proxy.