### PR TITLE
Remove unneeded packet type specifications in pytest

### DIFF
--- a/test/local/helpers.py
+++ b/test/local/helpers.py
@@ -212,8 +212,8 @@ def stop_process(process):
 
 
 def _send_external_icmp_echo(dst_ipv4, ul_ipv6):
-	icmp_pkt = (Ether(dst=PF0.mac, src=ipv6_multicast_mac, type=0x86DD) /
-			    IPv6(dst=ul_ipv6, src=router_ul_ipv6, nh=4) /
+	icmp_pkt = (Ether(dst=PF0.mac, src=ipv6_multicast_mac) /
+			    IPv6(dst=ul_ipv6, src=router_ul_ipv6) /
 			    IP(dst=dst_ipv4, src=public_ip) /
 			    ICMP(type=8, id=0x0040))
 	delayed_sendp(icmp_pkt, PF0.tap)
@@ -226,9 +226,9 @@ def external_ping(dst_ipv4, ul_ipv6):
 
 
 def _send_external_icmp_echo6(dst_ipv6, ul_ipv6):
-	icmp_pkt = (Ether(dst=PF0.mac, src=ipv6_multicast_mac, type=0x86DD) /
-				IPv6(dst=ul_ipv6, src=router_ul_ipv6, nh=0x29) /
-				IPv6(dst=dst_ipv6, src=public_ipv6, nh=58) /
+	icmp_pkt = (Ether(dst=PF0.mac, src=ipv6_multicast_mac) /
+				IPv6(dst=ul_ipv6, src=router_ul_ipv6) /
+				IPv6(dst=dst_ipv6, src=public_ipv6) /
 				ICMPv6EchoRequest())
 	delayed_sendp(icmp_pkt, PF0.tap)
 

--- a/test/local/tcp_tester.py
+++ b/test/local/tcp_tester.py
@@ -119,7 +119,7 @@ class _TCPTester:
 		server_thread = threading.Thread(target=self.reply_tcp, args=(syn_style,))
 		server_thread.start()
 
-		tcp_pkt = (Ether(dst=self.server_mac, src=self.client_mac, type=0x0800) /
+		tcp_pkt = (Ether(dst=self.server_mac, src=self.client_mac) /
 				   IP(dst=self.server_ip, src=self.client_ip) /
 				   TCP(dport=self.server_port, sport=self.client_port, seq=self.tcp_sender_seq, flags=flags, options=[("NOP", None)]))
 		if payload != None:
@@ -163,7 +163,7 @@ class _TCPTester:
 			return
 
 		# send ACK
-		tcp_pkt = (Ether(dst=self.server_mac, src=self.client_mac, type=0x0800) /
+		tcp_pkt = (Ether(dst=self.server_mac, src=self.client_mac) /
 				   IP(dst=self.server_ip, src=self.client_ip) /
 				   TCP(dport=self.server_port, sport=self.client_port, flags="A", seq=self.tcp_sender_seq, ack=reply_seq))
 		delayed_sendp(tcp_pkt, self.client_tap)
@@ -213,7 +213,7 @@ class TCPTesterLocal(_TCPTester):
 						 client_pkt_check=client_pkt_check, server_pkt_check=server_pkt_check)
 	# VM-VM local communication, stay in IPv4
 	def get_server_l3_reply(self, pkt):
-		return (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x0800) /
+		return (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
 				IP(dst=pkt[IP].src, src=pkt[IP].dst))
 
 class TCPTesterVirtsvc(_TCPTester):
@@ -223,7 +223,7 @@ class TCPTesterVirtsvc(_TCPTester):
 						 client_pkt_check=client_pkt_check, server_pkt_check=server_pkt_check)
 	# Virtual-service communication, no tunnel, replace header with IPv6
 	def get_server_l3_reply(self, pkt):
-		return (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
+		return (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
 				IPv6(dst=pkt[IPv6].src, src=pkt[IPv6].dst, nh=6))
 
 class TCPTesterPublic(_TCPTester):
@@ -234,6 +234,6 @@ class TCPTesterPublic(_TCPTester):
 		self.nat_ul_ipv6 = nat_ul_ipv6
 	# Underlay communication, use IP-IP tunnel
 	def get_server_l3_reply(self, pkt):
-		return (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				IPv6(dst=self.nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+		return (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				IPv6(dst=self.nat_ul_ipv6, src=pkt[IPv6].dst) /
 				IP(dst=pkt[IP].src, src=pkt[IP].dst))

--- a/test/local/test_encap.py
+++ b/test/local/test_encap.py
@@ -12,15 +12,15 @@ def ipv4_in_ipv6_icmp_responder(pf_name, vm_ipv6):
 	pkt = sniff_packet(pf_name, is_encaped_icmp_pkt)
 	assert pkt[IPv6].dst == neigh_vni1_ul_ipv6, \
 		"Invalid destination in encaped request"
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=vm_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=vm_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 ICMP(type=0))
 	delayed_sendp(reply_pkt, pf_name)
 
 def send_ipv4_icmp(dst_ip, pf_name, responder, vm_ipv6):
 	threading.Thread(target=responder, args=(pf_name, vm_ipv6)).start()
-	icmp_echo_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	icmp_echo_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 					 IP(dst=dst_ip, src=VM1.ip) /
 					 ICMP(type=8))
 	delayed_sendp(icmp_echo_pkt, VM1.tap)
@@ -38,9 +38,9 @@ def ipv6_in_ipv6_icmp6_responder(pf_name, vm_ul_ipv6):
 	pkt = sniff_packet(pf_name, is_encaped_icmpv6_pkt)
 	assert pkt[IPv6].dst == neigh_vni1_ul_ipv6, \
 		"Invalid destination in encaped request"
-	reply_pkt = (Ether(dst=pkt.getlayer(Ether).src, src=pkt.getlayer(Ether).dst, type=0x86DD) /
-				 IPv6(dst=vm_ul_ipv6, src=pkt.getlayer(IPv6,1).dst, nh=0x29) /
-				 IPv6(dst=pkt.getlayer(IPv6,2).src, src=pkt.getlayer(IPv6,2).dst, nh=58) /
+	reply_pkt = (Ether(dst=pkt.getlayer(Ether).src, src=pkt.getlayer(Ether).dst) /
+				 IPv6(dst=vm_ul_ipv6, src=pkt.getlayer(IPv6,1).dst) /
+				 IPv6(dst=pkt.getlayer(IPv6,2).src, src=pkt.getlayer(IPv6,2).dst) /
 				 ICMPv6EchoReply(type=129))
 	delayed_sendp(reply_pkt, pf_name)
 
@@ -51,8 +51,8 @@ def test_ipv6_in_ipv6(prepare_ifaces, port_redundancy):
 
 	threading.Thread(target=ipv6_in_ipv6_icmp6_responder, args=(PF0.tap, VM1.ul_ipv6)).start()
 
-	icmp_echo_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x86DD) /
-					 IPv6(dst=f"{neigh_vni1_ov_ipv6_prefix}::123", src=VM1.ipv6, nh=58) /
+	icmp_echo_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
+					 IPv6(dst=f"{neigh_vni1_ov_ipv6_prefix}::123", src=VM1.ipv6) /
 					 ICMPv6EchoRequest())
 	delayed_sendp(icmp_echo_pkt, VM1.tap)
 

--- a/test/local/test_flows.py
+++ b/test/local/test_flows.py
@@ -49,8 +49,8 @@ def test_nat_table_flush(prepare_ipv4, grpc_client, port_redundancy):
 
 
 def send_bounce_pkt_to_pf(ipv6_nat):
-	bounce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-				  IPv6(dst=ipv6_nat, src=router_ul_ipv6, nh=4) /
+	bounce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac) /
+				  IPv6(dst=ipv6_nat, src=router_ul_ipv6) /
 				  IP(dst=nat_vip, src=public_ip) /
 				  TCP(sport=8989, dport=510))
 	delayed_sendp(bounce_pkt, PF0.tap)

