### PR TITLE
Container quality of life improvements

### DIFF
--- a/hack/dpservice.bashrc
+++ b/hack/dpservice.bashrc
@@ -4,3 +4,21 @@ source /etc/bash_completion
 source <(dpservice-cli completion bash)
 
 source ~/tcpdump_helpers.inc
+
+if [ -z "${DP_FILE_PREFIX:-}" ]; then
+	DP_FILE_PREFIX=dpservice
+fi
+
+if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	PS1='\[\033[01;31m\]\h\[\033[00m\] $DP_FILE_PREFIX \[\033[01;34m\]\w \$\[\033[00m\] '
+
+	alias ls='ls --color=auto'
+
+	alias grep='grep --color=auto'
+	alias fgrep='fgrep --color=auto'
+	alias egrep='egrep --color=auto'
+else
+	PS1='\h $DP_FILE_PREFIX \w \$ '
+fi
+
+HISTCONTROL=ignoredups


### PR DESCRIPTION
This is based on #741 to prevent merge collision

Quality of life improvements for dpservice container:
 - `HISTCONTROL=ignoredups` - when monitoring stuff it is often helpful to just `<up-arrow><enter>` which pollutes bash history without this setting
 - colors - it is immensely helpful to actually see `grep` matches and when your command output starts (i.e. colored prompt)
 - `DP_FILE_PREFIX` in prompt - it is useful know which process this is when running dpservice-HA (this variable is already used by `dpservice-dump` and `dpservice-inspect`
 
Issue #736