### PR TITLE
dpservice-cli: fix for pytest unable to detect errors

### DIFF
--- a/cli/dpservice-cli/go.mod
+++ b/cli/dpservice-cli/go.mod
@@ -17,7 +17,6 @@ require (
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -26,7 +25,6 @@ require (
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect

--- a/cli/dpservice-cli/go.sum
+++ b/cli/dpservice-cli/go.sum
@@ -3,7 +3,6 @@ github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -42,7 +41,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=

--- a/cli/dpservice-cli/main.go
+++ b/cli/dpservice-cli/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/ironcore-dev/dpservice/cli/dpservice-cli/cmd"
@@ -18,18 +17,49 @@ var version = "unknown"
 
 func main() {
 	util.BuildVersion = version
-	if err := cmd.Command().Execute(); err != nil {
+	output := manualParseOutput()
+	err := cmd.Command().Execute()
+	if err != nil {
+		//fmt.Println(cmd.Output)
 		if strings.Contains(err.Error(), "Unimplemented desc") {
-			fmt.Println("Error in gRPC, client and server are probably using different proto version")
+			err := cmd.RenderError(os.Stdout, fmt.Errorf("error in gRPC, client and server are probably using different proto version"), output)
+			if err != nil {
+				fmt.Printf("failed to render error: %v", err)
+			}
 			os.Exit(errors.SERVER_ERROR)
 		}
 		// check if it is Server side error
-		if err.Error() == strconv.Itoa(errors.SERVER_ERROR) || strings.Contains(err.Error(), "error code") {
-			fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
+		if strings.Contains(err.Error(), "error code") {
+			err := cmd.RenderError(os.Stdout, err, output)
+			if err != nil {
+				fmt.Printf("failed to render error: %v", err)
+			}
 			os.Exit(errors.SERVER_ERROR)
 		}
 		// else it is Client side error
-		fmt.Fprintf(os.Stderr, "Client error: %v\n", err)
+		err := cmd.RenderError(os.Stdout, err, output)
+		if err != nil {
+			fmt.Printf("failed to render error: %v", err)
+		}
 		os.Exit(errors.CLIENT_ERROR)
 	}
+}
+
+// manually parses output flag
+// needed because if command execution fails, flags set inside command are not parsed
+func manualParseOutput() string {
+	args := os.Args[1:]
+
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--output" || args[i] == "-o" {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		} else if strings.HasPrefix(args[i], "--output=") {
+			return strings.SplitN(args[i], "=", 2)[1]
+		} else if strings.HasPrefix(args[i], "-o=") {
+			return strings.SplitN(args[i], "=", 2)[1]
+		}
+	}
+	return "name"
 }

--- a/go/dpservice-go/client/client.go
+++ b/go/dpservice-go/client/client.go
@@ -886,7 +886,7 @@ func (c *client) ListNats(ctx context.Context, natIP *netip.Addr, natType string
 		} else if natEntry.GetNatIp() != nil {
 			nattedIP, err = netip.ParseAddr(string(natEntry.GetNatIp().GetAddress()))
 			if err != nil {
-				return nil, fmt.Errorf("error parsing natted ip: %w", err)
+				return &api.NatList{}, fmt.Errorf("error parsing natted ip: %w", err)
 			}
 			nat.Spec.NatIP = &nattedIP
 			nat.Kind = api.NatKind


### PR DESCRIPTION
# Proposed Changes

- Changes in error rendering: errors that are returned to main are parsed and rendered based on output flag, if json output was requested, error will now be rendered as json (using JsonError struct similar to other objects)
- Pytest was updated to reflect new output formats
- Pytest now also always checks for response from grpc client  
- Error object also includes "source" field that indicates where the error originated (client, grpc, server)

Fixes #650