### PR TITLE
Accept all MAC changes from the VM

### DIFF
--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -758,9 +758,11 @@ int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uin
 
 void dp_l2_addr_set(struct dp_port *port, const struct rte_ether_addr *l2_addr)
 {
-	rte_ether_addr_copy(l2_addr, &port->neigh_mac);
+	if (!rte_is_same_ether_addr(l2_addr, &port->neigh_mac)) {
+		rte_ether_addr_copy(l2_addr, &port->neigh_mac);
+		dp_sync_send_mac(port->port_id, &port->neigh_mac);  // errors ignored
+	}
 	port->iface.l2_addr_received = true;
-	dp_sync_send_mac(port->port_id, &port->neigh_mac);  // errors ignored
 }
 
 

--- a/src/nodes/arp_node.c
+++ b/src/nodes/arp_node.c
@@ -42,7 +42,7 @@ static __rte_always_inline bool arp_handled(struct rte_mbuf *m)
 	uint32_t temp_ip;
 
 	// ARP reply from VM
-	if (unlikely(dp_l2_addr_needed(port) && sender_ip == htonl(port->iface.cfg.own_ip))) {
+	if (unlikely(sender_ip == htonl(port->iface.cfg.own_ip))) {
 		dp_l2_addr_set(port, &incoming_eth_hdr->src_addr);
 		return true;
 	}

--- a/src/nodes/dhcp_node.c
+++ b/src/nodes/dhcp_node.c
@@ -229,7 +229,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 
 	rte_ether_addr_copy(&incoming_eth_hdr->src_addr, &incoming_eth_hdr->dst_addr);
 	rte_ether_addr_copy(&port->own_mac, &incoming_eth_hdr->src_addr);
-	if (unlikely(response_type == DHCPACK && dp_l2_addr_needed(port)))
+	if (unlikely(response_type == DHCPACK))
 		dp_l2_addr_set(port, &incoming_eth_hdr->dst_addr);
 
 	incoming_ipv4_hdr->src_addr = server_ip;

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -76,8 +76,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		static_assert(sizeof(nd_msg->target) == sizeof(*gw_ip), "Incompatible IPv6 format in ND message structure");
 		if (!dp_ipv6_match((const union dp_ipv6 *)nd_msg->target, gw_ip))
 			return IPV6_ND_NEXT_DROP;
-		if (unlikely(dp_l2_addr_needed(port)))
-			dp_l2_addr_set(port, &req_eth_hdr->dst_addr);
+		dp_l2_addr_set(port, &req_eth_hdr->dst_addr);
 		dp_copy_ipv6(&port->iface.cfg.own_ipv6, dp_get_dst_ipv6(req_ipv6_hdr));
 		req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
 		req_icmp6_hdr->icmp6_solicited = 1;

--- a/test/local/test_arp.py
+++ b/test/local/test_arp.py
@@ -44,13 +44,13 @@ def test_l2_addr_once(request, prepare_ifaces, grpc_client):
 	assert pkt[Ether].dst == "12:34:56:78:9a:bc", \
 		"Dpservice not using actual VM MAC"
 
-	# Additional ARP/DHCP/ND should not be able to change MAC again
-	request_ip(VM4)
+	# Additional ARP/DHCP/ND should be able to change MAC again
+	request_ip(VM4, "98:76:54:32:10:ab")
 
 	threading.Thread(target=vm_mac_sender).start()
 	pkt = sniff_packet(VM4.tap, is_udp_pkt)
-	assert pkt[Ether].dst == "12:34:56:78:9a:bc", \
-		"Dpservice changed VM MAC"
+	assert pkt[Ether].dst == "98:76:54:32:10:ab", \
+		"Dpservice did not change VM MAC"
 
 	# Now the VM gets removed and *another one* is put into its place
 	# This can have different MAC address
@@ -60,7 +60,7 @@ def test_l2_addr_once(request, prepare_ifaces, grpc_client):
 	# Without ARP/DHCP/ND dpservice should try the use the old MAC
 	threading.Thread(target=vm_mac_sender).start()
 	pkt = sniff_packet(VM4.tap, is_udp_pkt)
-	assert pkt[Ether].dst == "12:34:56:78:9a:bc", \
+	assert pkt[Ether].dst == "98:76:54:32:10:ab", \
 		"Dpservice reset VM MAC"
 
 	# Additional ARP/DHCP/ND should be able to change MAC


### PR DESCRIPTION
Fixes #768

In a previous PR #714 I changed the behavior of MAC address discovery for the VM.

The idea was to only update the MAC once, so prevent unnecessary memory copy.

I knew that the user can change a MAC manually in the VM, but that was really not a concern.

What I missed though is the fact, that iPXE and systemd both use different MAC address:
1. There is the MAC address of the VF (can be seen on host)
2. iPXE starts the VM and requests DHCP - with the VF's original MAC
3. iPXE downloads kernel, initramfs and squashfs and starts the image
4. systemd starts DHCP but due to `MACAddressPolicy=persistent` in `/usr/lib/systemd/network/99-default.link` it generates a new MAC
5. dpservice refuses to update it because of PR #714
6. kernel drops all incoming traffic due to MAC mismatch

I was able to make this happen on many host machine reboots. After applying this PR I am unable to do it