### PR TITLE
Fix missing flow_ptr init for ARP node

### DIFF
--- a/src/nodes/cls_node.c
+++ b/src/nodes/cls_node.c
@@ -135,15 +135,15 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 	l3_type = m->packet_type & RTE_PTYPE_L3_MASK;
 	ether_hdr = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
 
+	// connected nodes need dp_flow structure (call cannot fail)
+	df = dp_init_flow_ptr(m);
+
 	if (unlikely(l3_type == 0)) {
 		// Manual test, because Mellanox PMD drivers do not set detailed L2 packet_type in mbuf
 		if (is_arp(ether_hdr))
 			return CLS_NEXT_ARP;
 		return CLS_NEXT_DROP;
 	}
-
-	// L3-aware nodes need dp_flow structure (call cannot fail)
-	df = dp_init_flow_ptr(m);
 
 	// this is validating the port-id for all subsequent uses of dp_get_port(m)
 	port = dp_get_port_by_id(m->port);


### PR DESCRIPTION
If ARP packet is encountered by CLS node, the graph will send the packet over to ARP node. That node then sends all proper packets to Tx node. 

However as seen in [tx_node.c:92](https://github.com/ironcore-dev/dpservice/blob/6b3aa29081730092118cad04b4fd9ba0edbad9b4/src/nodes/tx_node.c#L92), Tx node **requires** `df->conntrack` to be initialized.

Since `dp_init_flow_ptr()` had not yet been called, the pointer `df->conntrack` value is whatever was in the private packet area. And because packets come from a pool where packets get recycled, this can contain some valid memory from previous packets.

This can be a big source of strange memory corruption.

Connected to issue #784