### PR TITLE
Implement --file-prefix EAL argument for secondary processes

### DIFF
--- a/docs/deployment/help_dpservice-dump.md
+++ b/docs/deployment/help_dpservice-dump.md
@@ -4,6 +4,7 @@
 |--------|----------|-------------|---------|
 | -h, --help | None | display this help and exit |  |
 | -v, --version | None | display version and exit |  |
+| --file-prefix | PREFIX | prefix for hugepage filenames |  |
 | --drops | None | show dropped packets |  |
 | --nodes | REGEX | show graph node traversal, limit to REGEX-matched nodes (empty string for all) |  |
 | --filter | FILTER | show only packets matching a pcap-style FILTER |  |

--- a/docs/deployment/help_dpservice-inspect.md
+++ b/docs/deployment/help_dpservice-inspect.md
@@ -4,6 +4,7 @@
 |--------|----------|-------------|---------|
 | -h, --help | None | display this help and exit |  |
 | -v, --version | None | display version and exit |  |
+| --file-prefix | PREFIX | prefix for hugepage filenames |  |
 | -o, --output-format | FORMAT | format of the output | 'human' (default), 'table', 'csv' or 'json' |
 | -t, --table | NAME | hash table to choose | 'list' (default), 'conntrack', 'dnat', 'iface', 'lb', 'lb_id', 'portmap', 'portoverload', 'snat', 'vnf', 'vnf_rev' or 'vni' |
 | -s, --socket | NUMBER | NUMA socket to use |  |

--- a/tools/common/dp_secondary_eal.c
+++ b/tools/common/dp_secondary_eal.c
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dp_secondary_eal.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <rte_common.h>
+#include <rte_eal.h>
+#include "dp_error.h"
+
+// EAL needs writable arguments (both the string and the array!)
+// therefore convert them from literals and remember them for freeing later
+static const char *eal_arg_strings[] = {
+	"dpservice-dump",				// this binary (not used, can actually be any string)
+	"--proc-type=secondary",		// connect to the primary process (dpservice-bin) instead
+	"--no-pci",						// do not try to use any hardware
+	"--log-level=6",				// hide DPDK's informational messages (level 7)
+};
+
+static char *eal_args_mem[RTE_DIM(eal_arg_strings)];
+static char *eal_args[RTE_DIM(eal_args_mem)];
+
+int dp_secondary_eal_init(void)
+{
+	for (size_t i = 0; i < RTE_DIM(eal_arg_strings); ++i) {
+		eal_args[i] = eal_args_mem[i] = strdup(eal_arg_strings[i]);
+		if (!eal_args[i]) {
+			fprintf(stderr, "Cannot allocate EAL arguments\n");
+			for (size_t j = 0; j < RTE_DIM(eal_args_mem); ++j)
+				free(eal_args_mem[j]);
+			return DP_ERROR;
+		}
+	}
+	return rte_eal_init(RTE_DIM(eal_args), eal_args);
+}
+
+void dp_secondary_eal_cleanup(void)
+{
+	rte_eal_cleanup();
+	for (size_t i = 0; i < RTE_DIM(eal_args_mem); ++i)
+		free(eal_args_mem[i]);
+}

