### PR TITLE
Make TAP devices usable in normal traffic scenarios

### DIFF
--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -196,6 +196,12 @@ struct dp_port *dp_get_port_by_pf_index(uint16_t index)
 	return index < RTE_DIM(_dp_pf_ports) ? _dp_pf_ports[index] : NULL;
 }
 
+static __rte_always_inline
+bool dp_conf_is_tap(void)
+{
+	return dp_conf_get_nic_type() == DP_CONF_NIC_TYPE_TAP;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -197,7 +197,7 @@ struct dp_port *dp_get_port_by_pf_index(uint16_t index)
 }
 
 static __rte_always_inline
-bool dp_conf_is_tap(void)
+bool dp_conf_is_tap_mode(void)
 {
 	return dp_conf_get_nic_type() == DP_CONF_NIC_TYPE_TAP;
 }

--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -268,8 +268,7 @@ void dp_nat_chg_ip(struct dp_flow *df, struct rte_ipv4_hdr *ipv4_hdr,
 {
 	struct rte_udp_hdr *udp_hdr;
 	struct rte_tcp_hdr *tcp_hdr;
-	struct dp_port *in_port = dp_get_in_port(m);
-	bool is_tap = dp_conf_is_tap();
+	bool is_tap = dp_conf_is_tap_mode();
 
 	ipv4_hdr->hdr_checksum = 0;
 	m->ol_flags |= RTE_MBUF_F_TX_IPV4;

--- a/src/dp_netlink.c
+++ b/src/dp_netlink.c
@@ -13,6 +13,7 @@
 #include "dp_log.h"
 #include "dp_netlink.h"
 #include "dp_util.h"
+#include "dp_port.h"
 
 static int dp_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *neigh,
 						 const struct rte_ether_addr *own_mac)
@@ -33,6 +34,9 @@ static int dp_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *
 				if (rt_attr->rta_type == NDA_LLADDR)
 					memcpy(&neigh->addr_bytes, RTA_DATA(rt_attr), sizeof(neigh->addr_bytes));
 			}
+			// If it is a tap device, we make an exception with own MAC address check. FeBOX case
+			if (dp_conf_is_tap_mode())
+				return DP_OK;
 			if (!DP_MAC_EQUAL(own_mac, neigh))
 				return DP_OK;
 		}


### PR DESCRIPTION
Make TAP devices usable in normal traffic scenarios and not only pytest based test scenarios where MAC addresses and checksums can be ignored if not directly effecting the testing scenario.