### PR TITLE
Remove unneded mount of hugepages in init container

### DIFF
--- a/config/default/dpservice.yaml
+++ b/config/default/dpservice.yaml
@@ -25,8 +25,6 @@ spec:
         command:
         - prepare.sh
         volumeMounts:
-        - mountPath: /dev
-          name: hugepages
         - mountPath: /run/dpservice
           name: run
         securityContext:


### PR DESCRIPTION
Removes `/dev/hugepages` mount into init container as it no longer uses it.

Tested in an OSC cluster, though there I know where the hugepages are being set-up.

Fixes #721