### PR TITLE
dp_rte_flow_helpers: Explicit array initialization

### DIFF
--- a/include/rte_flow/dp_rte_flow_helpers.h
+++ b/include/rte_flow/dp_rte_flow_helpers.h
@@ -42,12 +42,12 @@ static const struct rte_flow_item_eth dp_flow_item_eth_mask = {
 	.hdr.ether_type = 0xffff,
 };
 static const struct rte_flow_item_eth dp_flow_item_eth_dst_mask = {
-	.hdr.dst_addr.addr_bytes = "\xff\xff\xff\xff\xff\xff",
+	.hdr.dst_addr.addr_bytes = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 	.hdr.ether_type = 0xffff,
 };
 static const struct rte_flow_item_eth dp_flow_item_eth_src_dst_mask = {
-	.hdr.src_addr.addr_bytes = "\xff\xff\xff\xff\xff\xff",
-	.hdr.dst_addr.addr_bytes = "\xff\xff\xff\xff\xff\xff",
+	.hdr.src_addr.addr_bytes = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+	.hdr.dst_addr.addr_bytes = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 	.hdr.ether_type = 0xffff,
 };
 
@@ -55,19 +55,19 @@ static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_mask = {
 	.hdr.proto = 0xff,
 };
 static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_src_mask = {
-	.hdr.src_addr.a = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+	.hdr.src_addr.a = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 	.hdr.proto = 0xff,
 };
 static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_dst_mask = {
-	.hdr.dst_addr.a = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+	.hdr.dst_addr.a = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 	.hdr.proto = 0xff,
 };
 static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_dst_pfx68_mask = {
-	.hdr.dst_addr.a = "\xff\xff\xff\xff\xff\xff\xff\xff\xf0\x00\x00\x00\x00\x00\x00\x00",
+	.hdr.dst_addr.a = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 };
 #ifdef ENABLE_VIRTSVC
 static const struct rte_flow_item_ipv6 dp_flow_item_ipv6_dst_only_mask = {
-	.hdr.dst_addr.a = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+	.hdr.dst_addr.a = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 };
 #endif
 


### PR DESCRIPTION
GCC 15 introduces 'unterminated-string-initialization'[0] warning and since we treat warning as errors in our builds, we might as well get ahead of the issue and change from string literals to explicit array initialization.

[0] https://gcc.gnu.org/cgit/gcc/commit/?id=44c9403ed1833ae71a59e84f9e37af3182be0df5

# Proposed Changes

- Use explicit byte array initialization instead of string literals.