### PR TITLE
Use ICMP type instead of identifier in snat portmap

### DIFF
--- a/src/dp_nat.c
+++ b/src/dp_nat.c
@@ -728,7 +728,7 @@ int dp_allocate_network_snat_port(struct snat_data *snat_data, struct dp_flow *d
 		return DP_ERROR;
 
 	if (df->l4_type == IPPROTO_ICMP || df->l4_type == IPPROTO_ICMPV6)
-		portmap_key.iface_src_port = ntohs(df->l4_info.icmp_field.icmp_identifier);
+		portmap_key.iface_src_port = df->l4_info.icmp_field.icmp_type;
 	else
 		portmap_key.iface_src_port = ntohs(df->l4_info.trans_port.src_port);
 

--- a/test/local/test_vf_to_pf.py
+++ b/test/local/test_vf_to_pf.py
@@ -25,7 +25,6 @@ def reply_icmp_pkt_from_vm1_identifier_check(nat_ul_ipv6):
 		f"Bad ICMP request (src ip: {src_ip})"
 
 	icmp_id_1 = pkt[ICMP].id
-	print(f"icmp_id_1: {icmp_id_1}")
 	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
 				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
@@ -39,9 +38,8 @@ def reply_icmp_pkt_from_vm1_identifier_check(nat_ul_ipv6):
 		f"Bad ICMP request (src ip: {src_ip})"
 
 	icmp_id_2 = pkt[ICMP].id
-	print(f"icmp_id_2: {icmp_id_2}")
-	assert icmp_id_1 != icmp_id_2, \
-		f"Got the same ICMP identifier (icmp id 1: {icmp_id_1}, icmp id 2: {icmp_id_2})"
+	assert icmp_id_1 == icmp_id_2, \
+		f"Got different ICMP identifier (icmp id 1: {icmp_id_1}, icmp id 2: {icmp_id_2})"
 	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
 				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /


### PR DESCRIPTION
Currently portmap table entries use ICMP identifier in place of TCP/UDP source port. But it is already used as TCP/UDP destination port.

All other parts of dpservice use the same destination port replacement, but replace source port with ICMP type instead.

To easily implement #697 (dpservice HA synchronization), the ICMP type needs to be part of portmap/portoverload tables.

---
Unless I am mistaken, changing this has only one impact on current dpservice and that is the way portmap entries will be overloaded.

Currently for each ICMP flow (identifier) a new NAT portmap entry is created, thus a new NAT port is being chosen.

After this change the portmap entry will be always the same for a given VM (and ICMP type, but in practice most ICMP calls will be to Echo). This in turn will reuse already present NAT port.

This in turn can bring more flow reusal (in theory one infinitely reused flow if some VM has a PING every 25s for example), which I am not sure how good/bad it is for real-world application.