--- a/test/local/test_pf_to_vf.py
+++ b/test/local/test_pf_to_vf.py
@@ -6,8 +6,8 @@ import threading
 from helpers import *
 
 def send_lb_pkt_to_pf(lb_ul_ipv6):
-	lb_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-			  IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6, nh=4) /
+	lb_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac) /
+			  IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6) /
 			  IP(dst=lb_ip, src=public_ip) /
 			  TCP(sport=1234, dport=80))
 	delayed_sendp(lb_pkt, PF0.tap)
@@ -34,8 +34,8 @@ def test_pf_to_vf_lb_tcp(prepare_ifaces, grpc_client):
 	# If TCP RST is implemented down the line, this can be overcome
 
 def send_lb_ipv6_pkt_to_pf(lb_ul_ipv6):
-	lb_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-			  IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6, nh=0x29) /
+	lb_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac) /
+			  IPv6(dst=lb_ul_ipv6, src=router_ul_ipv6) /
 			  IPv6(dst=lb_ip6, src=public_ipv6) /
 			  TCP(sport=1234, dport=8080))
 	delayed_sendp(lb_pkt, PF0.tap)

--- a/test/local/test_vf_to_pf.py
+++ b/test/local/test_vf_to_pf.py
@@ -12,8 +12,8 @@ def reply_icmp_pkt_from_vm1(nat_ul_ipv6, pf_tap):
 	assert src_ip == nat_vip, \
 		f"Bad ICMP request (src ip: {src_ip})"
 
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 ICMP(type=0, id=pkt[ICMP].id, seq=pkt[ICMP].seq))
 	delayed_sendp(reply_pkt, pf_tap)
