### PR TITLE
Add DPSERVICE_VERSION build arg to override version during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG DPDK_VER=25.11
 ARG DPDK_BUILDTYPE=release
 ARG DPSERVICE_BUILDTYPE=debug
 ARG DPSERVICE_FEATURES=""
+ARG DPSERVICE_VERSION=""
 
 WORKDIR /workspace
 
@@ -99,7 +100,7 @@ COPY include/ include/
 COPY .git/ .git/
 
 # Compile dpservice itself
-RUN meson setup build -Dbuild_dpservice_cli=true -Dbuildtype=$DPSERVICE_BUILDTYPE $DPSERVICE_FEATURES && ninja -C build
+RUN DPSERVICE_VERSION="${DPSERVICE_VERSION}" meson setup build -Dbuild_dpservice_cli=true -Dbuildtype=$DPSERVICE_BUILDTYPE $DPSERVICE_FEATURES && ninja -C build
 
 
 # Extended build image for test-image

--- a/hack/get_version.sh
+++ b/hack/get_version.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Allow overriding the version via environment variable
+if [ -n "$DPSERVICE_VERSION" ]; then
+    echo "$DPSERVICE_VERSION"
+    exit 0
+fi
+
 # For non-tagged commits, this is a simple "vX.X.X-XX-gXXXXXXX"
 # For dpservice-bin tagged commits, this is "vX.X.X"
 # For dpservice-go tagged commits, this is "go/dpservice-go/vX.X.X-XX-gXXXXXXX"


### PR DESCRIPTION
If set during `meson build`, environment variable `DPSERVICE_VERSION` has the ability to override the version generation from current git tag.

Without this variable set, everything should behave as it previously did.

Fixes #773 