--- a/tools/common/dp_secondary_eal.h
+++ b/tools/common/dp_secondary_eal.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __DP_SECONDARY_EAL_H__
+#define __DP_SECONDARY_EAL_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int dp_secondary_eal_init(void);
+
+void dp_secondary_eal_cleanup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tools/common/dp_secondary_eal.h
+++ b/tools/common/dp_secondary_eal.h
@@ -8,7 +8,9 @@
 extern "C" {
 #endif
 
-int dp_secondary_eal_init(void);
+#define DP_SECONDARY_FILE_PREFIX_DEFAULT ""
+
+int dp_secondary_eal_init(const char *file_prefix);
 
 void dp_secondary_eal_cleanup(void);
 

--- a/tools/dump/dp_conf.json
+++ b/tools/dump/dp_conf.json
@@ -4,6 +4,14 @@
   "markdown": "../../docs/deployment/help_dpservice-dump.md",
   "options": [
     {
+      "lgopt": "file-prefix",
+      "arg": "PREFIX",
+      "help": "prefix for hugepage filenames",
+      "var": "eal_file_prefix",
+      "type": "char",
+      "array_size": 32
+    },
+    {
       "lgopt": "drops",
       "help": "show dropped packets",
       "var": "showing_drops",

--- a/tools/dump/main.c
+++ b/tools/dump/main.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <rte_eal.h>
 #include <rte_alarm.h>
 
 #include "dp_error.h"
@@ -17,6 +16,7 @@
 #include "monitoring/dp_graphtrace_shared.h"
 #include "monitoring/dp_pcap.h"
 #include "rte_flow/dp_rte_flow.h"
+#include "../common/dp_secondary_eal.h"
 
 // generated definitions for getopt(),
 // generated storage variables and
@@ -37,18 +37,6 @@ static const struct timespec connect_timeout = {
 	.tv_nsec = 0,
 };
 
-// EAL needs writable arguments (both the string and the array!)
-// therefore convert them from literals and remember them for freeing later
-static const char *eal_arg_strings[] = {
-	"dpservice-dump",				// this binary (not used, can actually be any string)
-	"--proc-type=secondary",		// connect to the primary process (dpservice-bin) instead
-	"--no-pci",						// do not try to use any hardware
-	"--log-level=6",				// hide DPDK's informational messages (level 7)
-};
-
-static char *eal_args_mem[RTE_DIM(eal_arg_strings)];
-static char *eal_args[RTE_DIM(eal_args_mem)];
-
 static const char *pcap_path = NULL;
 static struct dp_pcap dp_pcap;
 
@@ -63,26 +51,6 @@ static bool primary_alive = false;
 static void print_packet(struct dp_pcap *dp_pcap, struct rte_mbuf *m, struct timeval *timestamp);
 static void (*dump_func)(struct dp_pcap *dp_pcap, struct rte_mbuf *m, struct timeval *timestamp) = print_packet;
 
-static int eal_init(void)
-{
-	for (size_t i = 0; i < RTE_DIM(eal_arg_strings); ++i) {
-		eal_args[i] = eal_args_mem[i] = strdup(eal_arg_strings[i]);
-		if (!eal_args[i]) {
-			fprintf(stderr, "Cannot allocate EAL arguments\n");
-			for (size_t j = 0; j < RTE_DIM(eal_args_mem); ++j)
-				free(eal_args_mem[j]);
-			return DP_ERROR;
-		}
-	}
-	return rte_eal_init(RTE_DIM(eal_args), eal_args);
-}
-
-static void eal_cleanup(void)
-{
-	rte_eal_cleanup();
-	for (size_t i = 0; i < RTE_DIM(eal_args_mem); ++i)
-		free(eal_args_mem[i]);
-}
 
 static int dp_graphtrace_connect(struct dp_graphtrace *graphtrace)
 {
@@ -420,7 +388,7 @@ int main(int argc, char **argv)
 		break;
 	}
 
-	ret = eal_init();
+	ret = dp_secondary_eal_init();
 	if (DP_FAILED(ret)) {
 		fprintf(stderr, "Cannot init EAL %s\n", dp_strerror_verbose(ret));
 		return EXIT_FAILURE;
@@ -431,7 +399,7 @@ int main(int argc, char **argv)
 	else
 		ret = do_graphtrace();
 
-	eal_cleanup();
+	dp_secondary_eal_cleanup();
 
 	return DP_FAILED(ret) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/tools/dump/main.c
+++ b/tools/dump/main.c
@@ -388,7 +388,7 @@ int main(int argc, char **argv)
 		break;
 	}
 
-	ret = dp_secondary_eal_init();
+	ret = dp_secondary_eal_init(dp_conf_get_eal_file_prefix());
 	if (DP_FAILED(ret)) {
 		fprintf(stderr, "Cannot init EAL %s\n", dp_strerror_verbose(ret));
 		return EXIT_FAILURE;

--- a/tools/dump/meson.build
+++ b/tools/dump/meson.build
@@ -1,5 +1,6 @@
 dpservice_dump_sources = [
   'main.c',
+  '../common/dp_secondary_eal.c',
   '../../src/dp_error.c',
   '../../src/monitoring/dp_graphtrace_shared.c',
   '../../src/monitoring/dp_pcap.c',

--- a/tools/dump/meson.build
+++ b/tools/dump/meson.build
@@ -1,6 +1,7 @@
 dpservice_dump_sources = [
   'main.c',
   '../common/dp_secondary_eal.c',
+  '../../src/dp_argparse.c',
   '../../src/dp_error.c',
   '../../src/monitoring/dp_graphtrace_shared.c',
   '../../src/monitoring/dp_pcap.c',

--- a/tools/dump/opts.c
+++ b/tools/dump/opts.c
@@ -18,6 +18,7 @@ enum {
 	OPT_HELP = 'h',
 	OPT_VERSION = 'v',
 _OPT_SHOPT_MAX = 255,
+	OPT_FILE_PREFIX,
 	OPT_DROPS,
 	OPT_NODES,
 	OPT_FILTER,
@@ -30,6 +31,7 @@ _OPT_SHOPT_MAX = 255,
 static const struct option dp_conf_longopts[] = {
 	{ "help", 0, 0, OPT_HELP },
 	{ "version", 0, 0, OPT_VERSION },
+	{ "file-prefix", 1, 0, OPT_FILE_PREFIX },
 	{ "drops", 0, 0, OPT_DROPS },
 	{ "nodes", 1, 0, OPT_NODES },
 	{ "filter", 1, 0, OPT_FILTER },
@@ -38,8 +40,14 @@ static const struct option dp_conf_longopts[] = {
 	{ NULL, 0, 0, 0 }
 };
 
+static char eal_file_prefix[32];
 static bool showing_drops = false;
 static bool stop_mode = false;
+
+const char *dp_conf_get_eal_file_prefix(void)
+{
+	return eal_file_prefix;
+}
 
 bool dp_conf_is_showing_drops(void)
 {
@@ -63,13 +71,14 @@ static int dp_argparse_opt_pcap(const char *arg);
 static inline void dp_argparse_help(const char *progname, FILE *outfile)
 {
 	fprintf(outfile, "Usage: %s [options]\n"
-		" -h, --help           display this help and exit\n"
-		" -v, --version        display version and exit\n"
-		"     --drops          show dropped packets\n"
-		"     --nodes=REGEX    show graph node traversal, limit to REGEX-matched nodes (empty string for all)\n"
-		"     --filter=FILTER  show only packets matching a pcap-style FILTER\n"
-		"     --pcap=FILE      write packets into a PCAP file\n"
-		"     --stop           do nothing, only make sure tracing is disabled in dp-service\n"
+		" -h, --help                display this help and exit\n"
+		" -v, --version             display version and exit\n"
+		"     --file-prefix=PREFIX  prefix for hugepage filenames\n"
+		"     --drops               show dropped packets\n"
+		"     --nodes=REGEX         show graph node traversal, limit to REGEX-matched nodes (empty string for all)\n"
+		"     --filter=FILTER       show only packets matching a pcap-style FILTER\n"
+		"     --pcap=FILE           write packets into a PCAP file\n"
+		"     --stop                do nothing, only make sure tracing is disabled in dp-service\n"
 	, progname);
 }
 
@@ -77,6 +86,8 @@ static int dp_conf_parse_arg(int opt, const char *arg)
 {
 	(void)arg;  // if no option uses an argument, this would be unused
 	switch (opt) {
+	case OPT_FILE_PREFIX:
+		return dp_argparse_string(arg, eal_file_prefix, ARRAY_SIZE(eal_file_prefix));
 	case OPT_DROPS:
 		return dp_argparse_store_true(&showing_drops);
 	case OPT_NODES:

--- a/tools/dump/opts.h
+++ b/tools/dump/opts.h
@@ -8,6 +8,7 @@
 /* Please edit dp_conf.json and re-run the script to update this file. */
 /***********************************************************************/
 
+const char *dp_conf_get_eal_file_prefix(void);
 bool dp_conf_is_showing_drops(void);
 bool dp_conf_is_stop_mode(void);
 

--- a/tools/inspect/dp_conf.json
+++ b/tools/inspect/dp_conf.json
@@ -4,6 +4,14 @@
   "markdown": "../../docs/deployment/help_dpservice-inspect.md",
   "options": [
     {
+      "lgopt": "file-prefix",
+      "arg": "PREFIX",
+      "help": "prefix for hugepage filenames",
+      "var": "eal_file_prefix",
+      "type": "char",
+      "array_size": 32
+    },
+    {
       "shopt": "o",
       "lgopt": "output-format",
       "arg": "FORMAT",

--- a/tools/inspect/main.c
+++ b/tools/inspect/main.c
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <getopt.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <rte_common.h>
-#include <rte_eal.h>
 
 #include "dp_error.h"
 #include "dp_version.h"
+#include "../common/dp_secondary_eal.h"
 
 #include "inspect.h"
 #include "inspect_conntrack.h"
@@ -23,39 +24,6 @@
 // generated getters for such variables
 #include "opts.h"
 #include "opts.c"
-
-// EAL needs writable arguments (both the string and the array!)
-// therefore convert them from literals and remember them for freeing later
-static const char *eal_arg_strings[] = {
-	"dpservice-inspect",			// this binary (not used, can actually be any string)
-	"--proc-type=secondary",		// connect to the primary process (dpservice-bin) instead
-	"--no-pci",						// do not try to use any hardware
-	"--log-level=6",				// hide DPDK's informational messages (level 7)
-};
-
-static char *eal_args_mem[RTE_DIM(eal_arg_strings)];
-static char *eal_args[RTE_DIM(eal_args_mem)];
-
-static int eal_init(void)
-{
-	for (size_t i = 0; i < RTE_DIM(eal_arg_strings); ++i) {
-		eal_args[i] = eal_args_mem[i] = strdup(eal_arg_strings[i]);
-		if (!eal_args[i]) {
-			fprintf(stderr, "Cannot allocate EAL arguments\n");
-			for (size_t j = 0; j < RTE_DIM(eal_args_mem); ++j)
-				free(eal_args_mem[j]);
-			return DP_ERROR;
-		}
-	}
-	return rte_eal_init(RTE_DIM(eal_args), eal_args);
-}
-
-static void eal_cleanup(void)
-{
-	rte_eal_cleanup();
-	for (size_t i = 0; i < RTE_DIM(eal_args_mem); ++i)
-		free(eal_args_mem[i]);
-}
 
 
 static void list_tables(enum dp_conf_output_format format)
@@ -162,7 +130,7 @@ int main(int argc, char **argv)
 		break;
 	}
 
-	ret = eal_init();
+	ret = dp_secondary_eal_init();
 	if (DP_FAILED(ret)) {
 		fprintf(stderr, "Cannot init EAL %s\n", dp_strerror_verbose(ret));
 		return EXIT_FAILURE;
@@ -178,7 +146,7 @@ int main(int argc, char **argv)
 								   get_format(dp_conf_get_output_format()));
 	}
 
-	eal_cleanup();
+	dp_secondary_eal_cleanup();
 
 	return DP_FAILED(ret) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/tools/inspect/main.c
+++ b/tools/inspect/main.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 		break;
 	}
 
-	ret = dp_secondary_eal_init();
+	ret = dp_secondary_eal_init(dp_conf_get_eal_file_prefix());
 	if (DP_FAILED(ret)) {
 		fprintf(stderr, "Cannot init EAL %s\n", dp_strerror_verbose(ret));
 		return EXIT_FAILURE;

--- a/tools/inspect/meson.build
+++ b/tools/inspect/meson.build
@@ -9,6 +9,7 @@ dpservice_inspect_sources = [
   'inspect_vnf.c',
   'inspect_vni.c',
   'main.c',
+  '../common/dp_secondary_eal.c',
   '../../src/dp_argparse.c',
   '../../src/dp_error.c',
   '../../src/dp_ipaddr.c',

--- a/tools/inspect/opts.c
+++ b/tools/inspect/opts.c
@@ -21,6 +21,7 @@ enum {
 	OPT_TABLE = 't',
 	OPT_SOCKET = 's',
 _OPT_SHOPT_MAX = 255,
+	OPT_FILE_PREFIX,
 	OPT_DUMP,
 };
 
@@ -32,6 +33,7 @@ _OPT_SHOPT_MAX = 255,
 static const struct option dp_conf_longopts[] = {
 	{ "help", 0, 0, OPT_HELP },
 	{ "version", 0, 0, OPT_VERSION },
+	{ "file-prefix", 1, 0, OPT_FILE_PREFIX },
 	{ "output-format", 1, 0, OPT_OUTPUT_FORMAT },
 	{ "table", 1, 0, OPT_TABLE },
 	{ "socket", 1, 0, OPT_SOCKET },
@@ -61,10 +63,16 @@ static const char *table_choices[] = {
 	"vni",
 };
 
+static char eal_file_prefix[32];
 static enum dp_conf_output_format output_format = DP_CONF_OUTPUT_FORMAT_HUMAN;
 static enum dp_conf_table table = DP_CONF_TABLE_LIST;
 static int numa_socket = -1;
 static bool dump = false;
+
+const char *dp_conf_get_eal_file_prefix(void)
+{
+	return eal_file_prefix;
+}
 
 enum dp_conf_output_format dp_conf_get_output_format(void)
 {
@@ -97,6 +105,7 @@ static inline void dp_argparse_help(const char *progname, FILE *outfile)
 	fprintf(outfile, "Usage: %s [options]\n"
 		" -h, --help                  display this help and exit\n"
 		" -v, --version               display version and exit\n"
+		"     --file-prefix=PREFIX    prefix for hugepage filenames\n"
 		" -o, --output-format=FORMAT  format of the output: 'human' (default), 'table', 'csv' or 'json'\n"
 		" -t, --table=NAME            hash table to choose: 'list' (default), 'conntrack', 'dnat', 'iface', 'lb', 'lb_id', 'portmap', 'portoverload', 'snat', 'vnf', 'vnf_rev' or 'vni'\n"
 		" -s, --socket=NUMBER         NUMA socket to use\n"
@@ -108,6 +117,8 @@ static int dp_conf_parse_arg(int opt, const char *arg)
 {
 	(void)arg;  // if no option uses an argument, this would be unused
 	switch (opt) {
+	case OPT_FILE_PREFIX:
+		return dp_argparse_string(arg, eal_file_prefix, ARRAY_SIZE(eal_file_prefix));
 	case OPT_OUTPUT_FORMAT:
 		return dp_argparse_enum(arg, (int *)&output_format, output_format_choices, ARRAY_SIZE(output_format_choices));
 	case OPT_TABLE:

--- a/tools/inspect/opts.h
+++ b/tools/inspect/opts.h
@@ -30,6 +30,7 @@ enum dp_conf_table {
 	DP_CONF_TABLE_VNI,
 };
 
+const char *dp_conf_get_eal_file_prefix(void);
 enum dp_conf_output_format dp_conf_get_output_format(void);
 enum dp_conf_table dp_conf_get_table(void);
 int dp_conf_get_numa_socket(void);


### PR DESCRIPTION
If dpservice is started with `--file-prefix` then no secondary process can attach anymore as it is still using the default.

This patch simply introduces an argument to the secondary process tools to send the value to EAL.

I also centralized the handling of EAL arguments for secondary processes.