@@ -26,8 +26,8 @@ def reply_icmp_pkt_from_vm1_identifier_check(nat_ul_ipv6):
 
 	icmp_id_1 = pkt[ICMP].id
 	print(f"icmp_id_1: {icmp_id_1}")
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 ICMP(type=0, id=pkt[ICMP].id, seq=pkt[ICMP].seq))
 	delayed_sendp(reply_pkt, PF0.tap)
@@ -42,8 +42,8 @@ def reply_icmp_pkt_from_vm1_identifier_check(nat_ul_ipv6):
 	print(f"icmp_id_2: {icmp_id_2}")
 	assert icmp_id_1 != icmp_id_2, \
 		f"Got the same ICMP identifier (icmp id 1: {icmp_id_1}, icmp id 2: {icmp_id_2})"
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 ICMP(type=0, id=pkt[ICMP].id, seq=pkt[ICMP].seq))
 	delayed_sendp(reply_pkt, PF0.tap)
@@ -55,7 +55,7 @@ def test_vf_to_pf_network_nat_icmp(prepare_ipv4, grpc_client, port_redundancy):
 
 	threading.Thread(target=reply_icmp_pkt_from_vm1, args=(nat_ul_ipv6, pf_tap)).start()
 
-	icmp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	icmp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			    IP(dst=public_ip3, src=VM1.ip) /
 			    ICMP(type=8, id=0x0050))
 	delayed_sendp(icmp_pkt, VM1.tap)
@@ -74,7 +74,7 @@ def test_vf_to_pf_network_nat_icmp_identifier_check(prepare_ipv4, grpc_client, p
 	nat_ul_ipv6 = grpc_client.addnat(VM1.name, nat_vip, nat_local_min_port, nat_local_max_port)
 	threading.Thread(target=reply_icmp_pkt_from_vm1_identifier_check, args=(nat_ul_ipv6,)).start()
 
-	icmp_pkt_1 = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	icmp_pkt_1 = (Ether(dst=PF0.mac, src=VM1.mac) /
 			    IP(dst=public_ip3, src=VM1.ip) /
 			    ICMP(type=8, id=0x0040))
 	delayed_sendp(icmp_pkt_1, VM1.tap)
@@ -84,7 +84,7 @@ def test_vf_to_pf_network_nat_icmp_identifier_check(prepare_ipv4, grpc_client, p
 	assert dst_ip == VM1.ip and pkt[ICMP].id == 0x0040, \
 		f"Bad ECHO reply (dst ip: {dst_ip})"
 
-	icmp_pkt_2 = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	icmp_pkt_2 = (Ether(dst=PF0.mac, src=VM1.mac) /
 			    IP(dst=public_ip2, src=VM1.ip) /
 			    ICMP(type=8, id=0x0050))
 	delayed_sendp(icmp_pkt_2, VM1.tap)
@@ -101,8 +101,8 @@ def test_vf_to_pf_network_nat_icmpv6(prepare_ipv4, grpc_client):
 
 	threading.Thread(target=reply_icmp_pkt_from_vm1, args=(nat_ul_ipv6, PF0.tap)).start()
 
-	icmp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x86DD) /
-					 IPv6(dst=public_nat64_ipv6, src=VM1.ipv6, nh=58) /
+	icmp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
+					 IPv6(dst=public_nat64_ipv6, src=VM1.ipv6) /
 					 ICMPv6EchoRequest(seq=1))
 
 	delayed_sendp(icmp_pkt, VM1.tap)
