### PR TITLE
Implement a gRPC health service

### DIFF
--- a/config/default/dp-service.yaml
+++ b/config/default/dp-service.yaml
@@ -57,11 +57,9 @@ spec:
         - mountPath: /var/run/dpdk/rte/
           name: socket-dir
         livenessProbe:
-          exec:
-            command:
-            - dpservice-cli
-            - get
-            - init
+          grpc:
+            port: 1337
+            service: ""
           initialDelaySeconds: 10
           periodSeconds: 10
       - name: prometheus-agent

--- a/include/grpc/dp_grpc_health.h
+++ b/include/grpc/dp_grpc_health.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __INCLUDE_DP_GRPC_HEALTH_H__
+#define __INCLUDE_DP_GRPC_HEALTH_H__
+
+#include "../proto/health.grpc.pb.h"
+#include <mutex>
+#include <condition_variable>
+
+class HealthService final : public grpc::health::v1::Health::Service {
+private:
+	std::mutex status_mutex_;
+	std::condition_variable status_condition_;
+	grpc::health::v1::HealthCheckResponse::ServingStatus status_ = grpc::health::v1::HealthCheckResponse::NOT_SERVING;
+
+public:
+	void SetServingStatus(grpc::health::v1::HealthCheckResponse::ServingStatus newStatus);
+	grpc::Status Check(grpc::ServerContext* context, const grpc::health::v1::HealthCheckRequest* request,
+					   grpc::health::v1::HealthCheckResponse* response);
+	grpc::Status Watch(grpc::ServerContext* context, const grpc::health::v1::HealthCheckRequest* request,
+                       grpc::ServerWriter<grpc::health::v1::HealthCheckResponse>* writer);
+};
+
+#endif

--- a/include/grpc/dp_grpc_service.h
+++ b/include/grpc/dp_grpc_service.h
@@ -4,6 +4,8 @@
 #ifndef __INCLUDE_DP_GRPC_SERVICE_H__
 #define __INCLUDE_DP_GRPC_SERVICE_H__
 
+#ifdef __cplusplus
+
 #include "../proto/dpdk.grpc.pb.h"
 
 #include <grpc/grpc.h>
@@ -12,6 +14,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 #include <uuid/uuid.h>
+
+#include "grpc/dp_grpc_health.h"
 
 #define DP_UUID_SIZE 37
 
@@ -29,6 +33,7 @@ private:
 	uuid_t binuuid;
 	char* uuid;
 	bool initialized = false;
+	std::unique_ptr<HealthService> health_service_;
 
 	void HandleRpcs();
 
@@ -42,6 +47,12 @@ public:
 	void SetInitStatus(bool status);
 	bool IsInitialized();
 	ServerCompletionQueue* GetCq() { return cq_.get(); }
+
+	void setHealthy(bool state);
 };
+
+#else  // not __cplusplus
+void dp_grpc_service_set_healthy(bool state);
+#endif
 
 #endif

