### PR TITLE
dpservice-cli: Fix JSON output

### DIFF
--- a/go/dpservice-go/api/types.go
+++ b/go/dpservice-go/api/types.go
@@ -330,8 +330,8 @@ type InterfaceSpec struct {
 	UnderlayRoute   *netip.Addr      `json:"underlay_route,omitempty"`
 	VirtualFunction *VirtualFunction `json:"virtual_function,omitempty"`
 	PXE             *PXE             `json:"pxe,omitempty"`
-	Nat             *Nat             `json:"-"`
-	VIP             *VirtualIP       `json:"-"`
+	Nat             *Nat             `json:"nat,omitempty"`
+	VIP             *VirtualIP       `json:"vip,omitempty"`
 	Metering        *MeteringParams  `json:"metering,omitempty"`
 }
 


### PR DESCRIPTION
## Proposed Changes

Changed InterfaceSpec json tags to show nat and vip fields in json output if `--wide` flag is used.
If Interface has some NAT or Virtual IP associated with it, this will be shown in JSON/YAML output and not only in default table view.

Fixes #624