### PR TITLE
Fix possible double-free of flow table entry

### DIFF
--- a/include/dp_flow.h
+++ b/include/dp_flow.h
@@ -145,7 +145,7 @@ bool dp_are_flows_identical(const struct flow_key *key1, const struct flow_key *
 
 int dp_get_flow(const struct flow_key *key, struct flow_value **p_flow_val);
 int dp_add_flow(const struct flow_key *key, struct flow_value *flow_val);
-void dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val);
+int dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val);
 int dp_build_flow_key(struct flow_key *key /* out */, struct rte_mbuf *m /* in */);
 void dp_invert_flow_key(const struct flow_key *key /* in */, struct flow_key *inv_key /* out */);
 int dp_flow_init(int socket_id);

--- a/src/dp_cntrack.c
+++ b/src/dp_cntrack.c
@@ -156,7 +156,7 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 	flow_val = rte_zmalloc("flow_val", sizeof(struct flow_value), RTE_CACHE_LINE_SIZE);
 	if (!flow_val) {
 		DPS_LOG_ERR("Failed to allocate new flow value");
-		goto error_alloc;
+		return NULL;
 	}
 
 	rte_memcpy(&flow_val->flow_key[DP_FLOW_DIR_ORG], key, sizeof(*key));
@@ -184,8 +184,10 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 		flow_val->l4_state.tcp.state = DP_FLOW_TCP_STATE_NONE;
 
 	dp_ref_init(&flow_val->ref_count, dp_free_flow);
-	if (DP_FAILED(dp_add_flow(key, flow_val)))
-		goto error_add;
+	if (DP_FAILED(dp_add_flow(key, flow_val))) {
+		rte_free(flow_val);
+		return NULL;
+	}
 
 	// Only the original flow (outgoing)'s hash value is recorded
 	// Implicit casting from hash_sig_t to uint32_t!
@@ -193,18 +195,15 @@ static __rte_always_inline struct flow_value *flow_table_insert_entry(struct flo
 
 	dp_invert_flow_key(key, &inverted_key);
 	rte_memcpy(&flow_val->flow_key[DP_FLOW_DIR_REPLY], &inverted_key, sizeof(inverted_key));
-	if (DP_FAILED(dp_add_flow(&inverted_key, flow_val)))
-		goto error_add_inv;
+	if (DP_FAILED(dp_add_flow(&inverted_key, flow_val))) {
+		// this decreases a ref counter, which already frees when it hits zero
+		if (DP_FAILED(dp_delete_flow(key, flow_val)))
+			rte_free(flow_val);
+		return NULL;
+	}
 	dp_ref_inc(&flow_val->ref_count);
 
 	return flow_val;
-
-error_add_inv:
-	dp_delete_flow(key, flow_val);
-error_add:
-	rte_free(flow_val);
-error_alloc:
-	return NULL;
 }
 
 
@@ -241,7 +240,7 @@ int dp_cntrack_from_sync_nat(const struct netnat_portoverload_tbl_key *portoverl
 	flow_val = rte_zmalloc("flow_val", sizeof(struct flow_value), RTE_CACHE_LINE_SIZE);
 	if (!flow_val) {
 		DPS_LOG_ERR("Failed to allocate new sync flow value");
-		goto error_alloc;
+		return DP_ERROR;
 	}
 
 	// Code based on flow_table_insert_entry() (see above).
@@ -293,22 +292,21 @@ int dp_cntrack_from_sync_nat(const struct netnat_portoverload_tbl_key *portoverl
 		dp_set_ipaddr_nat64(&key.l3_dst, htonl(key.l3_dst.ipv4));
 
 	// Create the original conntrack flow
-	if (DP_FAILED(dp_add_flow(&key, flow_val)))
-		goto error_add;
+	if (DP_FAILED(dp_add_flow(&key, flow_val))) {
+		rte_free(flow_val);
+		return DP_ERROR;
+	}
 
 	// Create the reply flow
-	if (DP_FAILED(dp_add_flow(&inverted_key, flow_val)))
-		goto error_add_inv;
+	if (DP_FAILED(dp_add_flow(&inverted_key, flow_val))) {
+		// this decreases a ref counter, which already frees when it hits zero
+		if (DP_FAILED(dp_delete_flow(&key, flow_val)))
+			rte_free(flow_val);
+		return DP_ERROR;
+	}
 	dp_ref_inc(&flow_val->ref_count);
 
 	return DP_OK;
-
-error_add_inv:
-	dp_delete_flow(&key, flow_val);
-error_add:
-	rte_free(flow_val);
-error_alloc:
-	return DP_ERROR;
 }
 
 

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -212,7 +212,7 @@ void dp_invert_flow_key(const struct flow_key *key /* in */, struct flow_key *in
 	}
 }
 
