### PR TITLE
Introduce DP_SUCCESS() macro

### DIFF
--- a/docs/development/style_guide.md
+++ b/docs/development/style_guide.md
@@ -85,6 +85,7 @@ int caller()
   return DP_OK;
 }
 ```
+> There is also a `DP_SUCCESS(ret)` for the unlikely inverse test, e.g. `if (DP_SUCCESS(rte_hash_lookup(...)))`.
 
 ### Boolean-like calls
 If a function returns `0` for failure and a non-zero for success, use this pattern:

--- a/include/dp_error.h
+++ b/include/dp_error.h
@@ -18,6 +18,8 @@ extern "C" {
 // NOTICE: these can be used directly with a function call, do not use RET multiple times
 #define DP_FAILED(RET) \
 	((RET) < 0)
+#define DP_SUCCESS(RET) \
+	(!DP_FAILED(RET))
 #define DP_FAILED_LOG(RET, LOGGER, ...) \
 	(DP_FAILED(RET) ? LOGGER(__VA_ARGS__), true : false)
 

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -113,7 +113,7 @@ static __rte_always_inline void dp_mark_vnf_type(struct dp_flow *df, const struc
 			key->vnf_type = df->vnf_type;
 		else
 			key->vnf_type = DP_VNF_TYPE_UNDEFINED;
-	} else if (!DP_FAILED(dp_ipv6_from_ipaddr(&dst_ipv6, &key->l3_dst))) {
+	} else if (DP_SUCCESS(dp_ipv6_from_ipaddr(&dst_ipv6, &key->l3_dst))) {
 		// assuming key->l3_src is also IPv6 (no IPv4<->IPv6 packets exist)
 		if (dp_is_ipv6_nat64(&dst_ipv6))
 			key->vnf_type = DP_VNF_TYPE_NAT;

--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -71,7 +71,7 @@ int dp_create_lb(struct dpgrpc_lb *lb, const union dp_ipv6 *ul_ip)
 	lb_key.vni = lb->vni;
 	dp_copy_ipaddr(&lb_key.ip, &lb->addr);
 
-	if (!DP_FAILED(rte_hash_lookup(lb_table, &lb_key)))
+	if (DP_SUCCESS(rte_hash_lookup(lb_table, &lb_key)))
 		return DP_GRPC_ERR_ALREADY_EXISTS;
 
 	lb_val = rte_zmalloc("lb_val", sizeof(struct lb_value), RTE_CACHE_LINE_SIZE);
@@ -203,7 +203,7 @@ bool dp_is_ip_lb(struct dp_flow *df, uint32_t vni)
 	else
 		return false;
 
-	return !DP_FAILED(rte_hash_lookup(lb_table, &lb_key));
+	return DP_SUCCESS(rte_hash_lookup(lb_table, &lb_key));
 }
 
 static bool dp_lb_is_back_ip_inserted(struct lb_value *val, const union dp_ipv6 *b_ip)

--- a/src/dp_vnf.c
+++ b/src/dp_vnf.c
@@ -130,11 +130,11 @@ int dp_add_vnf(const union dp_ipv6 *ul_addr6, enum dp_vnf_type type,
 	int ret;
 
 	ret = rte_hash_lookup_with_hash(vnf_handle_tbl, ul_addr6, hash);
-	if (ret != -ENOENT) {
-		if (!DP_FAILED(ret))
-			DPS_LOG_WARNING("Underlay address already registered", DP_LOG_IPV6(*ul_addr6));
-		else
-			DPS_LOG_ERR("VNF hash table lookup failed", DP_LOG_RET(ret));
+	if (DP_SUCCESS(ret)) {
+		DPS_LOG_WARNING("Underlay address already registered", DP_LOG_IPV6(*ul_addr6));
+		return DP_ERROR;
+	} else if (ret != -ENOENT) {
+		DPS_LOG_ERR("VNF hash table lookup failed", DP_LOG_RET(ret));
 		return DP_ERROR;
 	}
 

--- a/src/nodes/rx_node.c
+++ b/src/nodes/rx_node.c
@@ -53,7 +53,7 @@ static uint64_t get_current_timestamp(void)
 		if (!port->allocated)
 			continue;
 		ret = rte_eth_read_clock(port->port_id, &timestamp);
-		if (!DP_FAILED(ret))
+		if (DP_SUCCESS(ret))
 			break;
 	}
 	return timestamp;

--- a/tools/inspect/main.c
+++ b/tools/inspect/main.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	}
 
 	ret = dp_inspect_init(dp_conf_get_table(), get_format(dp_conf_get_output_format()), &spec);
-	if (!DP_FAILED(ret)) {
+	if (DP_SUCCESS(ret)) {
 		if (!spec.table_name)
 			list_tables(dp_conf_get_output_format());
 		else


### PR DESCRIPTION
Added `DP_SUCCESS(ret)` macro as a replacement for `!DP_FAILED(ret)`. Cases with direct test of `ret == DP_OK` are untouched, as success is any non-negative integer, not only zero.

One case can actually now be written more concisely.

Fixes #695