### PR TITLE
Remove soon to be obsolete __rte_packed

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -62,7 +62,7 @@ enum dp_flow_nat_type {
 	DP_FLOW_LB_TYPE_LOCAL_NEIGH_TRAFFIC,
 	DP_FLOW_LB_TYPE_RECIRC,
 	DP_FLOW_LB_TYPE_FORWARD,
-} __rte_packed;
+} __attribute__((__packed__));
 
 enum dp_flow_tcp_state {
 	DP_FLOW_TCP_STATE_NONE,
@@ -84,7 +84,7 @@ struct flow_key {
 		uint16_t type_src; /* ICMP */
 	} src;
 	uint32_t vni;
-} __rte_packed;
+} __attribute__((__packed__));
 static_assert(sizeof(((struct flow_key *)0)->vnf_type) == 1,
 			  "enum dp_vnf_type is unnecessarily big");
 

--- a/include/dp_ipaddr.h
+++ b/include/dp_ipaddr.h
@@ -36,11 +36,11 @@ union dp_ipv6 {
 		rte_be64_t	_suffix;
 	};
 	const uint8_t	bytes[DP_IPV6_ADDR_SIZE];
-	struct __rte_packed {
+	struct __attribute__((__packed__)) {
 		uint8_t		prefix[DP_IPV6_ADDR_SIZE - sizeof(rte_be32_t)];
 		rte_be32_t	ipv4;
 	} _nat64;
-	struct __rte_packed {
+	struct __attribute__((__packed__)) {
 		rte_be64_t	prefix;
 		rte_be16_t	kernel;
 		uint8_t		flags;
@@ -175,7 +175,7 @@ struct dp_ip_address {
 		bool				_is_v6;
 		const bool			is_v6;
 	};
-} __rte_packed;
+} __attribute__((__packed__));
 
 static __rte_always_inline
 int dp_ipv6_from_ipaddr(union dp_ipv6 *ipv6, const struct dp_ip_address *addr)

--- a/include/dp_lb.h
+++ b/include/dp_lb.h
@@ -21,7 +21,7 @@ extern "C" {
 struct lb_key {
 	uint32_t				vni;
 	struct dp_ip_address	ip;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct lb_port {
 	uint8_t			protocol;

--- a/include/dp_mbuf_dyn.h
+++ b/include/dp_mbuf_dyn.h
@@ -24,18 +24,18 @@ extern "C" {
 enum dp_flow_type {
 	DP_FLOW_WEST_EAST,
 	DP_FLOW_SOUTH_NORTH,
-} __rte_packed;
+} __attribute__((__packed__));
 
 enum dp_pkt_offload_state {
 	DP_FLOW_NON_OFFLOAD,
 	DP_FLOW_OFFLOAD_INSTALL,
 	DP_FLOW_OFFLOADED,
-} __rte_packed;
+} __attribute__((__packed__));
 
 enum dp_flow_dir {
 	DP_FLOW_DIR_ORG,
 	DP_FLOW_DIR_REPLY,
-} __rte_packed;
+} __attribute__((__packed__));
 #define DP_FLOW_DIR_CAPACITY 2
 
 enum dp_nat_type {
@@ -46,7 +46,7 @@ enum dp_nat_type {
 	DP_LB_RECIRC,
 	DP_NAT_64_CHG_SRC_IP,
 	DP_NAT_64_CHG_DST_IP,
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dp_flow {
 	enum dp_flow_type			flow_type : 1;

--- a/include/dp_nat.h
+++ b/include/dp_nat.h
@@ -26,7 +26,7 @@ extern "C" {
 struct nat_key {
 	uint32_t	ip;
 	uint32_t	vni;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct nat_entry {
 	uint32_t		nat_ip;
@@ -54,7 +54,7 @@ struct netnat_portmap_key {
 	uint32_t				vni;
 	struct dp_ip_address	src_ip;
 	uint16_t				iface_src_port;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct netnat_portmap_data {
 	uint32_t	nat_ip;
@@ -68,7 +68,7 @@ struct netnat_portoverload_tbl_key {
 	uint32_t dst_ip;
 	uint16_t dst_port;
 	uint8_t	l4_type;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct nat_check_result {
 	bool	is_vip_natted;

--- a/include/dp_vnf.h
+++ b/include/dp_vnf.h
@@ -29,7 +29,7 @@ enum dp_vnf_type {
 	DP_VNF_TYPE_VIP,
 	DP_VNF_TYPE_NAT,
 	DP_VNF_TYPE_INTERFACE_IP,
-} __rte_packed;  // for 'struct dp_flow' and 'struct flow_key'
+} __attribute__((__packed__));  // for 'struct dp_flow' and 'struct flow_key'
 
 struct dp_vnf_prefix {
 	struct dp_ip_address	ol;

--- a/include/dp_vni.h
+++ b/include/dp_vni.h
@@ -30,7 +30,7 @@ extern struct rte_hash *vni_handle_tbl;
 
 struct dp_vni_key {
 	uint32_t vni;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dp_vni_data {
 	struct rte_rib	*ipv4[DP_NB_SOCKETS];

--- a/include/protocols/dp_dhcpv6.h
+++ b/include/protocols/dp_dhcpv6.h
@@ -67,39 +67,39 @@ struct dhcpv6_packet {
 	uint8_t msg_type;
 	uint8_t transaction_id[3];
 	uint8_t options[];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_option {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	uint8_t data[];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_dns_servers {
 	uint16_t opt_code;
 	uint16_t opt_len;
 	struct in6_addr dns_server_addrs[]; // Array of IPv6 addresses
-} __rte_packed;
+} __attribute__((__packed__));
 
 // client id can be of any type, this is the maximum size allowed
 struct dhcpv6_opt_client_id {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	uint8_t id[128];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_ia_na {
 	rte_be32_t iaid;
 	rte_be32_t t1;
 	rte_be32_t t2;
 	struct dhcpv6_option options[];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_ia_na {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	struct dhcpv6_ia_na ia_na;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_vnd_cls {
 	rte_be16_t op_code;
@@ -107,33 +107,33 @@ struct dhcpv6_opt_vnd_cls {
 	rte_be32_t entp_id;
 	rte_be16_t opq_data_len;
 	uint8_t opq_data[];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_usr_cls {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	rte_be16_t sub_opt_len;
 	uint8_t sub_opt_data[];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_ia_addr {
 	uint8_t  ipv6[16];
 	rte_be32_t preferred_lifetime;
 	rte_be32_t valid_lifetime;
 	struct dhcpv6_option options[];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_ia_addr {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	struct dhcpv6_ia_addr addr;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_status_code {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	rte_be16_t status;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_duid_ll {
 	rte_be16_t type;
@@ -154,31 +154,31 @@ struct dhcpv6_ia_addr_status {
 	rte_be32_t preferred_lifetime;
 	rte_be32_t valid_lifetime;
 	struct dhcpv6_opt_status_code options[1];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_ia_addr_status {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	struct dhcpv6_ia_addr_status addr;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_ia_na_single_addr_status {
 	rte_be32_t iaid;
 	rte_be32_t t1;
 	rte_be32_t t2;
 	struct dhcpv6_opt_ia_addr_status options[1];
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_ia_na_single_addr_status {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	struct dhcpv6_ia_na_single_addr_status ia_na;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct dhcpv6_opt_boot_file_url {
 	rte_be16_t op_code;
 	rte_be16_t op_len;
 	char boot_file_url[DHCPV6_BOOT_FILE_BUF_LEN];
-} __rte_packed;
+} __attribute__((__packed__));
 
 #endif

--- a/src/dp_virtsvc.c
+++ b/src/dp_virtsvc.c
@@ -37,7 +37,7 @@ struct dp_virtsvc_conn_key {
 	uint16_t vf_port_id;
 	rte_be16_t vf_l4_port;
 	rte_be32_t vf_ip;
-} __rte_packed;
+} __attribute__((__packed__));
 
 static struct dp_virtsvc *dp_virtservices;
 static struct dp_virtsvc *dp_virtservices_end;


### PR DESCRIPTION
DPDK 25 obsoleted `__rte_packed` in favor of a (more compatible with MSVC) pair of `__rte_packed_begin` and `__rte_packed_end` as per [this commit](https://github.com/DPDK/dpdk/commit/154303b06ab29e040000f0536961601d952e2974).

As a proposal of a solution I created this PR. The other solution would be to use both new macros, but they look worse than this solution, so basically this draft is a discussion PR.