### PR TITLE
Fix dpservice-cli crash when running before initialisation

### DIFF
--- a/cli/dpservice-cli/cmd/capture_start.go
+++ b/cli/dpservice-cli/cmd/capture_start.go
@@ -148,7 +148,7 @@ func RunCaptureStart(ctx context.Context, dpdkClientFactory DPDKClientFactory, r
 		},
 	})
 
-	if err != nil && capture.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error initializing packet capturing: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/capture_status.go
+++ b/cli/dpservice-cli/cmd/capture_status.go
@@ -46,7 +46,7 @@ func RunCaptureStatus(
 	}()
 
 	capture, err := client.CaptureStatus(ctx)
-	if err != nil && capture.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error checking initialization status: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/capture_stop.go
+++ b/cli/dpservice-cli/cmd/capture_stop.go
@@ -41,7 +41,7 @@ func RunCaptureStop(ctx context.Context, dpdkClientFactory DPDKClientFactory, re
 
 	captureStop, err := dpdkClient.CaptureStop(ctx)
 
-	if err != nil && captureStop.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error stopping capturing: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/common.go
+++ b/cli/dpservice-cli/cmd/common.go
@@ -158,21 +158,12 @@ func (o *RendererOptions) RenderObject(operation string, w io.Writer, obj api.Ob
 }
 
 func (o *RendererOptions) RenderList(operation string, w io.Writer, list api.List) error {
-	if list.GetStatus().Code != 0 {
-		operation = fmt.Sprintf("server error: %d, %s", list.GetStatus().Code, list.GetStatus().Message)
-		if o.Output == "table" {
-			o.Output = "name"
-		}
-	}
 	renderer, err := o.NewRenderer(operation, w)
 	if err != nil {
 		return fmt.Errorf("error creating renderer: %w", err)
 	}
 	if err := renderer.Render(list); err != nil {
 		return fmt.Errorf("error rendering %s: %w", list.GetItems()[0].GetKind(), err)
-	}
-	if list.GetStatus().Code != 0 {
-		return fmt.Errorf(strconv.Itoa(apierrors.SERVER_ERROR))
 	}
 	return nil
 }

--- a/cli/dpservice-cli/cmd/create_firewall_rule.go
+++ b/cli/dpservice-cli/cmd/create_firewall_rule.go
@@ -199,7 +199,7 @@ func RunCreateFirewallRule(ctx context.Context, dpdkClientFactory DPDKClientFact
 				Filter: protocolFilter.Filter},
 		},
 	})
-	if err != nil && fwrule.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating firewall rule: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_interface.go
+++ b/cli/dpservice-cli/cmd/create_interface.go
@@ -97,7 +97,7 @@ func RunCreateInterface(ctx context.Context, dpdkClientFactory DPDKClientFactory
 			Metering: &api.MeteringParams{TotalRate: opts.TotalMeterRate, PublicRate: opts.PublicMeterRate},
 		},
 	})
-	if err != nil && iface.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating interface: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_loadbalancer.go
+++ b/cli/dpservice-cli/cmd/create_loadbalancer.go
@@ -93,7 +93,7 @@ func RunCreateLoadBalancer(ctx context.Context, dpdkClientFactory DPDKClientFact
 			Lbports: ports,
 		},
 	})
-	if err != nil && lb.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating loadbalancer: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_loadbalancer_prefix.go
+++ b/cli/dpservice-cli/cmd/create_loadbalancer_prefix.go
@@ -87,7 +87,7 @@ func RunCreateLoadBalancerPrefix(
 			Prefix: opts.Prefix,
 		},
 	})
-	if err != nil && lbprefix.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating loadbalancer prefix: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_loadbalancer_target.go
+++ b/cli/dpservice-cli/cmd/create_loadbalancer_target.go
@@ -84,7 +84,7 @@ func RunCreateLoadBalancerTarget(
 		LoadBalancerTargetMeta: api.LoadBalancerTargetMeta{LoadbalancerID: opts.LoadBalancerID},
 		Spec:                   api.LoadBalancerTargetSpec{TargetIP: &opts.TargetIP},
 	})
-	if err != nil && lbtarget.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating loadbalancer target: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_nat.go
+++ b/cli/dpservice-cli/cmd/create_nat.go
@@ -85,7 +85,7 @@ func RunCreateNat(ctx context.Context, dpdkClientFactory DPDKClientFactory, rend
 			MaxPort: opts.MaxPort,
 		},
 	})
