### PR TITLE
Update go to 1.24.13 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ libgrpc++-dev \
 libpcap0.8-dev
 
 # Need at least Golang 1.20 which is not part of Debian-12 stable
-RUN curl -Ls https://golang.org/dl/go1.20.14.linux-${TARGETARCH}.tar.gz | tar xz -C /usr/local/
+# Also, due to recent vulnerabilites, 1.24.13 is installed
+RUN curl -Ls https://golang.org/dl/go1.24.13.linux-${TARGETARCH}.tar.gz | tar xz -C /usr/local/
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 # Download DPDK


### PR DESCRIPTION
Simple update of Dockerfile should be fine for the built image. 

I have not update the `go.mod` as to not break developer workflow.

Fixes #764