### PR TITLE
Add tcpdump_helpers.inc to dpservice container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,8 @@ COPY --from=builder \
 COPY --from=builder /usr/local/lib /usr/local/lib
 RUN ldconfig
 
-# Ensure bash-completion is working in operations
-RUN echo 'PATH=${PATH}:/\nsource /etc/bash_completion\nsource <(dpservice-cli completion bash)' >> /root/.bashrc
+# Ensure quality-of-life for operations
+COPY hack/tcpdump_helpers.inc hack/dpservice.bashrc /root/
+RUN echo 'source ~/dpservice.bashrc' >> /root/.bashrc
 
 ENTRYPOINT ["dpservice-bin"]

--- a/hack/dpservice.bashrc
+++ b/hack/dpservice.bashrc
@@ -1,0 +1,6 @@
+PATH="${PATH}:/"
+
+source /etc/bash_completion
+source <(dpservice-cli completion bash)
+
+source ~/tcpdump_helpers.inc


### PR DESCRIPTION
When using `dpservice-dump`, the pcap-style filter can either specify an overlay IPv4 or underlay IPv6.

This means when tracing a packet over the graph, the user must manually switch from underlay to overlay, thus losing the full trace.

Including these macros (already used on every node in OSC for tcpdump), the user can do
```
dpservice-dump --nodes "" --filter "host 1.2.3.4 or $(ipip_host 1.2.3.4)"
```
and see the whole packet trace over the graph from start to finish.

Issue #736