@@ -123,8 +123,8 @@ def reply_tcp_if_port_not(forbidden_port, nat_ul_ipv6):
 		f"Bad TCP packet (ip: {src_ip}, sport: {sport})"
 
 	if forbidden_port is None or sport != forbidden_port:
-		reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-					 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+		reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+					 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst) /
 					 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 					 TCP(sport=pkt[TCP].dport, dport=pkt[TCP].sport))
 		delayed_sendp(reply_pkt, PF0.tap)
@@ -139,7 +139,7 @@ def reply_tcp_pkt_from_vm1_max_port(nat_ul_ipv6):
 	reply_tcp_if_port_not(sport, nat_ul_ipv6)
 
 def send_tcp_through_port(port):
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			   IP(dst=public_ip3, src=VM1.ip) /
 			   TCP(sport=port))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -152,7 +152,7 @@ def send_tcp_through_port(port):
 
 def send_tcp_through_port_with_ipv6(port):
 
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x86DD) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			   IPv6(dst=public_nat64_ipv6, src=VM1.ipv6) /
 			   TCP(sport=port))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -190,8 +190,8 @@ def test_vf_to_pf_network_nat_tcp_with_ipv6(prepare_ipv4, grpc_client):
 
 def encaped_tcp_in_ipv6_vip_responder(pf_name, vip_ul_ipv6):
 	pkt = sniff_packet(pf_name, is_tcp_pkt)
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=vip_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=vip_ul_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 TCP(sport=pkt[TCP].dport, dport=pkt[TCP].sport))
 	delayed_sendp(reply_pkt, pf_name)
@@ -199,7 +199,7 @@ def encaped_tcp_in_ipv6_vip_responder(pf_name, vip_ul_ipv6):
 def request_tcp(dport, pf_name, vip_ul_ipv6):
 	threading.Thread(target=encaped_tcp_in_ipv6_vip_responder, args=(pf_name, vip_ul_ipv6)).start()
 	# vm2 (vf1) -> PF0/PF1 (internet traffic), vm2 has VIP, check on PFs side, whether VIP is source (SNAT)
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM2.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM2.mac) /
 			   IP(dst=public_ip, src=VM2.ip) /
 			   TCP(sport=1240, dport=dport))
 	delayed_sendp(tcp_pkt, VM2.tap)