-	if err != nil && nat.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating nat: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_neighbor_nat.go
+++ b/cli/dpservice-cli/cmd/create_neighbor_nat.go
@@ -89,7 +89,7 @@ func RunCreateNeighborNat(ctx context.Context, dpdkClientFactory DPDKClientFacto
 	}
 
 	nnat, err := client.CreateNeighborNat(ctx, neigbhorNat)
-	if err != nil && nnat.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating neighbor nat: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_prefix.go
+++ b/cli/dpservice-cli/cmd/create_prefix.go
@@ -87,7 +87,7 @@ func RunCreatePrefix(
 			Prefix: opts.Prefix,
 		},
 	})
-	if err != nil && prefix.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating prefix: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_route.go
+++ b/cli/dpservice-cli/cmd/create_route.go
@@ -90,7 +90,7 @@ func RunCreateRoute(
 				IP:  &opts.NextHopIP,
 			}},
 	})
-	if err != nil && route.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating route: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/create_virtualip.go
+++ b/cli/dpservice-cli/cmd/create_virtualip.go
@@ -84,7 +84,7 @@ func RunCreateVirtualIP(
 			IP: &opts.Vip,
 		},
 	})
-	if err != nil && virtualIP.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error creating virtual ip: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_firewall_rule.go
+++ b/cli/dpservice-cli/cmd/delete_firewall_rule.go
@@ -69,7 +69,7 @@ func RunDeleteFirewallRule(ctx context.Context, dpdkClientFactory DPDKClientFact
 	defer DpdkClose(cleanup)
 
 	fwrule, err := client.DeleteFirewallRule(ctx, opts.InterfaceID, opts.RuleID)
-	if err != nil && fwrule.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting firewall rule: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_interface.go
+++ b/cli/dpservice-cli/cmd/delete_interface.go
@@ -67,7 +67,7 @@ func RunDeleteInterface(ctx context.Context, dpdkClientFactory DPDKClientFactory
 	defer DpdkClose(cleanup)
 
 	iface, err := client.DeleteInterface(ctx, opts.ID)
-	if err != nil && iface.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting interface: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_loadbalancer.go
+++ b/cli/dpservice-cli/cmd/delete_loadbalancer.go
@@ -67,7 +67,7 @@ func RunDeleteLoadBalancer(ctx context.Context, dpdkClientFactory DPDKClientFact
 	defer DpdkClose(cleanup)
 
 	lb, err := client.DeleteLoadBalancer(ctx, opts.ID)
-	if err != nil && lb.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting loadbalancer: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_loadbalancer_prefix.go
+++ b/cli/dpservice-cli/cmd/delete_loadbalancer_prefix.go
@@ -71,7 +71,7 @@ func RunDeleteLoadBalancerPrefix(ctx context.Context, dpdkClientFactory DPDKClie
 	defer DpdkClose(cleanup)
 
 	lbprefix, err := client.DeleteLoadBalancerPrefix(ctx, opts.InterfaceID, &opts.Prefix)
-	if err != nil && lbprefix.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting loadbalancer prefix: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_loadbalancer_target.go
+++ b/cli/dpservice-cli/cmd/delete_loadbalancer_target.go
@@ -71,7 +71,7 @@ func RunDeleteLoadBalancerTarget(ctx context.Context, dpdkClientFactory DPDKClie
 	defer DpdkClose(cleanup)
 
 	lbtarget, err := client.DeleteLoadBalancerTarget(ctx, opts.LoadBalancerID, &opts.TargetIP)
-	if err != nil && lbtarget.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting neighbor nat: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_nat.go
+++ b/cli/dpservice-cli/cmd/delete_nat.go
@@ -67,7 +67,7 @@ func RunDeleteNat(ctx context.Context, dpdkClientFactory DPDKClientFactory, rend
 	defer DpdkClose(cleanup)
 
 	nat, err := client.DeleteNat(ctx, opts.InterfaceID)
-	if err != nil && nat.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting nat: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_neighbor_nat.go
+++ b/cli/dpservice-cli/cmd/delete_neighbor_nat.go
@@ -85,7 +85,7 @@ func RunDeleteNeighborNat(ctx context.Context, dpdkClientFactory DPDKClientFacto
 		},
 	}
 	nnat, err := client.DeleteNeighborNat(ctx, &neigbhorNat)
-	if err != nil && nnat.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting neighbor nat: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_prefix.go
+++ b/cli/dpservice-cli/cmd/delete_prefix.go
@@ -71,7 +71,7 @@ func RunDeletePrefix(ctx context.Context, dpdkClientFactory DPDKClientFactory, r
 	defer DpdkClose(cleanup)
 
 	prefix, err := client.DeletePrefix(ctx, opts.InterfaceID, &opts.Prefix)
-	if err != nil && prefix.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting prefix: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_route.go
+++ b/cli/dpservice-cli/cmd/delete_route.go
@@ -71,7 +71,7 @@ func RunDeleteRoute(ctx context.Context, dpdkClientFactory DPDKClientFactory, re
 	defer DpdkClose(cleanup)
 
 	route, err := client.DeleteRoute(ctx, opts.VNI, &opts.Prefix)
-	if err != nil && route.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting route: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/delete_virtualip.go
+++ b/cli/dpservice-cli/cmd/delete_virtualip.go
@@ -67,7 +67,7 @@ func RunDeleteVirtualIP(ctx context.Context, dpdkClientFactory DPDKClientFactory
 	defer DpdkClose(cleanup)
 
 	virtualIP, err := client.DeleteVirtualIP(ctx, opts.InterfaceID)
-	if err != nil && virtualIP.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error deleting virtual ip: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/get_firewall_rule.go
+++ b/cli/dpservice-cli/cmd/get_firewall_rule.go
@@ -86,7 +86,7 @@ func RunGetFirewallRule(
 		)
 	} else {
 		fwrule, err := client.GetFirewallRule(ctx, opts.InterfaceID, opts.RuleID)
-		if err != nil && fwrule.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error getting firewall rule: %w", err)
 		}
 

--- a/cli/dpservice-cli/cmd/get_init.go
+++ b/cli/dpservice-cli/cmd/get_init.go
@@ -46,7 +46,7 @@ func RunGetInit(
 	}()
 
 	init, err := client.CheckInitialized(ctx)
-	if err != nil && init.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error checking initialization status: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/get_interface.go
+++ b/cli/dpservice-cli/cmd/get_interface.go
@@ -74,7 +74,7 @@ func RunGetInterface(
 		)
 	} else {
 		iface, err := client.GetInterface(ctx, opts.ID)
-		if err != nil && iface.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error getting interface: %w", err)
 		}
 

--- a/cli/dpservice-cli/cmd/get_loadbalancer.go
+++ b/cli/dpservice-cli/cmd/get_loadbalancer.go
@@ -75,7 +75,7 @@ func RunGetLoadBalancer(
 		)
 	} else {
 		lb, err := client.GetLoadBalancer(ctx, opts.ID)
-		if err != nil && lb.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error getting loadbalancer: %w", err)
 		}
 

--- a/cli/dpservice-cli/cmd/get_nat.go
+++ b/cli/dpservice-cli/cmd/get_nat.go
@@ -69,7 +69,7 @@ func RunGetNat(
 
 	if opts.InterfaceID == "" {
 		ifaces, err := client.ListInterfaces(ctx)
-		if err != nil && ifaces.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error listing interfaces: %w", err)
 		}
 		natList := api.NatList{
@@ -77,7 +77,7 @@ func RunGetNat(
 		}
 		for _, iface := range ifaces.Items {
 			nat, err := client.GetNat(ctx, iface.ID)
-			if err != nil && nat.Status.Code == 0 {
+			if err != nil {
 				return fmt.Errorf("error getting nat: %w", err)
 			}
 			natList.Items = append(natList.Items, *nat)
@@ -87,7 +87,7 @@ func RunGetNat(
 	}
 
 	nat, err := client.GetNat(ctx, opts.InterfaceID)
-	if err != nil && nat.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error getting nat: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/get_version.go
+++ b/cli/dpservice-cli/cmd/get_version.go
@@ -72,7 +72,7 @@ func RunGetVersion(
 			ClientVersion: util.BuildVersion,
 		},
 	})
-	if err != nil && svcVersion.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error getting version: %w", err)
 	}
 	return rendererFactory.RenderObject("", os.Stdout, svcVersion)

--- a/cli/dpservice-cli/cmd/get_vni.go
+++ b/cli/dpservice-cli/cmd/get_vni.go
@@ -74,7 +74,7 @@ func RunGetVni(
 	defer DpdkClose(cleanup)
 
 	vni, err := client.GetVni(ctx, opts.VNI, opts.VniType)
-	if err != nil && vni.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error getting vni: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/init.go
+++ b/cli/dpservice-cli/cmd/init.go
@@ -78,7 +78,7 @@ func RunInit(
 	}
 	// else initialize and show uuid
 	init, err := client.Initialize(ctx)
-	if err != nil && res.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error initializing: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/list_firewall_rules.go
+++ b/cli/dpservice-cli/cmd/list_firewall_rules.go
@@ -75,13 +75,13 @@ func RunListFirewallRules(
 	}
 	if opts.InterfaceID == "" {
 		ifaces, err := client.ListInterfaces(ctx)
-		if err != nil && ifaces.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error listing interfaces: %w", err)
 		}
 
 		for _, iface := range ifaces.Items {
 			fwrule, err := client.ListFirewallRules(ctx, iface.ID)
-			if err != nil && fwrule.Status.Code == 0 {
+			if err != nil {
 				return fmt.Errorf("error getting firewall rules: %w", err)
 			}
 			fwruleList.Items = append(fwruleList.Items, fwrule.Items...)

--- a/cli/dpservice-cli/cmd/list_loadbalancer_prefixes.go
+++ b/cli/dpservice-cli/cmd/list_loadbalancer_prefixes.go
@@ -76,13 +76,13 @@ func RunListLoadBalancerPrefixes(
 	}
 	if opts.InterfaceID == "" {
 		ifaces, err := client.ListInterfaces(ctx)
-		if err != nil && ifaces.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error listing interfaces: %w", err)
 		}
 
 		for _, iface := range ifaces.Items {
 			prefixes, err := client.ListLoadBalancerPrefixes(ctx, iface.ID)
-			if err != nil && prefixes.Status.Code == 0 {
+			if err != nil {
 				return fmt.Errorf("error getting loadbalancer prefixes: %w", err)
 			}
 			for id := range prefixes.Items {

--- a/cli/dpservice-cli/cmd/list_loadbalancer_targets.go
+++ b/cli/dpservice-cli/cmd/list_loadbalancer_targets.go
@@ -75,7 +75,7 @@ func RunListLoadBalancerTargets(
 	defer DpdkClose(cleanup)
 
 	lbtargets, err := client.ListLoadBalancerTargets(ctx, opts.LoadBalancerID)
-	if err != nil && lbtargets.Status.Code == 0 {
+	if err != nil {
 		return fmt.Errorf("error listing loadbalancer targets: %w", err)
 	}
 

--- a/cli/dpservice-cli/cmd/list_nats.go
+++ b/cli/dpservice-cli/cmd/list_nats.go
@@ -25,7 +25,7 @@ func ListNats(dpdkClientFactory DPDKClientFactory, rendererFactory RendererFacto
 	cmd := &cobra.Command{
 		Use:     "nats <--nat-ip> <--nat-type>",
 		Short:   "List local/neighbor/both nats with selected IP",
-		Example: "dpservice-cli list nats --nat-ip=10.20.30.40 --info-type=local",
+		Example: "dpservice-cli list nats --nat-ip=10.20.30.40 --nat-type=local",
 		Aliases: NatAliases,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/dpservice-cli/cmd/list_prefixes.go
+++ b/cli/dpservice-cli/cmd/list_prefixes.go
@@ -75,13 +75,13 @@ func RunListPrefixes(
 	}
 	if opts.InterfaceID == "" {
 		ifaces, err := client.ListInterfaces(ctx)
-		if err != nil && ifaces.Status.Code == 0 {
+		if err != nil {
 			return fmt.Errorf("error listing interfaces: %w", err)
 		}
 
 		for _, iface := range ifaces.Items {
 			prefixes, err := client.ListPrefixes(ctx, iface.ID)
-			if err != nil && prefixes.Status.Code == 0 {
+			if err != nil {
 				return fmt.Errorf("error getting prefixes: %w", err)
 			}
 			for id := range prefixes.Items {

--- a/cli/dpservice-cli/main.go
+++ b/cli/dpservice-cli/main.go
@@ -25,10 +25,11 @@ func main() {
 		}
 		// check if it is Server side error
 		if err.Error() == strconv.Itoa(errors.SERVER_ERROR) || strings.Contains(err.Error(), "error code") {
+			fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
 			os.Exit(errors.SERVER_ERROR)
 		}
 		// else it is Client side error
-		fmt.Fprintf(os.Stderr, "Error running command: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Client error: %v\n", err)
 		os.Exit(errors.CLIENT_ERROR)
 	}
 }


### PR DESCRIPTION
Unify error handling accross all commands

- change in dpservice-go library: unified the return values of gRPC functions
- this fixes #639; empty struct is now always returned and accessing Status.Code field doesn't crash dpservice-cli
- changes in dpservice-cli: removed checking for Status.Code as it is handled by error value
- removed the check of Status.Code from RenderList(), Status is checked before, errorous Lists are not rendered and error is returned

Fixes #639