### PR TITLE
Support VF TX rate limiting using netlink

### DIFF
--- a/cli/dpservice-cli/docs/commands/dpservice-cli_create_interface.md
+++ b/cli/dpservice-cli/docs/commands/dpservice-cli_create_interface.md
@@ -20,10 +20,10 @@ dpservice-cli create interface --id=vm4 --ipv4=10.200.1.4 --ipv6=2000:200:1::4 -
       --id string                ID of the interface.
       --ipv4 ip                  IPv4 address to assign to the interface. (default invalid IP)
       --ipv6 ip                  IPv6 address to assign to the interface. (default ::)
-      --public-meter-rate uint   Public meter rate.
+      --public-meter-rate uint   Metering rate used to limit VM's internet outgoing (TX) traffic rate (South-North).
       --pxe-file-name string     PXE boot file name.
       --pxe-server string        PXE next server.
-      --total-meter-rate uint    Total meter rate.
+      --total-meter-rate uint    Metering rate used to limit VM's total outgoing (TX) traffic rate (South-North + West-East).
       --vni uint32               VNI to add the interface to.
 ```
 

--- a/cli/dpservice-cli/renderer/renderer.go
+++ b/cli/dpservice-cli/renderer/renderer.go
@@ -249,7 +249,7 @@ func (t defaultTableConverter) loadBalancerTargetTable(lbtargets []api.LoadBalan
 }
 
 func (t defaultTableConverter) interfaceTable(ifaces []api.Interface) (*TableData, error) {
-	headers := []any{"ID", "VNI", "Device", "IPv4", "IPv6", "UnderlayRoute", "TotalMeterRate", "PublicMeterRate", "Hostname"}
+	headers := []any{"ID", "VNI", "Device", "IPv4", "IPv6", "UnderlayRoute", "TotalTx", "PublicTx", "Hostname"}
 	vfNeeded := isColumnNeeded(ifaces, "Spec.VirtualFunction")
 	if vfNeeded {
 		headers = append(headers, "VirtualFunction")

--- a/include/dp_netlink.h
+++ b/include/dp_netlink.h
@@ -26,7 +26,14 @@ struct dp_nlnk_req {
 	struct dp_nl_tlv if_tlv;
 };
 
-int dp_get_pf_neigh_mac(uint32_t if_idx, struct rte_ether_addr *neigh, const struct rte_ether_addr *own_mac);
+struct dp_nl_vf_rate_req {
+	struct nlmsghdr nl;
+	struct ifinfomsg ifi;
+	char attrbuf[512];
+};
+
+int dp_nl_get_pf_neigh_mac(uint32_t if_idx, struct rte_ether_addr *neigh, const struct rte_ether_addr *own_mac);
+int dp_nl_set_vf_rate(uint32_t pf_if_idx, uint32_t vf_index, uint32_t min_tx_rate, uint32_t max_tx_rate);
 
 #ifdef __cplusplus
 }

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -63,7 +63,7 @@ struct rte_hash *dp_create_jhash_table(int capacity, size_t key_len, const char 
 
 void dp_free_jhash_table(struct rte_hash *table);
 
-int dp_set_vf_rate_limit(uint16_t port_id, uint64_t rate);
+int dp_set_vf_rate_limit(uint16_t port_id, uint32_t rate);
 
 
 #ifdef __cplusplus

--- a/src/dp_netlink.c
+++ b/src/dp_netlink.c
@@ -15,7 +15,7 @@
 #include "dp_util.h"
 #include "dp_port.h"
 
-static int dp_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *neigh,
+static int dp_nl_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *neigh,
 						 const struct rte_ether_addr *own_mac)
 {
 	struct rtattr *rt_attr;
@@ -44,7 +44,7 @@ static int dp_read_neigh(struct nlmsghdr *nh, __u32 nll, struct rte_ether_addr *
 	return DP_ERROR;
 }
 
-static int dp_recv_nl_neigh_msg(struct sockaddr_nl sock_addr, int sock, char *buf, int bufsize)
+static int dp_nl_recv_neigh_msg(struct sockaddr_nl sock_addr, int sock, char *buf, int bufsize)
 {
 	struct nlmsghdr *nh;
 	ssize_t recv_len;
@@ -117,13 +117,13 @@ int dp_nl_get_pf_neigh_mac(uint32_t if_idx, struct rte_ether_addr *neigh, const 
 		goto cleanup;
 	}
 
-	reply_len = dp_recv_nl_neigh_msg(sa, sock, reply, sizeof(reply));
+	reply_len = dp_nl_recv_neigh_msg(sa, sock, reply, sizeof(reply));
 	if (reply_len < 0) {
 		DPS_LOG_ERR("Cannot receive message from netlink", DP_LOG_NETLINK(strerror(reply_len)));
 		goto cleanup;
 	}
 
-	ret = dp_read_neigh((struct nlmsghdr *)reply, reply_len, neigh, own_mac);
+	ret = dp_nl_read_neigh((struct nlmsghdr *)reply, reply_len, neigh, own_mac);
 
 cleanup:
 	close(sock);

--- a/src/dp_util.c
+++ b/src/dp_util.c
@@ -185,10 +185,10 @@ int dp_set_vf_rate_limit(uint16_t port_id, uint32_t rate)
 	struct dp_port *port = dp_get_port_by_id(port_id);
 	const struct dp_port *pf_port = dp_get_pf0();
 	uint32_t rate_in_mbits = rate;
-	int res;
-	uint32_t vf_index; // store which order VF this is (e.g., 0 for enp59s0f0v0, 1 for enp59s0f0v1, etc.)
 	const char *vf_num_str;
+	uint32_t vf_index; // store which order VF this is (e.g., 0 for enp59s0f0v0, 1 for enp59s0f0v1, etc.)
 	char *endptr;
+	int res;
 
 	if (!port)
 		return DP_ERROR;


### PR DESCRIPTION
Address #679 

How to test:
1) start dpservice
2) run commands:
```
./dpservice-cli create interface --id=vm3 --vni=66 --ipv4=172.32.4.9 --ipv6=2003::123 --device=0000:3b:00.0_representor_vf0 --total-meter-rate=5000 --public-meter-rate=500

ip link show enp59s0f0np0
6: enp59s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 04:3f:72:e8:cf:ca brd ff:ff:ff:ff:ff:ff
    vf 0     link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff, tx rate 5000 (Mbps), max_tx_rate 5000Mbps, spoof checking off, link-state auto, trust off, query_rss off
    vf 1     link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff, spoof checking off, link-state auto, trust off, query_rss off
    
 
./dpservice-cli delete interface --id=vm3

ip link show enp59s0f0np0
6: enp59s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 04:3f:72:e8:cf:ca brd ff:ff:ff:ff:ff:ff
    vf 0     link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff, spoof checking off, link-state auto, trust off, query_rss off
    vf 1     link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff, spoof checking off, link-state auto, trust off, query_rss off
```

killing dpservice / crashing leaves the configured rate untouched until new dpservice configures it when creating interface.