### PR TITLE
Log which loadbalancer already exists when adding fails

### DIFF
--- a/src/dp_lb.c
+++ b/src/dp_lb.c
@@ -71,8 +71,11 @@ int dp_create_lb(struct dpgrpc_lb *lb, const union dp_ipv6 *ul_ip)
 	lb_key.vni = lb->vni;
 	dp_copy_ipaddr(&lb_key.ip, &lb->addr);
 
-	if (DP_SUCCESS(rte_hash_lookup(lb_table, &lb_key)))
+	if (DP_SUCCESS(rte_hash_lookup_data(lb_table, &lb_key, (void **)&lb_val))) {
+		DPS_LOG_WARNING("Loadbalancer for this IP already exists",
+						DP_LOG_IPV4(lb->addr.ipv4), DP_LOG_VNI(lb->vni), DP_LOG_LBID(lb_val->lb_id));
 		return DP_GRPC_ERR_ALREADY_EXISTS;
+	}
 
 	lb_val = rte_zmalloc("lb_val", sizeof(struct lb_value), RTE_CACHE_LINE_SIZE);
 	if (!lb_val)


### PR DESCRIPTION
If adding a loadbalancer fails with ALREADY_EXISTS, it would be nice to know what is the ID of the existing LB, makes it easier to investigate.

Of course this information already is in some objects, but since we are already doing a hashtable lookup, this is basically free information and it does make operations easier.

Issue #736 