### PR TITLE
Update Dockerfile to Debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image with DPDK, etc.
-FROM --platform=${TARGETPLATFORM} debian:12-slim AS builder
+FROM --platform=${TARGETPLATFORM} debian:13-slim AS builder
 
 ARG TARGETARCH
 ARG DPDK_VER=24.11.1
@@ -108,7 +108,7 @@ RUN meson setup xtratest_build $DPSERVICE_FEATURES -Denable_tests=true && ninja 
 
 
 # Test-image to run pytest
-FROM debian:12-slim AS tester
+FROM debian:13-slim AS tester
 
 RUN apt-get update && apt-get install -y --no-install-recommends ON \
 libibverbs-dev \
@@ -149,7 +149,7 @@ ENTRYPOINT ["./runtest.py", "../build", "../xtratest_build"]
 
 
 # Deployed pod image itself
-FROM debian:12-slim AS production
+FROM debian:13-slim AS production
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ON \
 libibverbs-dev \


### PR DESCRIPTION
Fortunately Debian 13 has been marked stable a few days ago, so the easiest way to fix this is just to use it in Dockerfile. Otherwise there is no backport of rdma-core libraries to Debian 12 and updating it to unstable looks awful in Dockerfile.

Fixes #707