### PR TITLE
Fix reuse issue

### DIFF
--- a/hack/dp_conf_generate.py
+++ b/hack/dp_conf_generate.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
-# SPDX-License-Identifier: Apache-2.0
-
 import argparse
 import json
 import re

--- a/src/dp_sync.c
+++ b/src/dp_sync.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #include "dp_sync.h"
 
 #include "dp_error.h"


### PR DESCRIPTION
address #733

I assume, one of failure reasons is that, `dp_conf_generate.py` under `/hack` shall not contain license info, as this path is configured to be ignored.