### PR TITLE
Helper environment variables for tools in container

### DIFF
--- a/cli/dpservice-cli/cmd/common.go
+++ b/cli/dpservice-cli/cmd/common.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"os"
 	"strconv"
 	"time"
 
@@ -34,7 +35,11 @@ type DPDKClientOptions struct {
 }
 
 func (o *DPDKClientOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.Address, "address", "localhost:1337", "dpservice address.")
+	grpcPort := os.Getenv("DP_GRPC_PORT")
+	if grpcPort == "" {
+		grpcPort = "1337"
+	}
+	fs.StringVar(&o.Address, "address", "localhost:"+grpcPort, "dpservice address (overrides DP_GRPC_PORT).")
 	fs.DurationVar(&o.ConnectTimeout, "connect-timeout", 4*time.Second, "Timeout to connect to the dpservice.")
 }
 

--- a/docs/deployment/help_dpservice-dump.md
+++ b/docs/deployment/help_dpservice-dump.md
@@ -4,7 +4,7 @@
 |--------|----------|-------------|---------|
 | -h, --help | None | display this help and exit |  |
 | -v, --version | None | display version and exit |  |
-| --file-prefix | PREFIX | prefix for hugepage filenames |  |
+| --file-prefix | PREFIX | prefix for hugepage filenames (overrides DP_FILE_PREFIX) |  |
 | --drops | None | show dropped packets |  |
 | --nodes | REGEX | show graph node traversal, limit to REGEX-matched nodes (empty string for all) |  |
 | --filter | FILTER | show only packets matching a pcap-style FILTER |  |

--- a/docs/deployment/help_dpservice-inspect.md
+++ b/docs/deployment/help_dpservice-inspect.md
@@ -4,7 +4,7 @@
 |--------|----------|-------------|---------|
 | -h, --help | None | display this help and exit |  |
 | -v, --version | None | display version and exit |  |
-| --file-prefix | PREFIX | prefix for hugepage filenames |  |
+| --file-prefix | PREFIX | prefix for hugepage filenames (overrides DP_FILE_PREFIX) |  |
 | -o, --output-format | FORMAT | format of the output | 'human' (default), 'table', 'csv' or 'json' |
 | -t, --table | NAME | hash table to choose | 'list' (default), 'conntrack', 'dnat', 'iface', 'lb', 'lb_id', 'portmap', 'portoverload', 'snat', 'vnf', 'vnf_rev' or 'vni' |
 | -s, --socket | NUMBER | NUMA socket to use |  |

--- a/tools/dump/dp_conf.json
+++ b/tools/dump/dp_conf.json
@@ -6,7 +6,7 @@
     {
       "lgopt": "file-prefix",
       "arg": "PREFIX",
-      "help": "prefix for hugepage filenames",
+      "help": "prefix for hugepage filenames (overrides DP_FILE_PREFIX)",
       "var": "eal_file_prefix",
       "type": "char",
       "array_size": 32

--- a/tools/dump/main.c
+++ b/tools/dump/main.c
@@ -377,6 +377,7 @@ static int dp_argparse_opt_filter(const char *arg)
 
 int main(int argc, char **argv)
 {
+	const char *file_prefix;
 	int ret;
 
 	switch (dp_conf_parse_args(argc, argv)) {
@@ -388,7 +389,11 @@ int main(int argc, char **argv)
 		break;
 	}
 
-	ret = dp_secondary_eal_init(dp_conf_get_eal_file_prefix());
+	file_prefix = dp_conf_get_eal_file_prefix();
+	if (!*file_prefix)
+		file_prefix = getenv("DP_FILE_PREFIX");
+
+	ret = dp_secondary_eal_init(file_prefix);
 	if (DP_FAILED(ret)) {
 		fprintf(stderr, "Cannot init EAL %s\n", dp_strerror_verbose(ret));
 		return EXIT_FAILURE;

--- a/tools/dump/opts.c
+++ b/tools/dump/opts.c
@@ -73,7 +73,7 @@ static inline void dp_argparse_help(const char *progname, FILE *outfile)
 	fprintf(outfile, "Usage: %s [options]\n"
 		" -h, --help                display this help and exit\n"
 		" -v, --version             display version and exit\n"
-		"     --file-prefix=PREFIX  prefix for hugepage filenames\n"
+		"     --file-prefix=PREFIX  prefix for hugepage filenames (overrides DP_FILE_PREFIX)\n"
 		"     --drops               show dropped packets\n"
 		"     --nodes=REGEX         show graph node traversal, limit to REGEX-matched nodes (empty string for all)\n"
 		"     --filter=FILTER       show only packets matching a pcap-style FILTER\n"

--- a/tools/inspect/dp_conf.json
+++ b/tools/inspect/dp_conf.json
@@ -6,7 +6,7 @@
     {
       "lgopt": "file-prefix",
       "arg": "PREFIX",
-      "help": "prefix for hugepage filenames",
+      "help": "prefix for hugepage filenames (overrides DP_FILE_PREFIX)",
       "var": "eal_file_prefix",
       "type": "char",
       "array_size": 32

--- a/tools/inspect/main.c
+++ b/tools/inspect/main.c
@@ -119,6 +119,7 @@ static void dp_argparse_version(void)
 int main(int argc, char **argv)
 {
 	struct dp_inspect_spec spec;
+	const char *file_prefix;
 	int ret;
 
 	switch (dp_conf_parse_args(argc, argv)) {
@@ -130,7 +131,11 @@ int main(int argc, char **argv)
 		break;
 	}
 
-	ret = dp_secondary_eal_init(dp_conf_get_eal_file_prefix());
+	file_prefix = dp_conf_get_eal_file_prefix();
+	if (!*file_prefix)
+		file_prefix = getenv("DP_FILE_PREFIX");
+
+	ret = dp_secondary_eal_init(file_prefix);
 	if (DP_FAILED(ret)) {
 		fprintf(stderr, "Cannot init EAL %s\n", dp_strerror_verbose(ret));
 		return EXIT_FAILURE;

--- a/tools/inspect/opts.c
+++ b/tools/inspect/opts.c
@@ -105,7 +105,7 @@ static inline void dp_argparse_help(const char *progname, FILE *outfile)
 	fprintf(outfile, "Usage: %s [options]\n"
 		" -h, --help                  display this help and exit\n"
 		" -v, --version               display version and exit\n"
-		"     --file-prefix=PREFIX    prefix for hugepage filenames\n"
+		"     --file-prefix=PREFIX    prefix for hugepage filenames (overrides DP_FILE_PREFIX)\n"
 		" -o, --output-format=FORMAT  format of the output: 'human' (default), 'table', 'csv' or 'json'\n"
 		" -t, --table=NAME            hash table to choose: 'list' (default), 'conntrack', 'dnat', 'iface', 'lb', 'lb_id', 'portmap', 'portoverload', 'snat', 'vnf', 'vnf_rev' or 'vni'\n"
 		" -s, --socket=NUMBER         NUMA socket to use\n"


### PR DESCRIPTION
Previous commit(s) introduced the ability to specify a different gRPC port and DPDK file-prefix for all tools.

But when dpservice is ran as a pod, these values are defined in the YAML. It is then a usability hurdle to specify these on the command line all the time while using dpservice tooling. 

This PR simply creates environment variables that can be set from the pod YAML.