### PR TITLE
Remove pytest packet noise, fix HW test side-effects

### DIFF
--- a/test/local/helpers.py
+++ b/test/local/helpers.py
@@ -88,9 +88,10 @@ def run_command(cmd):
 	subprocess.check_output(shlex.split(cmd))
 
 def interface_init(interface, enabled=True):
+	if interface.startswith(pf_tap_pattern) or interface.startswith(vf_tap_pattern):
+		run_command(f"sysctl net.ipv6.conf.{interface}.disable_ipv6=1")
 	if enabled:
 		run_command(f"ip link set dev {interface} up")
-	run_command(f"ip addr flush dev {interface}")
 
 
 def _validate_length(pkt, original_packet):


### PR DESCRIPTION
While using `--graphtrace` in dpservice PyTest suite, I noticed I am getting unwanted packets:
```
2025-05-29 23:29:07.369 3(worker) D GRAPH: drop        #0:   1 >> DROP          : 22:22:22:22:22:00 -> 33:33:00:00:00:16 / 0:0:0:0:0:0:0:0 -> ff02:0:0:0:0:0:0:16
```
This seems to be some IPv6 autoconfiguration/nd stuff. But when testing we do not even need the kernel IPv6 stack, so the best solution seemed to be just disabling it altogether.

That would of course break your host configuration in real HW tests, so I changed the code to only do it for TAP devices. This also fixed an old bug where HW tests removed the IPv6 address from the real HW card.
