### PR TITLE
Fix DHCPv6 options serialization to prevent extra bytes in replies

### DIFF
--- a/src/nodes/dhcpv6_node.c
+++ b/src/nodes/dhcpv6_node.c
@@ -247,8 +247,10 @@ static int generate_reply_options(struct rte_mbuf *m, uint8_t *options, int opti
 		memcpy(options, (void *)&reply_options.opt_iana, reply_options.opt_iana_len);
 		options += reply_options.opt_iana_len;
 	}
-	if (reply_options.opt_rapid_len)
+	if (reply_options.opt_rapid_len) {
 		memcpy(options, &reply_options.opt_rapid, reply_options.opt_rapid_len);
+		options += reply_options.opt_rapid_len;
+	}
 
 	// Add DNS server option
 	memcpy(options, &dns_opt.opt_code, sizeof(dns_opt.opt_code));
@@ -258,8 +260,10 @@ static int generate_reply_options(struct rte_mbuf *m, uint8_t *options, int opti
 	memcpy(options, dhcpv6_dns->array, dhcpv6_dns->len);
 	options += dhcpv6_dns->len;
 
-	if (reply_options.pxe_mode != DP_PXE_MODE_NONE)
+	if (reply_options.pxe_mode != DP_PXE_MODE_NONE) {
 		memcpy(options, &reply_options.boot_file_url, reply_options.opt_boot_file_len);
+		options += reply_options.opt_boot_file_len;
+	}
 
 	return reply_options_len;
 }


### PR DESCRIPTION
# Proposed Changes

In the `generate_reply_options` function, fixed an issue where DHCPv6 reply packets contained extra unintended bytes at the end. The problem was due to the `options` pointer not being incremented after copying the `opt_rapid` and `boot_file_url` options into the packet buffer.

Changes made:

- After copying `opt_rapid`, the `options` pointer is now incremented by `reply_options.opt_rapid_len`.
- After copying `boot_file_url`, the `options` pointer is now incremented by `reply_options.opt_boot_file_len`.

These changes ensure that all DHCPv6 options are correctly serialized in the packet buffer without overlaps or gaps. By properly advancing the `options` pointer, we prevent unintended data from being included at the end of the packet, eliminating the extra bytes that were being sent.

This fix addresses the issue where clients were receiving malformed DHCPv6 packets due to the extra bytes, which could lead to communication errors or unexpected behavior.