### PR TITLE
Revert garp to old system

### DIFF
--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -46,7 +46,7 @@ struct dp_port_iface {
 	uint32_t				nat_ip;
 	uint16_t				nat_port_range[2];
 	bool					ready;
-	bool					l2_addr_received;
+	bool					arp_done;
 	uint64_t				total_flow_rate_cap;
 	uint64_t				public_flow_rate_cap;
 	uint32_t				hostname_len;
@@ -133,13 +133,13 @@ int dp_set_pf_neigh_mac(uint16_t port_id, const struct rte_ether_addr *mac);
 
 int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uint64_t public_flow_rate_cap);
 
-static __rte_always_inline
-bool dp_l2_addr_needed(const struct dp_port *port)
-{
-	return port->iface.ready && !port->iface.l2_addr_received;
-}
-
 void dp_l2_addr_set(struct dp_port *port, const struct rte_ether_addr *l2_addr);
+
+static __rte_always_inline
+bool dp_arp_cycle_needed(const struct dp_port *port)
+{
+	return port->iface.ready && !port->iface.arp_done;
+}
 
 static __rte_always_inline
 int dp_load_mac(struct dp_port *port)

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -57,7 +57,7 @@ void send_to_all_vfs(const struct rte_mbuf *pkt, uint16_t eth_type)
 		if (eth_type == RTE_ETHER_TYPE_ARP) {
 			arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
 			rte_ether_addr_copy(&port->own_mac, &arp_hdr->arp_data.arp_sha);
-			if (dp_l2_addr_needed(port))
+			if (dp_arp_cycle_needed(port))
 				arp_hdr->arp_data.arp_tip = htonl(port->iface.cfg.own_ip);
 		}
 

--- a/src/dp_port.c
+++ b/src/dp_port.c
@@ -167,7 +167,7 @@ static int dp_port_init_ethdev(struct dp_port *port, struct rte_eth_dev_info *de
 	// guess the inital VM MAC until ARP arrives
 	if (!port->is_pf) {
 		rte_ether_addr_copy(&port->own_mac, &port->neigh_mac);
-		port->iface.l2_addr_received = false;
+		port->iface.arp_done = false;
 	}
 
 	static_assert(sizeof(port->dev_name) == RTE_ETH_NAME_MAX_LEN, "Incompatible port dev_name size");
@@ -758,11 +758,10 @@ int dp_port_meter_config(struct dp_port *port, uint64_t total_flow_rate_cap, uin
 
 void dp_l2_addr_set(struct dp_port *port, const struct rte_ether_addr *l2_addr)
 {
-	if (!rte_is_same_ether_addr(l2_addr, &port->neigh_mac)) {
-		rte_ether_addr_copy(l2_addr, &port->neigh_mac);
-		dp_sync_send_mac(port->port_id, &port->neigh_mac);  // errors ignored
-	}
-	port->iface.l2_addr_received = true;
+	if (rte_is_same_ether_addr(l2_addr, &port->neigh_mac))
+		return;
+	rte_ether_addr_copy(l2_addr, &port->neigh_mac);
+	dp_sync_send_mac(port->port_id, &port->neigh_mac);  // errors ignored
 }
 
 
@@ -777,9 +776,7 @@ int dp_set_port_sync_neigh_mac(uint16_t port_id, const struct rte_ether_addr *ma
 		return DP_ERROR;
 	}
 
-	if (!port->iface.l2_addr_received)
-		rte_ether_addr_copy(mac, &port->neigh_mac);
-
+	rte_ether_addr_copy(mac, &port->neigh_mac);
 	return DP_OK;
 }
 

--- a/src/nodes/arp_node.c
+++ b/src/nodes/arp_node.c
@@ -42,8 +42,9 @@ static __rte_always_inline bool arp_handled(struct rte_mbuf *m)
 	uint32_t temp_ip;
 
 	// ARP reply from VM
-	if (unlikely(sender_ip == htonl(port->iface.cfg.own_ip))) {
+	if (unlikely(dp_arp_cycle_needed(port) && sender_ip == htonl(port->iface.cfg.own_ip))) {
 		dp_l2_addr_set(port, &incoming_eth_hdr->src_addr);
+		port->iface.arp_done = true;
 		return true;
 	}
 


### PR DESCRIPTION
This is a fix of a fix from #769 which introduced a bug in ARP which degraded performace. Network wos working but with occasional packet loss, that is why previous tests missed it.

I simply fully reverted the garp implementation to before #714, the rest of #769, i.e. DHCP and ND is kept.

Fixes #768