### PR TITLE
Reduce the size of the string used to name internal memory RIB tables

### DIFF
--- a/go/dpservice-go/client/client_test.go
+++ b/go/dpservice-go/client/client_test.go
@@ -1464,7 +1464,6 @@ var _ = Describe("negative loadbalancer related tests", Label("negative"), func(
 
 	Context("When using loadbalancer functions", Label("loadbalancer"), Ordered, func() {
 		var lb *api.LoadBalancer
-		var res *api.LoadBalancer
 		var err error
 
 		It("should not create", func() {
@@ -1492,48 +1491,48 @@ var _ = Describe("negative loadbalancer related tests", Label("negative"), func(
 
 			By("not defining loadbalancer virtual ip")
 			lb.Spec.LbVipIP = nil
-			res, err = dpdkClient.CreateLoadBalancer(ctx, lb)
+			_, err = dpdkClient.CreateLoadBalancer(ctx, lb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalanced_ip"))
 
 			By("not defining ID")
 			lb.Spec.LbVipIP = &lbVipIp
 			lb.ID = ""
-			res, err = dpdkClient.CreateLoadBalancer(ctx, lb)
+			_, err = dpdkClient.CreateLoadBalancer(ctx, lb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalancer_id"))
 
 			By("defining lbport with incorrect protocol")
 			lb.ID = "lb1"
 			lb.Spec.Lbports = []api.LBPort{{Protocol: 999, Port: 443}}
-			res, err = dpdkClient.CreateLoadBalancer(ctx, lb)
+			_, err = dpdkClient.CreateLoadBalancer(ctx, lb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalanced_ports.protocol"))
 
 			By("defining lbport with incorrect port")
 			lb.Spec.Lbports = []api.LBPort{{Protocol: 6, Port: 90000}}
-			res, err = dpdkClient.CreateLoadBalancer(ctx, lb)
+			_, err = dpdkClient.CreateLoadBalancer(ctx, lb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalanced_ports.port"))
 
 			By("defining incorrect vni")
 			lb.Spec.Lbports = []api.LBPort{{Protocol: 6, Port: 443}}
 			lb.Spec.VNI = 999999999
-			res, err = dpdkClient.CreateLoadBalancer(ctx, lb)
+			_, err = dpdkClient.CreateLoadBalancer(ctx, lb)
 			Expect(err).To(HaveOccurred())
-			Expect(res.GetStatus().Code).To(Equal(uint32(errors.VNI_INIT4)))
+			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = VNI exceeds 24-bit range"))
 		})
 
 		It("should not get", func() {
 			By("not defining loadbalancer ID")
-			res, err = dpdkClient.GetLoadBalancer(ctx, "")
+			_, err = dpdkClient.GetLoadBalancer(ctx, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalancer_id"))
 		})
 
 		It("should not delete", func() {
 			By("not defining loadbalancer ID")
-			res, err = dpdkClient.DeleteLoadBalancer(ctx, "")
+			_, err = dpdkClient.DeleteLoadBalancer(ctx, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalancer_id"))
 		})

--- a/include/dp_util.h
+++ b/include/dp_util.h
@@ -21,6 +21,7 @@ extern "C" {
 #define DP_IFACE_PXE_MAX_LEN	32
 #define DP_LB_ID_MAX_LEN		64
 #define DP_LB_MAX_PORTS			16
+#define DP_VNI_MAX_SIZE			0xFFFFFF
 
 #define DP_MAC_EQUAL(mac1, mac2) (((mac1)->addr_bytes[0] == (mac2)->addr_bytes[0]) && \
 								((mac1)->addr_bytes[1] == (mac2)->addr_bytes[1]) && \

--- a/src/dp_vni.c
+++ b/src/dp_vni.c
@@ -68,12 +68,12 @@ static __rte_always_inline int dp_create_rib6(uint32_t vni, int socket_id, struc
 {
 	struct rte_rib6_conf config_ipv6;
 	struct rte_rib6 *new_rib6;
-	char s[64];
+	char s[32];
 
 	config_ipv6.max_nodes = IPV6_DP_RIB_MAX_RULES;
 	config_ipv6.ext_sz = sizeof(struct dp_iface_route);
 
-	snprintf(s, sizeof(s), "IPV6_DP_RIB_%d_%d", vni, socket_id);
+	snprintf(s, sizeof(s), "RIB6_DP_%d_%d", vni, socket_id);
 	new_rib6 = rte_rib6_create(s, socket_id, &config_ipv6);
 	if (!new_rib6) {
 		DPS_LOG_ERR("Unable to create DP RIB6 table", DP_LOG_SOCKID(socket_id));
@@ -90,12 +90,12 @@ static __rte_always_inline int dp_create_rib(uint32_t vni, int socket_id, struct
 {
 	struct rte_rib_conf config_ipv4;
 	struct rte_rib *new_rib;
-	char s[64];
+	char s[32];
 
 	config_ipv4.max_nodes = IPV4_DP_RIB_MAX_RULES;
 	config_ipv4.ext_sz = sizeof(struct dp_iface_route);
 
-	snprintf(s, sizeof(s), "IPV4_DP_RIB_%d_%d", vni, socket_id);
+	snprintf(s, sizeof(s), "RIB4_DP_%d_%d", vni, socket_id);
 	new_rib = rte_rib_create(s, socket_id, &config_ipv4);
 	if (!new_rib) {
 		DPS_LOG_ERR("Unable to create DP RIB table", DP_LOG_SOCKID(socket_id));

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -713,6 +713,8 @@ const char* CreateLoadBalancerCall::FillRequest(struct dpgrpc_request* request)
 					DP_LOG_UNDERLAY(request_.preferred_underlay_route().c_str()));
 	if (SNPRINTF_FAILED(request->add_lb.lb_id, request_.loadbalancer_id()))
 		return "Invalid loadbalancer_id";
+	if (request_.vni() > DP_VNI_MAX_SIZE)
+		return "VNI exceeds 24-bit range";
 	request->add_lb.vni = request_.vni();
 	if (!GrpcConv::GrpcToDpAddress(request_.loadbalanced_ip(), &request->add_lb.addr))
 		return "Invalid loadbalanced_ip";


### PR DESCRIPTION
The allocated memory table name used by the RIB structure has a hidden limit of 25 characters in PMD. This becomes a problem when 8 digit VNIs are used and there's no NUMA(like on Bluefields) and socket_id becomes -1 and uses two characters.
So reduce the rest of the string to have enough room even with -1 in the string.
