### PR TITLE
Wait for workers before cleaning up

### DIFF
--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -240,11 +240,18 @@ int dp_dpdk_main_loop(void)
 		DPS_LOG_ERR("Cannot launch lcores", DP_LOG_RET(ret));
 		// custom threads are already running, stop them
 		dp_force_quit();
+		// FUTURE - with multiple workers, some may already be running, wait before cleaning up
+		rte_eal_mp_wait_lcore();
 		return ret;
 	}
 
 	/* Launch timer loop on main core */
-	return main_core_loop();
+	ret = main_core_loop();
+
+	// wait for workers to finish, as to not teardown something still used in packet processing
+	rte_eal_mp_wait_lcore();
+
+	return ret;
 }
 
 struct dp_dpdk_layer *get_dpdk_layer(void)


### PR DESCRIPTION
During heavy packet processing, if dpservice is being stopped, it is possible for the main thread to start cleaning up before workers are done with the last packet (before checking `force_quit`). In this case the code could touch some memory that is already freed.

I guess this is rare and really an edge case, but this is the right pattern when working with worker threads.

Only downside I can see is that `rte_eal_mp_wait_lcore()` could block forever. But we are running as a pod, so kubernetes will simply SIGKILL after 30s anyway. Which is not ideal, but again, this seems like a rare case.

Discovered during testing #784