### PR TITLE
Feature/vf mac change func

### DIFF
--- a/include/dp_iface.h
+++ b/include/dp_iface.h
@@ -4,6 +4,8 @@
 #ifndef __INCLUDE_DP_IFACE_H__
 #define __INCLUDE_DP_IFACE_H__
 
+#include <rte_ether.h>
+#include <stdint.h>
 #include "dp_port.h"
 
 #ifdef __cplusplus
@@ -22,12 +24,6 @@ struct dp_port *dp_get_port_with_iface_id(const char iface_id[DP_IFACE_ID_MAX_LE
 int dp_setup_iface(struct dp_port *port, uint32_t vni);
 void dp_delete_iface(struct dp_port *port);
 
-
-static __rte_always_inline
-bool dp_arp_cycle_needed(const struct dp_port *port)
-{
-	return port->iface.ready && !port->iface.arp_done;
-}
 
 static __rte_always_inline
 void dp_fill_ether_hdr(struct rte_ether_hdr *ether_hdr, const struct dp_port *port, uint16_t ether_type)

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <net/if.h>
+#include <rte_ether.h>
 #include <rte_meter.h>
 #include <rte_pci.h>
 #include <rte_timer.h>
@@ -45,7 +46,7 @@ struct dp_port_iface {
 	uint32_t				nat_ip;
 	uint16_t				nat_port_range[2];
 	bool					ready;
-	bool					arp_done;
+	bool					l2_addr_received;
 	uint64_t				total_flow_rate_cap;
 	uint64_t				public_flow_rate_cap;
 	uint32_t				hostname_len;
@@ -129,6 +130,14 @@ void dp_stop_acquiring_neigh_mac(struct dp_port *port);
 int dp_set_pf_neigh_mac(uint16_t port_id, const struct rte_ether_addr *mac);
 
 int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uint64_t public_flow_rate_cap);
+
+static __rte_always_inline
+bool dp_l2_addr_needed(const struct dp_port *port)
+{
+	return port->iface.ready && !port->iface.l2_addr_received;
+}
+
+void dp_l2_addr_set(struct dp_port *port, const struct rte_ether_addr *l2_addr);
 
 static __rte_always_inline
 int dp_load_mac(struct dp_port *port)

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -126,7 +126,7 @@ int dp_stop_port(struct dp_port *port);
 
 void dp_start_acquiring_neigh_mac(struct dp_port *port);
 void dp_stop_acquiring_neigh_mac(struct dp_port *port);
-int dp_set_neigh_mac(uint16_t port_id, const struct rte_ether_addr *mac);
+int dp_set_pf_neigh_mac(uint16_t port_id, const struct rte_ether_addr *mac);
 
 int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uint64_t public_flow_rate_cap);
 

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -57,7 +57,7 @@ void send_to_all_vfs(const struct rte_mbuf *pkt, uint16_t eth_type)
 		if (eth_type == RTE_ETHER_TYPE_ARP) {
 			arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
 			rte_ether_addr_copy(&port->own_mac, &arp_hdr->arp_data.arp_sha);
-			if (dp_arp_cycle_needed(port))
+			if (dp_l2_addr_needed(port))
 				arp_hdr->arp_data.arp_tip = htonl(port->iface.cfg.own_ip);
 		}
 

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -492,13 +492,13 @@ void dp_stop_acquiring_neigh_mac(struct dp_port *port)
 	rte_timer_stop_sync(&port->neighmac_timer);
 }
 
