### PR TITLE
Fix exporter for different NUMA nodes

### DIFF
--- a/cli/dpservice-exporter/metrics/types.go
+++ b/cli/dpservice-exporter/metrics/types.go
@@ -75,7 +75,11 @@ type DpServiceGraphCallCount struct {
 	GraphCallCnt GraphCallCount `json:"/dp_service/graph/call_count"`
 }
 
-type DpServiceHeapInfo struct {
+type EalHeapList struct {
+	Value []int `json:"/eal/heap_list"`
+}
+
+type EalHeapInfo struct {
 	Value map[string]any `json:"/eal/heap_info"`
 }
 


### PR DESCRIPTION
Currently dpservice-exporter uses `/eal/heap_info,0` on all nodes. Some nodes in OSC require the use of `/eal/heap_info,1`, so this PR uses `/eal/heap_list` to ask for the right (NUMA node?) number.

I am not that versed in Go, so I simply "copied" the code for interfaces, therefore this code would not work when there are multiple `heap_info` entries. But for our deployment it should be fine.

Connected to #606 

