### PR TITLE
mbufs holding a reference to conntrack should be part of ref counting

### DIFF
--- a/include/dp_error.h
+++ b/include/dp_error.h
@@ -11,6 +11,9 @@ extern "C" {
 #include <assert.h>
 #include <rte_errno.h>
 
+#define DP_RETURN_REF_COUNT_REDUCE_DROP(var, X) \
+    do { dp_ref_dec(&(var)->ref_count); return X; } while (0)
+
 #define DP_OK 0
 #define DP_ERROR (-RTE_MAX_ERRNO)
 #define _DP_GRPC_ERRCODES (DP_ERROR-1)

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -305,6 +305,7 @@ int dp_cntrack_handle(struct rte_mbuf *m, struct dp_flow *df)
 		return DP_ERROR;
 
 	df->conntrack = flow_val;
+	dp_ref_inc(&flow_val->ref_count);
 	dp_cntrack_set_pkt_offload_decision(df);
 
 	return DP_OK;

--- a/src/nodes/conntrack_node.c
+++ b/src/nodes/conntrack_node.c
@@ -80,10 +80,10 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	case DP_VNF_TYPE_ALIAS_PFX:
 		return CONNTRACK_NEXT_FIREWALL;
 	case DP_VNF_TYPE_UNDEFINED:
-		return CONNTRACK_NEXT_DROP;
+		DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, CONNTRACK_NEXT_DROP);
 	}
 
-	return CONNTRACK_NEXT_DROP;
+	DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, CONNTRACK_NEXT_DROP);
 }
 
 static uint16_t conntrack_node_process(struct rte_graph *graph,

--- a/src/nodes/ipip_encap_node.c
+++ b/src/nodes/ipip_encap_node.c
@@ -76,6 +76,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	m->ol_flags |= RTE_MBUF_F_TX_TUNNEL_IP;
 
 	if (df->nat_type == DP_LB_RECIRC) {
+		dp_ref_dec(&df->conntrack->ref_count);
 		dp_get_pkt_mark(m)->flags.is_recirc = true;
 		return IPIP_ENCAP_NEXT_CLS;
 	}

--- a/src/nodes/ipv4_lookup_node.c
+++ b/src/nodes/ipv4_lookup_node.c
@@ -37,11 +37,11 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 	out_port = dp_get_ip4_out_port(in_port, df->tun_info.dst_vni, df, &route, &ip);
 	if (!out_port)
-		return IPV4_LOOKUP_NEXT_DROP;
+		DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, IPV4_LOOKUP_NEXT_DROP);
 
 	if (out_port->is_pf) {
 		if (in_port->is_pf)
-			return IPV4_LOOKUP_NEXT_DROP;
+			DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, IPV4_LOOKUP_NEXT_DROP);
 		dp_copy_ipv6(&df->tun_info.ul_dst_addr6, &route.nh_ipv6);
 		out_port = dp_multipath_get_pf(df->dp_flow_hash);
 	} else {

--- a/src/nodes/ipv6_lookup_node.c
+++ b/src/nodes/ipv6_lookup_node.c
@@ -32,11 +32,11 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 	out_port = dp_get_ip6_out_port(in_port, t_vni, df, &route, &ip);
 	if (!out_port)
-		return IPV6_LOOKUP_NEXT_DROP;
+		DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, IPV6_LOOKUP_NEXT_DROP);
 
 	if (out_port->is_pf) {
 		if (in_port->is_pf)
-			return IPV6_LOOKUP_NEXT_DROP;
+			DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, IPV6_LOOKUP_NEXT_DROP);
 		dp_copy_ipv6(&df->tun_info.ul_dst_addr6, &route.nh_ipv6);
 	} else {
 		// next hop is known, fill in Ether header

--- a/src/nodes/lb_node.c
+++ b/src/nodes/lb_node.c
@@ -64,12 +64,12 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 			}
 			/* ICMP error types conntrack keys are built from original TCP/UDP header, so let them slip */
 			if (df->l4_info.icmp_field.icmp_type != DP_IP_ICMP_TYPE_ERROR)
-				return LB_NEXT_DROP;
+				DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, LB_NEXT_DROP);
 		}
 
 		target_ip6 = dp_lb_get_backend_ip(&cntrack->flow_key[DP_FLOW_DIR_ORG], vni);
 		if (!target_ip6)
-			return LB_NEXT_DROP;
+			DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, LB_NEXT_DROP);
 
 		dp_copy_ipv6(&df->tun_info.ul_src_addr6, &df->tun_info.ul_dst_addr6);  // same trick as in packet_relay_node.c
 		dp_copy_ipv6(&df->tun_info.ul_dst_addr6, target_ip6);

--- a/src/nodes/packet_relay_node.c
+++ b/src/nodes/packet_relay_node.c
@@ -24,7 +24,7 @@ static __rte_always_inline rte_edge_t lb_nnat_icmp_reply(struct dp_flow *df, str
 	uint32_t cksum;
 
 	if (icmp_hdr->icmp_type != RTE_IP_ICMP_ECHO_REQUEST)
-		return PACKET_RELAY_NEXT_DROP;
+		DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, PACKET_RELAY_NEXT_DROP);
 
 	// rewrite the packet and send it back
 	icmp_hdr->icmp_type = RTE_IP_ICMP_ECHO_REPLY;
@@ -53,7 +53,7 @@ static __rte_always_inline rte_edge_t lb_nnat_icmpv6_reply(struct dp_flow *df, s
 	union dp_ipv6 temp_addr;
 
 	if (icmp6_hdr->icmp_type != DP_ICMPV6_ECHO_REQUEST)
-		return PACKET_RELAY_NEXT_DROP;
+		DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, PACKET_RELAY_NEXT_DROP);
 
 	icmp6_hdr->icmp_type = DP_ICMPV6_ECHO_REPLY;
 
@@ -92,7 +92,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	if (df->l4_type == IPPROTO_ICMPV6)
 		return lb_nnat_icmpv6_reply(df, m);
 
-	return PACKET_RELAY_NEXT_DROP;
+	DP_RETURN_REF_COUNT_REDUCE_DROP(df->conntrack, PACKET_RELAY_NEXT_DROP);
 }
 
 static uint16_t packet_relay_node_process(struct rte_graph *graph,

--- a/src/nodes/tx_node.c
+++ b/src/nodes/tx_node.c
@@ -98,6 +98,7 @@ static uint16_t tx_node_process(struct rte_graph *graph,
 			if (df->offload_state == DP_FLOW_OFFLOAD_INSTALL)
 				if (DP_FAILED(dp_offload_handler(m, df)))
 					DPNODE_LOG_WARNING(node, "Offloading handler failed");
+			dp_ref_dec(&df->conntrack->ref_count);
 		}
 	}
 


### PR DESCRIPTION
An mbuf entering the graph via conntrack node and holding a pointer to conntrack entry should cause the reference count increase and the mbuf leaving the graph should get its reference count decreased.
