### PR TITLE
List all routes and lbtargets using gRPC

### DIFF
--- a/cli/dpservice-cli/cmd/list_loadbalancer_targets.go
+++ b/cli/dpservice-cli/cmd/list_loadbalancer_targets.go
@@ -54,11 +54,6 @@ func (o *ListLoadBalancerTargetOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *ListLoadBalancerTargetOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"lb-id"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/cli/dpservice-cli/cmd/list_routes.go
+++ b/cli/dpservice-cli/cmd/list_routes.go
@@ -50,16 +50,11 @@ type ListRoutesOptions struct {
 }
 
 func (o *ListRoutesOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.Uint32Var(&o.VNI, "vni", o.VNI, "VNI to get the routes from.")
+	fs.Uint32Var(&o.VNI, "vni", 0, "VNI to get the routes from.")
 	fs.StringVar(&o.SortBy, "sort-by", "", "Column to sort by.")
 }
 
 func (o *ListRoutesOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"vni"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/go/dpservice-go/client/client_test.go
+++ b/go/dpservice-go/client/client_test.go
@@ -1603,13 +1603,6 @@ var _ = Describe("negative loadbalancer related tests", Label("negative"), func(
 			Expect(err.Error()).To(Equal("[error code 204] BAD_IPVER"))
 		})
 
-		It("should not list", func() {
-			By("not defining loadbalancer ID")
-			_, err = dpdkClient.ListLoadBalancerTargets(ctx, "")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("rpc error: code = InvalidArgument desc = Invalid loadbalancer_id"))
-		})
-
 		It("should not delete", func() {
 			By("not defining loadbalancer ID")
 			targetIp := netip.MustParseAddr("ff80::5")

--- a/src/dp_vni.c
+++ b/src/dp_vni.c
@@ -240,6 +240,10 @@ int dp_reset_all_vni_route_tables(void)
 		return DP_OK;
 
 	while ((ret = rte_hash_iterate(vni_handle_tbl, (const void **)&vni_key, (void **)&vni_data, &iter)) != -ENOENT) {
+		if (DP_FAILED(ret)) {
+			DPS_LOG_ERR("Cannot iterate VNI table", DP_LOG_RET(ret));
+			return DP_ERROR;
+		}
 		if (DP_FAILED(dp_reset_vni_data(vni_key->vni, vni_data)))
 			return DP_ERROR;
 	}

--- a/src/grpc/dp_async_grpc.cpp
+++ b/src/grpc/dp_async_grpc.cpp
@@ -851,8 +851,11 @@ const char* ListLoadBalancerTargetsCall::FillRequest(struct dpgrpc_request* requ
 {
 	DPGRPC_LOG_INFO("Listing loadbalancer targets",
 					DP_LOG_LBID(request_.loadbalancer_id().c_str()));
-	if (SNPRINTF_FAILED(request->list_lbtrgt.lb_id, request_.loadbalancer_id()))
-		return "Invalid loadbalancer_id";
+	if (request_.loadbalancer_id().empty())
+		request->list_lbtrgt.lb_id[0] = 0;
+	else
+		if (SNPRINTF_FAILED(request->list_lbtrgt.lb_id, request_.loadbalancer_id()))
+			return "Invalid loadbalancer_id";
 	return NULL;
 }
 void ListLoadBalancerTargetsCall::ParseReply(struct dpgrpc_reply* reply)


### PR DESCRIPTION
I added the ability to list all loadbalancer targets and all prefixes (incl. lbprefixes), in the same fashion as previously has been done with NATs, i.e. by specifying an "empty" identifier.

For prefixes, the drawback is that in the response, the VNI is not valid, it is the "empty" one.
 - given the fact that target VNI is always the same as VNI anyway, this is a non-issue
 
For LB targets, the actual LB id is missing from the output.
 - not ideal, but for checking whether both dpservices are orchestrated the same, this is enough.

Both of the above is easily fixable, but requires changes to the gRPC protocol, which I would rather not do. And given the fact that this already covers the intended purpose (quick check of HA dpservices), the need for the change is low in my opinion.

Fixes #745