-void dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val)
+int dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val)
 {
 	int ret;
 
@@ -222,7 +222,7 @@ void dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val)
 			dp_flow_log_key(key, "Attempt to delete a non-existing hash key");
 		else
 			DPS_LOG_ERR("Cannot delete key from flow table", DP_LOG_RET(ret));
-		return;
+		return ret;
 	}
 #ifdef ENABLE_PYTEST
 	dp_flow_log_key(key, "Successfully deleted an existing hash key");
@@ -231,6 +231,7 @@ void dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val)
 	// removed a flow, purge the cache to be safe
 	// (could only remove this key from cache, but that would need matching, which takes time)
 	dp_cntrack_flush_cache();
+	return DP_OK;
 }
 
 int dp_add_flow(const struct flow_key *key, struct flow_value *flow_val)

--- a/src/dp_flow.c
+++ b/src/dp_flow.c
@@ -222,6 +222,11 @@ int dp_delete_flow(const struct flow_key *key, struct flow_value *flow_val)
 			dp_flow_log_key(key, "Attempt to delete a non-existing hash key");
 		else
 			DPS_LOG_ERR("Cannot delete key from flow table", DP_LOG_RET(ret));
+		// return without changing reference counter
+		// decreasing ref counter without deleting would leave invalid refence in the table
+		// safe to act this way:
+		//   ENOENT: entry was not present, so there is no reference in use
+		//   else: according to docs this can only be EINVAL - invalid parameters
 		return ret;
 	}
 #ifdef ENABLE_PYTEST
@@ -421,7 +426,7 @@ void dp_process_aged_flows_non_offload(void)
 		}
 
 		if (unlikely((current_timestamp - flow_val->timestamp) > timer_hz * flow_val->timeout_value))
-			dp_delete_flow(next_key, flow_val);
+			dp_delete_flow(next_key, flow_val);  // ignore errors - see inside
 	}
 }
 
@@ -429,7 +434,7 @@ static __rte_always_inline void dp_remove_flow(struct flow_value *flow_val, cons
 {
 	if (offload_mode_enabled)
 		dp_rte_flow_remove(flow_val);
-	dp_delete_flow(key, flow_val);
+	dp_delete_flow(key, flow_val);  // ignore errors - see inside
 }
 
 void dp_remove_nat_flows(uint16_t port_id, enum dp_flow_nat_type nat_type)

--- a/src/nodes/dnat_node.c
+++ b/src/nodes/dnat_node.c
@@ -80,6 +80,7 @@ static __rte_always_inline rte_edge_t get_next_index(__rte_unused struct rte_nod
 
 			/* Expect the new source in this conntrack object */
 			cntrack->flow_flags |= DP_FLOW_FLAG_DST_NAT;
+			// ignore errors - see inside
 			dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
 			dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_src, ntohl(ipv4_hdr->dst_addr));
 			if (DP_FAILED(dp_add_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack)))

--- a/src/nodes/snat_node.c
+++ b/src/nodes/snat_node.c
@@ -62,6 +62,7 @@ static __rte_always_inline int dp_process_ipv4_snat(struct rte_mbuf *m, struct d
 
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT;
+	// ignore errors - see inside
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
 	dp_set_ipaddr4(&cntrack->flow_key[DP_FLOW_DIR_REPLY].l3_dst, ntohl(ipv4_hdr->src_addr));
 	if (snat_data->nat_ip != 0)
@@ -118,6 +119,7 @@ static __rte_always_inline int dp_process_ipv6_nat64(struct rte_mbuf *m, struct 
 
 	/* Expect the new destination in this conntrack object */
 	cntrack->flow_flags |= DP_FLOW_FLAG_SRC_NAT64;
+	// ignore errors - see inside
 	dp_delete_flow(&cntrack->flow_key[DP_FLOW_DIR_REPLY], cntrack);
 	if (df->l4_type == IPPROTO_ICMP) {
 		if (cntrack->flow_key[DP_FLOW_DIR_REPLY].src.type_src == DP_ICMPV6_ECHO_REQUEST)


### PR DESCRIPTION
If flow table insertion fails, the rollback code has a bug. Due to the nature of `dp_delete_flow()` which calls `dp_ref_dec()`, the flow value would already be freed by the reference counter hitting zero.

But `dp_delete_flow()` can actually fail, so the result needs to be passed to the caller to decide if `rte_val` still remains to be freed or not.

Connected to issue #784