-int dp_set_neigh_mac(uint16_t port_id, const struct rte_ether_addr *mac)
+int dp_set_pf_neigh_mac(uint16_t port_id, const struct rte_ether_addr *mac)
 {
 	struct dp_port *port;
 	char strmac[18];
 
 	port = dp_get_port_by_id(port_id);
-	if (!port) {
+	if (!port || !port->is_pf) {
 		DPS_LOG_WARNING("Cannot set neighboring router, port invalid", DP_LOG_PORTID(port_id));
 		return DP_ERROR;
 	}

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -164,7 +164,7 @@ static int dp_port_init_ethdev(struct dp_port *port, struct rte_eth_dev_info *de
 	// guess the inital VM MAC until ARP arrives
 	if (!port->is_pf) {
 		rte_ether_addr_copy(&port->own_mac, &port->neigh_mac);
-		port->iface.arp_done = false;
+		port->iface.l2_addr_received = false;
 	}
 
 	static_assert(sizeof(port->dev_name) == RTE_ETH_NAME_MAX_LEN, "Incompatible port dev_name size");
@@ -690,4 +690,11 @@ int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uin
 	port->iface.public_flow_rate_cap = public_flow_rate_cap;
 
 	return DP_OK;
+}
+
+
+void dp_l2_addr_set(struct dp_port *port, const struct rte_ether_addr *l2_addr)
+{
+	rte_ether_addr_copy(l2_addr, &port->neigh_mac);
+	port->iface.l2_addr_received = true;
 }

--- a/src/monitoring/dp_event.c
+++ b/src/monitoring/dp_event.c
@@ -151,5 +151,5 @@ void dp_process_event_neighmac_msg(struct rte_mbuf *m)
 {
 	struct dp_event_msg *neighmac_msg = rte_pktmbuf_mtod(m, struct dp_event_msg *);
 
-	dp_set_neigh_mac(neighmac_msg->event_entry.neighmac.port_id, &neighmac_msg->event_entry.neighmac.mac);
+	dp_set_pf_neigh_mac(neighmac_msg->event_entry.neighmac.port_id, &neighmac_msg->event_entry.neighmac.mac);
 }

--- a/src/nodes/arp_node.c
+++ b/src/nodes/arp_node.c
@@ -42,9 +42,8 @@ static __rte_always_inline bool arp_handled(struct rte_mbuf *m)
 	uint32_t temp_ip;
 
 	// ARP reply from VM
-	if (dp_arp_cycle_needed(port) && sender_ip == htonl(port->iface.cfg.own_ip)) {
-		rte_ether_addr_copy(&incoming_eth_hdr->src_addr, &port->neigh_mac);
-		port->iface.arp_done = true;
+	if (unlikely(dp_l2_addr_needed(port) && sender_ip == htonl(port->iface.cfg.own_ip))) {
+		dp_l2_addr_set(port, &incoming_eth_hdr->src_addr);
 		return true;
 	}
 

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -229,8 +229,8 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 
 	rte_ether_addr_copy(&incoming_eth_hdr->src_addr, &incoming_eth_hdr->dst_addr);
 	rte_ether_addr_copy(&port->own_mac, &incoming_eth_hdr->src_addr);
-	if (response_type == DHCPACK)
-		rte_ether_addr_copy(&incoming_eth_hdr->dst_addr, &port->neigh_mac);
+	if (unlikely(response_type == DHCPACK && dp_l2_addr_needed(port)))
+		dp_l2_addr_set(port, &incoming_eth_hdr->dst_addr);
 
 	incoming_ipv4_hdr->src_addr = server_ip;
 

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -76,7 +76,8 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		static_assert(sizeof(nd_msg->target) == sizeof(*gw_ip), "Incompatible IPv6 format in ND message structure");
 		if (!dp_ipv6_match((const union dp_ipv6 *)nd_msg->target, gw_ip))
 			return IPV6_ND_NEXT_DROP;
-		rte_ether_addr_copy(&req_eth_hdr->dst_addr, &port->neigh_mac);
+		if (unlikely(dp_l2_addr_needed(port)))
+			dp_l2_addr_set(port, &req_eth_hdr->dst_addr);
 		dp_copy_ipv6(&port->iface.cfg.own_ipv6, dp_get_dst_ipv6(req_ipv6_hdr));
 		req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
 		req_icmp6_hdr->icmp6_solicited = 1;

--- a/test/local/helpers.py
+++ b/test/local/helpers.py
@@ -12,7 +12,7 @@ from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, _ICMPv6
 from config import *
 
 
-def request_ip(vm):
+def request_ip(vm, src_mac=None):
 	scapy.config.conf.checkIPaddr = False
 	answer = dhcp_request(iface=vm.tap, timeout=sniff_timeout)
 	validate_checksums(answer)
@@ -34,7 +34,7 @@ def request_ip(vm):
 		assert hostname_option.decode('utf-8') == expected_hostname, \
 			f"DHCP reply does not specify the correct hostname: {hostname_option.decode('utf-8')} instead of {expected_hostname}"
 
-	pkt = (Ether(dst=answer[Ether].src) /
+	pkt = (Ether(src=src_mac, dst=answer[Ether].src) /
 		   IP(src=vm.ip, dst=answer[IP].src) /
 		   UDP(sport=68, dport=67) /
 		   BOOTP(chaddr=vm.mac) /

--- a/test/local/test_arp.py
+++ b/test/local/test_arp.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from helpers import *
 
 def test_l2_arp(prepare_ifaces):
@@ -13,3 +14,62 @@ def test_l2_arp(prepare_ifaces):
 		src_mac = received[ARP].hwsrc
 		assert src_mac == VM1.mac, \
 			f"Bad ARP response (source mac: {src_mac})"
+
+
+def vm_mac_sender():
+	pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
+		   IP(dst=VM4.ip, src=VM1.ip) /
+		   UDP(dport=1234))
+	delayed_sendp(pkt, VM1.tap)
+
+def test_l2_addr_once(request, prepare_ifaces, grpc_client):
+	if request.config.getoption("--hw"):
+		pytest.skip("Cannot test MAC address change with real hardware")
+
+	grpc_client.addinterface(VM4.name, VM4.pci, VM4.vni, VM4.ip, VM4.ipv6)
+
+	# No need to use ARP/DHCP/ND, since dpservice already "guessed" the MAC from the representor
+
+	threading.Thread(target=vm_mac_sender).start()
+	pkt = sniff_packet(VM4.tap, is_udp_pkt)
+	assert pkt[Ether].dst == VM4.mac, \
+		"Dpservice not using reprentor MAC"
+
+	# Now ARP/DHCP/ND happens, discovering the VM actually has a different MAC
+	# (can happen on newer systemd with MACAddressPolicy != 'persistent')
+	request_ip(VM4, "12:34:56:78:9a:bc")
+
+	threading.Thread(target=vm_mac_sender).start()
+	pkt = sniff_packet(VM4.tap, is_udp_pkt)
+	assert pkt[Ether].dst == "12:34:56:78:9a:bc", \
+		"Dpservice not using actual VM MAC"
+
+	# Additional ARP/DHCP/ND should not be able to change MAC again
+	request_ip(VM4)
+
+	threading.Thread(target=vm_mac_sender).start()
+	pkt = sniff_packet(VM4.tap, is_udp_pkt)
+	assert pkt[Ether].dst == "12:34:56:78:9a:bc", \
+		"Dpservice changed VM MAC"
+
+	# Now the VM gets removed and *another one* is put into its place
+	# This can have different MAC address
+	grpc_client.delinterface(VM4.name)
+	grpc_client.addinterface(VM4.name, VM4.pci, VM4.vni, VM4.ip, VM4.ipv6)
+
+	# Without ARP/DHCP/ND dpservice should try the use the old MAC
+	threading.Thread(target=vm_mac_sender).start()
+	pkt = sniff_packet(VM4.tap, is_udp_pkt)
+	assert pkt[Ether].dst == "12:34:56:78:9a:bc", \
+		"Dpservice reset VM MAC"
+
+	# Additional ARP/DHCP/ND should be able to change MAC
+	# because it is the first time after installing the interface
+	request_ip(VM4, "01:02:03:04:05:06")
+
+	threading.Thread(target=vm_mac_sender).start()
+	pkt = sniff_packet(VM4.tap, is_udp_pkt)
+	assert pkt[Ether].dst == "01:02:03:04:05:06", \
+		"Dpservice did not accept VM MAC"
+
+	grpc_client.delinterface(VM4.name)


### PR DESCRIPTION
I created a wrapper function to set the VF MAC address. This will later be helpful for synchronizing the MAC address with the backup dpservice.

MAC address is only changed once per-lifetime of the VF. The old value is kept and reused as a "suggestion" until ARP/DHCP/ND arrives.

The initial value is set in the process init stage to the MAC address of the representor.

I also renamed `dp_set_neigh_mac()` as it was meant as the "neighboring router mac", i.e. neighbor of a PF, never a VF.

Fixes #713 