--- a/proto/health.proto
+++ b/proto/health.proto
@@ -1,0 +1,24 @@
+// taken from https://grpc.github.io/grpc/cpp/md_doc_health-checking.html
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+	string service = 1;
+}
+
+message HealthCheckResponse {
+	enum ServingStatus {
+		UNKNOWN = 0;
+		SERVING = 1;
+		NOT_SERVING = 2;
+		SERVICE_UNKNOWN = 3;
+	}
+	ServingStatus status = 1;
+}
+
+service Health {
+	rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+	rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/proto/meson.build
+++ b/proto/meson.build
@@ -13,3 +13,19 @@ grpc_generated = custom_target(
 	install : true,
 	install_dir : meson.source_root() + '/' + 'proto'
 )
+
+grpc_health_generated = custom_target(
+  'healthservice_generated',
+  input: ['health.proto'],
+  output: ['@BASENAME@.pb.h', '@BASENAME@.pb.cc', '@BASENAME@.grpc.pb.h', '@BASENAME@.grpc.pb.cc'],
+  command: [
+    protoc,
+    '--plugin=protoc-gen-grpc=' + grpc_cpp.path(),
+    '--proto_path=@CURRENT_SOURCE_DIR@',
+    '--cpp_out=@OUTDIR@',
+    '--grpc_out=@OUTDIR@',
+    '@INPUT@'
+  ],
+  install : true,
+  install_dir : meson.source_root() + '/' + 'proto'
+)

--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -10,6 +10,7 @@
 #include "dp_mbuf_dyn.h"
 #include "dp_timers.h"
 #include "dp_util.h"
+#include "grpc/dp_grpc_service.h"
 #include "grpc/dp_grpc_thread.h"
 
 static volatile bool force_quit;
@@ -88,6 +89,7 @@ void dp_force_quit(void)
 {
 	DPS_LOG_INFO("Stopping service...");
 	force_quit = true;
+	dp_grpc_service_set_healthy(false);
 }
 
 

--- a/src/grpc/dp_grpc_health.cpp
+++ b/src/grpc/dp_grpc_health.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "grpc/dp_grpc_health.h"
+#include "../proto/dpdk.grpc.pb.h"
+
+void HealthService::SetServingStatus(grpc::health::v1::HealthCheckResponse::ServingStatus newStatus)
+{
+	std::lock_guard<std::mutex> lock(status_mutex_);
+	if (newStatus != status_) {
+		status_ = newStatus;
+		status_condition_.notify_all();
+	}
+}
+
+grpc::Status HealthService::Check(grpc::ServerContext* /*context*/, const grpc::health::v1::HealthCheckRequest* request,
+								  grpc::health::v1::HealthCheckResponse* response)
+{
+	if (!request->service().empty() && request->service() != dpdkironcore::v1::DPDKironcore::service_full_name()) {
+		response->set_status(grpc::health::v1::HealthCheckResponse::SERVICE_UNKNOWN);
+	} else {
+		std::lock_guard<std::mutex> lock(status_mutex_);
+		response->set_status(status_);
+	}
+	return grpc::Status::OK;
+}
+
+grpc::Status HealthService::Watch(grpc::ServerContext* context, const grpc::health::v1::HealthCheckRequest* request,
+								  grpc::ServerWriter<grpc::health::v1::HealthCheckResponse>* writer)
+{
+	if (!request->service().empty() && request->service() != dpdkironcore::v1::DPDKironcore::service_full_name())
+        return grpc::Status(grpc::StatusCode::NOT_FOUND, "Service not found");
+
+	grpc::health::v1::HealthCheckResponse response;
+
+	// return the current status first
+	{
+		std::lock_guard<std::mutex> lock(status_mutex_);
+		response.set_status(status_);
+	}
+	writer->Write(response);
+
+	// only report changes after that
+	while (!context->IsCancelled()) {
+		{
+			std::unique_lock<std::mutex> lock(status_mutex_);
+			while (status_ == response.status() && !context->IsCancelled())
+				status_condition_.wait(lock);
+			if (context->IsCancelled())
+				break;
+			response.set_status(status_);
+		}
+		writer->Write(response);
+	}
+
+	return grpc::Status(grpc::StatusCode::CANCELLED, "Client disconnected");
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 dp_sources = [
   'grpc/dp_async_grpc.cpp',
   'grpc/dp_grpc_conv.cpp',
+  'grpc/dp_grpc_health.cpp',
   'grpc/dp_grpc_impl.c',
   'grpc/dp_grpc_responder.c',
   'grpc/dp_grpc_service.cpp',
@@ -75,7 +76,7 @@ if get_option('enable_virtual_services')
 endif
 
 exe = executable('dpservice-bin',
-  sources: [ dp_sources, grpc_generated, version_h ],
+  sources: [ dp_sources, grpc_generated, grpc_health_generated, version_h ],
   include_directories: [ includes ],
   dependencies: [ dpdk_dep, proto_dep, grpc_dep, grpccpp_dep, thread_dep, libuuid_dep, pcap_dep ]
 )


### PR DESCRIPTION
Fixes #653 

I implemented the service "from scratch" because I could not find a built-in service (unlike golang has). But it's not that big in the end.

One difference to golng implementation - golang uses TCP keepalive (packets of length 0), I was unable to find such option here (without overriding some methods to set it for all sockets by calling `setsockopt`), so I used `GRPC_ARG_KEEPALIVE_TIME_MS`. This is layer 7 though, so instead of two 0-length packets, this uses two packets of length 17 and an additional ACK.
I chose the same keepalive interval as observed by TCPdump for golang implementation, 15s.

This implementation uses `std::mutex` and `std::condition_variable` to prevent periodic sending of current status, simply only send a "change" in the value of status of the service (that's what the lock+cv is used for).