### PR TITLE
added InterfaceID and VNI to prefix table view, …

### DIFF
--- a/cli/dpservice-cli/cmd/command.go
+++ b/cli/dpservice-cli/cmd/command.go
@@ -9,6 +9,8 @@ import (
 )
 
 func Command() *cobra.Command {
+	cobra.EnableCaseInsensitive = true
+
 	dpdkClientOptions := &DPDKClientOptions{}
 	rendererOptions := &RendererOptions{}
 

--- a/cli/dpservice-cli/cmd/create_loadbalancer_prefix.go
+++ b/cli/dpservice-cli/cmd/create_loadbalancer_prefix.go
@@ -29,7 +29,7 @@ func CreateLoadBalancerPrefix(
 		Short:   "Create a loadbalancer prefix",
 		Example: "dpservice-cli create lbprefix --prefix=10.10.10.0/24 --interface-id=vm1",
 		Args:    cobra.ExactArgs(0),
-		Aliases: PrefixAliases,
+		Aliases: LoadBalancerPrefixAliases,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			return RunCreateLoadBalancerPrefix(

--- a/cli/dpservice-cli/renderer/renderer.go
+++ b/cli/dpservice-cli/renderer/renderer.go
@@ -290,11 +290,11 @@ func (t defaultTableConverter) interfaceTable(ifaces []api.Interface) (*TableDat
 }
 
 func (t defaultTableConverter) prefixTable(prefixes []api.Prefix) (*TableData, error) {
-	headers := []any{"Prefix", "UnderlayRoute"}
+	headers := []any{"VNI", "Prefix", "UnderlayRoute", "InterfaceID"}
 
 	columns := make([][]any, len(prefixes))
 	for i, prefix := range prefixes {
-		columns[i] = []any{prefix.Spec.Prefix, prefix.Spec.UnderlayRoute}
+		columns[i] = []any{prefix.Vni, prefix.Spec.Prefix, prefix.Spec.UnderlayRoute, prefix.InterfaceID}
 	}
 
 	return &TableData{

--- a/go/dpservice-go/api/types.go
+++ b/go/dpservice-go/api/types.go
@@ -128,6 +128,7 @@ type Prefix struct {
 
 type PrefixMeta struct {
 	InterfaceID string `json:"interface_id"`
+	Vni         uint32 `json:"vni"`
 }
 
 func (m *Prefix) GetName() string {


### PR DESCRIPTION
# Proposed Changes

VNI field added to Prefix struct, it is populated based on associated Interface.
Added VNI and InterfaceID columns to prefixes and loadbalancer prefixes table view (they are also included in json output).
```
dpservice-cli list prefixes
 VNI  Prefix         UnderlayRoute    InterfaceID 
```
Commands are now case insensitive, e.g.: `dpservice-cli list LoadBalancers`

Fixes #632