### PR TITLE
Feature/rename dhcp ipv6

### DIFF
--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -29,7 +29,6 @@ struct dp_iface_cfg {
 	uint32_t				neigh_ip;
 	uint8_t					ip_depth;
 	union dp_ipv6			dhcp_ipv6;
-	union dp_ipv6			own_ipv6;
 	uint8_t					ip6_depth;
 	struct dp_ip_address	pxe_ip;
 	char					pxe_str[DP_IFACE_PXE_MAX_LEN];

--- a/include/dp_port.h
+++ b/include/dp_port.h
@@ -28,7 +28,7 @@ struct dp_iface_cfg {
 	uint32_t				own_ip;
 	uint32_t				neigh_ip;
 	uint8_t					ip_depth;
-	union dp_ipv6			dhcp_ipv6;
+	union dp_ipv6			own_ipv6;
 	uint8_t					ip6_depth;
 	struct dp_ip_address	pxe_ip;
 	char					pxe_str[DP_IFACE_PXE_MAX_LEN];

--- a/src/dp_iface.c
+++ b/src/dp_iface.c
@@ -84,7 +84,7 @@ void dp_delete_iface(struct dp_port *port)
 	uint32_t vni = port->iface.vni;
 
 	dp_del_route(port, vni, port->iface.cfg.own_ip, 32);
-	dp_del_route6(port, vni, &port->iface.cfg.dhcp_ipv6, 128);
+	dp_del_route6(port, vni, &port->iface.cfg.own_ipv6, 128);
 
 	if (DP_FAILED(dp_delete_vni_route_tables(vni)))
 		DPS_LOG_WARNING("Unable to delete route tables", DP_LOG_VNI(vni));

--- a/src/dp_lpm.c
+++ b/src/dp_lpm.c
@@ -26,7 +26,7 @@ static __rte_always_inline int dp_lpm_fill_route_tables(const struct dp_port *po
 	if (DP_FAILED(ret))
 		return ret;
 
-	ret = dp_add_route6(port, port->iface.vni, 0, &port->iface.cfg.dhcp_ipv6, &dp_empty_ipv6, 128);
+	ret = dp_add_route6(port, port->iface.vni, 0, &port->iface.cfg.own_ipv6, &dp_empty_ipv6, 128);
 	if (DP_FAILED(ret))
 		return ret;
 

--- a/src/dp_periodic_msg.c
+++ b/src/dp_periodic_msg.c
@@ -18,7 +18,7 @@ static const struct rte_ether_addr dp_mc_mac = {
 
 static __rte_always_inline bool dp_is_ip_set(struct dp_port *port, uint16_t eth_type)
 {
-	return (eth_type == RTE_ETHER_TYPE_IPV6 && !dp_is_ipv6_zero(&port->iface.cfg.dhcp_ipv6)) ||
+	return (eth_type == RTE_ETHER_TYPE_IPV6 && !dp_is_ipv6_zero(&port->iface.cfg.own_ipv6)) ||
 		   (eth_type == RTE_ETHER_TYPE_ARP && port->iface.cfg.own_ip != 0);
 }
 

--- a/src/grpc/dp_grpc_impl.c
+++ b/src/grpc/dp_grpc_impl.c
@@ -456,7 +456,7 @@ static int dp_process_create_interface(struct dp_grpc_responder *responder)
 	dp_copy_ipv6(&port->iface.ul_ipv6, &request->ul_addr6);
 	port->iface.cfg.own_ip = request->ip4_addr;
 	port->iface.cfg.ip_depth = DP_LPM_DHCP_IP_DEPTH;
-	dp_copy_ipv6(&port->iface.cfg.dhcp_ipv6, &request->ip6_addr);
+	dp_copy_ipv6(&port->iface.cfg.own_ipv6, &request->ip6_addr);
 	port->iface.cfg.ip6_depth = DP_LPM_DHCP_IP6_DEPTH;
 	static_assert(sizeof(request->pxe_str) == sizeof(port->iface.cfg.pxe_str), "Incompatible interface PXE size");
 	rte_memcpy(port->iface.cfg.pxe_str, request->pxe_str, sizeof(port->iface.cfg.pxe_str));
@@ -553,7 +553,7 @@ static int dp_process_get_interface(struct dp_grpc_responder *responder)
 		return DP_GRPC_ERR_NOT_FOUND;
 
 	reply->ip4_addr = port->iface.cfg.own_ip;
-	dp_copy_ipv6(&reply->ip6_addr, &port->iface.cfg.dhcp_ipv6);
+	dp_copy_ipv6(&reply->ip6_addr, &port->iface.cfg.own_ipv6);
 	reply->vni = port->iface.vni;
 	static_assert(sizeof(reply->iface_id) == sizeof(port->iface.id), "Incompatible VM ID size");
 	rte_memcpy(reply->iface_id, port->iface.id, sizeof(reply->iface_id));
@@ -752,7 +752,7 @@ static int dp_process_list_interfaces(struct dp_grpc_responder *responder)
 			return DP_GRPC_ERR_OUT_OF_MEMORY;
 
 		reply->ip4_addr = port->iface.cfg.own_ip;
-		dp_copy_ipv6(&reply->ip6_addr, &port->iface.cfg.dhcp_ipv6);
+		dp_copy_ipv6(&reply->ip6_addr, &port->iface.cfg.own_ipv6);
 		reply->vni = port->iface.vni;
 		static_assert(sizeof(reply->iface_id) == sizeof(port->iface.id), "Incompatible VM ID size");
 		rte_memcpy(reply->iface_id, port->iface.id, sizeof(reply->iface_id));

--- a/src/nodes/dhcpv6_node.c
+++ b/src/nodes/dhcpv6_node.c
@@ -148,10 +148,10 @@ static __rte_always_inline int parse_options(struct rte_mbuf *m,
 			reply_options->opt_iana = opt_iana_template;
 			reply_options->opt_iana.ia_na.iaid = ((const struct dhcpv6_ia_na *)&opt->data)->iaid;
 			// cannot use optimized function here due to the destination being packed (can cause alignment problems)
-			static_assert(sizeof(reply_options->opt_iana.ia_na.options[0].addr.ipv6) == sizeof(dp_get_in_port(m)->iface.cfg.dhcp_ipv6.bytes),
+			static_assert(sizeof(reply_options->opt_iana.ia_na.options[0].addr.ipv6) == sizeof(dp_get_in_port(m)->iface.cfg.own_ipv6.bytes),
 						  "Incompatible IPv6 array for IA_NA options");
 			rte_memcpy(reply_options->opt_iana.ia_na.options[0].addr.ipv6,
-					   dp_get_in_port(m)->iface.cfg.dhcp_ipv6.bytes, sizeof(dp_get_in_port(m)->iface.cfg.dhcp_ipv6.bytes));
+					   dp_get_in_port(m)->iface.cfg.own_ipv6.bytes, sizeof(dp_get_in_port(m)->iface.cfg.own_ipv6.bytes));
 			reply_options->opt_iana_len = sizeof(opt_iana_template);
 			break;
 		case DHCPV6_OPT_RAPID_COMMIT:
@@ -279,7 +279,7 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	int reply_options_len;
 	size_t payload_len;
 
-	if (dp_is_ipv6_zero(&dp_get_in_port(m)->iface.cfg.dhcp_ipv6))
+	if (dp_is_ipv6_zero(&dp_get_in_port(m)->iface.cfg.own_ipv6))
 		return DHCPV6_NEXT_DROP;
 
 	// packet length is uint16_t, negative value means it's less than the required length

--- a/src/nodes/ipv6_nd_node.c
+++ b/src/nodes/ipv6_nd_node.c
@@ -77,7 +77,6 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 		if (!dp_ipv6_match((const union dp_ipv6 *)nd_msg->target, gw_ip))
 			return IPV6_ND_NEXT_DROP;
 		dp_l2_addr_set(port, &req_eth_hdr->dst_addr);
-		dp_copy_ipv6(&port->iface.cfg.own_ipv6, dp_get_dst_ipv6(req_ipv6_hdr));
 		req_icmp6_hdr->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
 		req_icmp6_hdr->icmp6_solicited = 1;
 		req_icmp6_hdr->icmp6_override = 1;


### PR DESCRIPTION
This PR simply removes the unused `own_ipv6` in `ipv6_nd_node.c` (it was set and never used). Then it reuses the name for the original `dhcp_ipv6`. This way the name is consistent with the `uint32_t own_ip`

Fixes #704 