### PR TITLE
Increase TX_QUEUE_SIZE

### DIFF
--- a/include/dpdk_layer.h
+++ b/include/dpdk_layer.h
@@ -37,8 +37,9 @@ extern "C" {
 // Seen recommendations to keep this at 2*RTE_GRAPH_BURST_SIZE or 4*RTE_GRAPH_BURST_SIZE
 #define DP_RX_QUEUE_SIZE (4 * RTE_GRAPH_BURST_SIZE)
 // Seen this recommended to be bigger than Rx because multiple Rx streams share the same Tx
-// but in our case we are only using one worker thread, so there is no concurrent Tx
-#define DP_TX_QUEUE_SIZE DP_RX_QUEUE_SIZE
+// in our case we are only using one worker thread, so the original thought was that there is no concurrent Tx
+// however in practice, having this less than 8xRx leads to tx_node transmission errors
+#define DP_TX_QUEUE_SIZE (8 * DP_RX_QUEUE_SIZE)
 
 #ifdef ENABLE_PYTEST
 #define DP_MBUF_POOL_SIZE	(50*1024)


### PR DESCRIPTION
Testing this is a bit complicated, because VM is the weakest link usually, so it requires many many VMs, or alternatively, one can send the packets out 10 times. This of course breaks communication, however in local testing works as intended. 

I was able to reach 200-300 kp/s and then the error messages start appearing.

Increasing the size of TX queue by a factor of 4 makes my local tests start failing at 1 Mp/s, and in our real-life scenario makes all problems go away, only the occasional VM unable to cope with the traffic.

In real-life deployment, factor of 4 was still occasionally producing an error, factor of 8 did not. The memory allocation is not that big, so I would recommend using the larger factor for future-proofing. (130-200 MB increase in `alloc_size`, but still fits into 1GiB total heap size, OSC reserves 2GiB for dpservice anyway).

Increasing more is not really possible because we run into some DPDK limit, fortunately this seems to be enough.
```
EAL log message, eal_msg: mlx5_net: port 0 Tx WQEBB count (65536) exceeds the limit (32768), try smaller queue size
```

Fixes #748 