@@ -216,15 +216,15 @@ def test_vf_to_pf_vip_snat(prepare_ipv4, grpc_client, port_redundancy):
 def reply_with_icmp_err_fragment_needed(pf_name, nat_ul_ipv6):
 	pkt = sniff_packet(pf_name, is_tcp_pkt)
 	orig_ip_pkt = pkt[IP]
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=orig_ip_pkt.src, src=orig_ip_pkt.dst) /
 				 ICMP(type=3, code=4, unused=1280) /
 				 orig_ip_pkt)
 	# https://blog.cloudflare.com/path-mtu-discovery-in-practice/
 	"""
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst, nh=4) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=nat_ul_ipv6, src=pkt[IPv6].dst) /
 				 IP(dst=orig_ip_pkt.src, src=orig_ip_pkt.dst) /
 				 ICMP(type=3, code=4, unused=1280) /
 				 str(orig_ip_pkt)[:28])
@@ -234,7 +234,7 @@ def reply_with_icmp_err_fragment_needed(pf_name, nat_ul_ipv6):
 def request_icmperr(dport, pf_name, nat_ul_ipv6):
 	threading.Thread(target=reply_with_icmp_err_fragment_needed, args=(pf_name, nat_ul_ipv6)).start();
 
-	tcp_pkt = (Ether(dst=ipv6_multicast_mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=ipv6_multicast_mac, src=VM1.mac) /
 			   IP(dst=public_ip, src=VM1.ip) /
 			   TCP(sport=1256, dport=dport))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -259,7 +259,7 @@ def test_vf_to_pf_firewall_tcp_block(prepare_ipv4, grpc_client):
 	resp_thread.start()
 	# Allow only tcp packets leaving the VM with destination port 453
 	grpc_client.addfwallrule(VM1.name, "fw0-vm1", proto="tcp", dst_port_min=453, dst_port_max=453, direction="egress")
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			   IP(dst=public_ip, src=VM1.ip) /
 			   TCP(dport=1024))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -277,7 +277,7 @@ def test_vf_to_pf_firewall_tcp_allow(prepare_ipv4, grpc_client, port_redundancy)
 	resp_thread.start()
 	# Allow only tcp packets leaving the VM with destination port 453
 	grpc_client.addfwallrule(VM1.name, "fw1-vm1", proto="tcp", dst_port_min=453, dst_port_max=453, direction="egress")
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			   IP(dst=public_ip, src=VM1.ip) /
 			   TCP(dport=453))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -295,7 +295,7 @@ def test_vf_to_pf_firewall_ipv6_tcp_allow(prepare_ipv4, grpc_client, port_redund
 	resp_thread.start()
 	# Allow only tcp packets leaving the VM with destination port 456
 	grpc_client.addfwallrule(VM1.name, "fw1-vm16", src_prefix="::/0", dst_prefix="::/0", proto="tcp", dst_port_min=456, dst_port_max=456, direction="egress")
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x86DD) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			   IPv6(dst=public_ipv6, src=VM1.ipv6) /
 			   TCP(dport=456))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -307,8 +307,8 @@ def test_vf_to_pf_firewall_ipv6_tcp_allow(prepare_ipv4, grpc_client, port_redund
 
 def encaped_tcp_ipv6_in_ipv6_responder(pf_name):
 	pkt = sniff_packet(pf_name, is_ipv6_tcp_pkt)
-	reply_pkt = (Ether(dst=pkt.getlayer(Ether).src, src=pkt.getlayer(Ether).dst, type=0x86DD) /
-				 IPv6(dst=pkt.getlayer(IPv6,1).src, src=pkt.getlayer(IPv6,1).dst, nh=0x29) /
+	reply_pkt = (Ether(dst=pkt.getlayer(Ether).src, src=pkt.getlayer(Ether).dst) /
+				 IPv6(dst=pkt.getlayer(IPv6,1).src, src=pkt.getlayer(IPv6,1).dst) /
 				 IPv6(dst=pkt.getlayer(IPv6,2).src, src=pkt.getlayer(IPv6,2).dst) /
 				 TCP(sport=pkt[TCP].dport, dport=pkt[TCP].sport))
 	delayed_sendp(reply_pkt, pf_name)
@@ -316,7 +316,7 @@ def encaped_tcp_ipv6_in_ipv6_responder(pf_name):
 def test_vf_to_pf_tcp_in_ipv6(prepare_ipv4, grpc_client):
 	threading.Thread(target=encaped_tcp_ipv6_in_ipv6_responder, args=(PF0.tap,)).start()
 	# vm2 (vf1) -> PF0 (ipv6 internet traffic), PF0 replies back
-	tcp_pkt = (Ether(dst=PF0.mac, src=VM2.mac, type=0x86DD) /
+	tcp_pkt = (Ether(dst=PF0.mac, src=VM2.mac) /
 			   IPv6(dst=public_ipv6, src=VM2.ipv6) /
 			   TCP(sport=1240, dport=180))
 	delayed_sendp(tcp_pkt, VM2.tap)

--- a/test/local/test_vf_to_vf.py
+++ b/test/local/test_vf_to_vf.py
@@ -8,7 +8,7 @@ from helpers import *
 
 def vf_to_vf_tcp_responder(vf_tap):
 	pkt = sniff_packet(vf_tap, is_tcp_pkt)
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x0800) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
 				 IP(dst=pkt[IP].src, src=pkt[IP].dst) /
 				 TCP(sport=pkt[TCP].dport, dport=pkt[TCP].sport))
 	delayed_sendp(reply_pkt, vf_tap)
@@ -17,7 +17,7 @@ def test_vf_to_vf_tcp(prepare_ipv4, grpc_client):
 	threading.Thread(target=vf_to_vf_tcp_responder, args=(VM2.tap,)).start()
 
 	grpc_client.addfwallrule(VM2.name, "fw0-vm2", proto="tcp", dst_port_min=1234, dst_port_max=1234)
-	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac) /
 			   IP(dst=VM2.ip, src=VM1.ip) /
 			   TCP(dport=1234))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -34,7 +34,7 @@ def test_vf_to_vf_vip_dnat(prepare_ipv4, grpc_client):
 
 	# vm1 (vf0) -> vm2 (vf2), vm2 has VIP, send packet to VIP from vm1 side, whether the packet is received
 	# and sent back by vm2 (DNAT)
-	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac) /
 			   IP(dst=vip_vip, src=VM1.ip) /
 			   TCP(sport=1200, dport=1235))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -52,7 +52,7 @@ def test1_vf_to_vf_firewall_tcp(prepare_ipv4, grpc_client):
 
 	#Accept only tcp packets from the source ip VM1.ip / 32, do not care about the rest
 	grpc_client.addfwallrule(VM2.name, "fw1-vm2", src_prefix=f"{VM1.ip}/32", proto="tcp")
-	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac) /
 			   IP(dst=VM2.ip, src=VM1.ip) /
 			   TCP(sport=1001, dport=1234))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -71,7 +71,7 @@ def test2_vf_to_vf_firewall_tcp(prepare_ipv4, grpc_client):
 
 	#Accept only tcp packets from the source ip 1.2.3.4 / 16 range, do not care about the rest
 	grpc_client.addfwallrule(VM2.name, "fw0-vm2", src_prefix="1.2.3.4/16", proto="tcp")
-	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) /
+	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac) /
 			   IP(dst=VM2.ip, src=VM1.ip) /
 			   TCP(sport=1002, dport=1234))
 	delayed_sendp(tcp_pkt, VM1.tap)
@@ -84,7 +84,7 @@ def test2_vf_to_vf_firewall_tcp(prepare_ipv4, grpc_client):
 
 def vf_to_vf_icmp_responder(vf_tap):
 	pkt = sniff_packet(vf_tap, is_icmp_pkt)
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x0800) / IP(dst=pkt[IP].src, src=pkt[IP].dst) / ICMP(type=0, id=pkt[ICMP].id))
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) / IP(dst=pkt[IP].src, src=pkt[IP].dst) / ICMP(type=0, id=pkt[ICMP].id))
 	delayed_sendp(reply_pkt, vf_tap)
 
 	pkt = sniff_packet(vf_tap, is_icmp_pkt)
@@ -95,7 +95,7 @@ def test_vf_to_vf_icmp(prepare_ipv4, grpc_client):
 	grpc_client.addfwallrule(VM2.name, "fw0-vm-icmp", proto="icmp")
 	grpc_client.addfwallrule(VM1.name, "fw0-vm-icmp", proto="icmp")
 	icmp_respond_thread = threading.Thread(target=vf_to_vf_icmp_responder, args=(VM2.tap,))
-	icmp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x0800) / IP(dst=VM2.ip, src=VM1.ip) / ICMP(type=8, id=0x0040))
+	icmp_pkt = (Ether(dst=VM2.mac, src=VM1.mac) / IP(dst=VM2.ip, src=VM1.ip) / ICMP(type=8, id=0x0040))
 	icmp_respond_thread.start()
 	delayed_sendp(icmp_pkt, VM1.tap)
 	sniff_packet(VM1.tap, is_icmp_pkt)
@@ -107,7 +107,7 @@ def test_vf_to_vf_icmp(prepare_ipv4, grpc_client):
 
 def vf_to_vf_icmpv6_responder(vf_tap):
 	pkt = sniff_packet(vf_tap, is_icmpv6_echo_pkt)
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) / IPv6(dst=pkt[IPv6].src, src=pkt[IPv6].dst, nh=58) / ICMPv6EchoReply(type=129))
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) / IPv6(dst=pkt[IPv6].src, src=pkt[IPv6].dst) / ICMPv6EchoReply(type=129))
 	delayed_sendp(reply_pkt, vf_tap)
 	pkt = sniff_packet(vf_tap, is_icmpv6_echo_pkt)
 	delayed_sendp(reply_pkt, vf_tap)
@@ -117,7 +117,7 @@ def test_vf_to_vf_icmpv6(prepare_ipv4, grpc_client):
 	grpc_client.addfwallrule(VM2.name, "fw0-vm-icmp", src_prefix="::/0", dst_prefix="::/0", proto="icmp")
 	grpc_client.addfwallrule(VM1.name, "fw0-vm-icmp", src_prefix="::/0", dst_prefix="::/0", proto="icmp")
 	icmpv6_respond_thread = threading.Thread(target=vf_to_vf_icmpv6_responder, args=(VM2.tap,))
-	icmpv6_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x86DD) / IPv6(dst=VM2.ipv6, src=VM1.ipv6, nh=58) / ICMPv6EchoRequest())
+	icmpv6_pkt = (Ether(dst=VM2.mac, src=VM1.mac) / IPv6(dst=VM2.ipv6, src=VM1.ipv6) / ICMPv6EchoRequest())
 	icmpv6_respond_thread.start()
 	delayed_sendp(icmpv6_pkt, VM1.tap)
 	sniff_packet(VM1.tap, is_icmpv6echo_reply_pkt)
@@ -129,7 +129,7 @@ def test_vf_to_vf_icmpv6(prepare_ipv4, grpc_client):
 
 def vf_to_vf_ipv6_tcp_responder(vf_tap):
 	pkt = sniff_packet(vf_tap, is_ipv6_tcp_pkt)
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
 				 IPv6(dst=pkt[IPv6].src, src=pkt[IPv6].dst) /
 				 TCP(sport=pkt[TCP].dport, dport=pkt[TCP].sport))
 	delayed_sendp(reply_pkt, vf_tap)
@@ -140,7 +140,7 @@ def test_vf_to_vf_ipv6_tcp(prepare_ipv4, grpc_client):
 	threading.Thread(target=vf_to_vf_ipv6_tcp_responder, args=(VM2.tap,)).start()
 	grpc_client.addfwallrule(VM2.name, "fw0-vm6" , src_prefix="::/0", dst_prefix="::/0", proto="tcp", dst_port_min=1235, dst_port_max=1235)
 
-	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac, type=0x86DD) /
+	tcp_pkt = (Ether(dst=VM2.mac, src=VM1.mac) /
 			   IPv6(dst=VM2.ipv6, src=VM1.ipv6) /
 			   TCP(dport=1235))
 	delayed_sendp(tcp_pkt, VM1.tap)

--- a/test/local/test_virtsvc.py
+++ b/test/local/test_virtsvc.py
@@ -22,15 +22,15 @@ def reply_udp(pf_name):
 
 	udp_used_port = pkt[UDP].sport
 
-	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst, type=0x86DD) /
-				 IPv6(dst=pkt[IPv6].src, src=pkt[IPv6].dst, nh=17) /
+	reply_pkt = (Ether(dst=pkt[Ether].src, src=pkt[Ether].dst) /
+				 IPv6(dst=pkt[IPv6].src, src=pkt[IPv6].dst) /
 				 UDP(dport=pkt[UDP].sport, sport=pkt[UDP].dport))
 	delayed_sendp(reply_pkt, pf_name)
 
 def request_udp(l4_port, pf_name):
 	threading.Thread(target=reply_udp, args=(pf_name,)).start()
 
-	udp_pkt = (Ether(dst=PF0.mac, src=VM1.mac, type=0x0800) /
+	udp_pkt = (Ether(dst=PF0.mac, src=VM1.mac) /
 			   IP(dst=virtsvc_udp_virtual_ip, src=VM1.ip) /
 			   UDP(dport=virtsvc_udp_virtual_port, sport=l4_port))
 	delayed_sendp(udp_pkt, VM1.tap)

--- a/test/local/xtratest_flow_timeout.py
+++ b/test/local/xtratest_flow_timeout.py
@@ -99,8 +99,8 @@ def test_virtsvc_tcp_timeout(request, prepare_ipv4, fast_flow_timeout):
 
 
 def send_bounce_pkt_to_pf(ipv6_lb):
-	bouce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac, type=0x86DD) /
-				 IPv6(dst=ipv6_lb, src=local_ul_ipv6, nh=4) /
+	bouce_pkt = (Ether(dst=ipv6_multicast_mac, src=PF0.mac) /
+				 IPv6(dst=ipv6_lb, src=local_ul_ipv6) /
 				 IP(dst=lb_ip, src=public_ip) /
 				 TCP(sport=8989, dport=80))
 	delayed_sendp(bouce_pkt, PF0.tap)


### PR DESCRIPTION
Simply removed unneeded arguments from packet creation where possible.

Fixes #738