### PR TITLE
send dhcp6 response to VM without IPv6 address configured

### DIFF
--- a/src/nodes/dhcpv6_node.c
+++ b/src/nodes/dhcpv6_node.c
@@ -269,6 +269,21 @@ static int generate_reply_options(struct rte_mbuf *m, uint8_t *options, int opti
 	return reply_options_len;
 }
 
+static __rte_always_inline int generate_noaddrs_reply(struct rte_mbuf *m, uint8_t *options, int options_len)
+{
+	struct dhcpv6_opt_status_code status_opt = {
+		.op_code = htons(DHCPV6_OPT_STATUS_CODE),
+		.op_len  = htons(sizeof(uint16_t)),
+		.status  = htons(DHCPV6_STATUS_NOADDRSAVAIL),
+	};
+
+	if (DP_FAILED(resize_packet(m, (int)sizeof(status_opt) - options_len)))
+		return DP_ERROR;
+
+	memcpy(options, &status_opt, sizeof(status_opt));
+	return (int)sizeof(status_opt);
+}
+
 static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, struct rte_mbuf *m)
 {
 	struct rte_ether_hdr *req_eth_hdr;
@@ -278,9 +293,6 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	int req_options_len = rte_pktmbuf_data_len(m) - (int)DP_DHCPV6_PKT_FIXED_LEN;
 	int reply_options_len;
 	size_t payload_len;
-
-	if (dp_is_ipv6_zero(&dp_get_in_port(m)->iface.cfg.own_ipv6))
-		return DHCPV6_NEXT_DROP;
 
 	// packet length is uint16_t, negative value means it's less than the required length
 	if (req_options_len < 0) {
@@ -303,22 +315,31 @@ static __rte_always_inline rte_edge_t get_next_index(struct rte_node *node, stru
 	req_udp_hdr->dst_port = htons(DHCPV6_CLIENT_PORT);
 
 	// create reply with options
-	switch (dhcp_pkt->msg_type) {
-	case DHCPV6_SOLICIT:
-		dhcp_pkt->msg_type = DHCPV6_ADVERTISE;
-		reply_options_len = generate_reply_options(m, dhcp_pkt->options, req_options_len);
-		break;
-	case DHCPV6_REQUEST:
-	case DHCPV6_RELEASE:
+	if (dp_is_ipv6_zero(&dp_get_in_port(m)->iface.cfg.own_ipv6)) {
+		// if no IPv6 address assigned to this interface — reject explicitly so the client
+		// stops waiting instead of timing out and blocking networkd-wait-online
+		if (dhcp_pkt->msg_type != DHCPV6_SOLICIT && dhcp_pkt->msg_type != DHCPV6_REQUEST)
+			return DHCPV6_NEXT_DROP;
 		dhcp_pkt->msg_type = DHCPV6_REPLY;
-		reply_options_len = generate_reply_options(m, dhcp_pkt->options, req_options_len);
-		break;
-	case DHCPV6_CONFIRM:
-		dhcp_pkt->msg_type = DHCPV6_REPLY;
-		reply_options_len = strip_options(m, req_options_len);
-		break;
-	default:
-		return DHCPV6_NEXT_DROP;
+		reply_options_len = generate_noaddrs_reply(m, dhcp_pkt->options, req_options_len);
+	} else {
+		switch (dhcp_pkt->msg_type) {
+		case DHCPV6_SOLICIT:
+			dhcp_pkt->msg_type = DHCPV6_ADVERTISE;
+			reply_options_len = generate_reply_options(m, dhcp_pkt->options, req_options_len);
+			break;
+		case DHCPV6_REQUEST:
+		case DHCPV6_RELEASE:
+			dhcp_pkt->msg_type = DHCPV6_REPLY;
+			reply_options_len = generate_reply_options(m, dhcp_pkt->options, req_options_len);
+			break;
+		case DHCPV6_CONFIRM:
+			dhcp_pkt->msg_type = DHCPV6_REPLY;
+			reply_options_len = strip_options(m, req_options_len);
+			break;
+		default:
+			return DHCPV6_NEXT_DROP;
+		}
 	}
 	if (DP_FAILED(reply_options_len))
 		return DHCPV6_NEXT_DROP;

--- a/test/local/test_dhcpv6.py
+++ b/test/local/test_dhcpv6.py
@@ -3,6 +3,7 @@
 
 from helpers import *
 from scapy.layers.dhcp6 import *
+import pytest
 
 PXE_MODE = 0
 IPXE_MODE = 1
@@ -117,3 +118,44 @@ def test_dhcpv6_vf0(prepare_ifaces):
 
 def test_dhcpv6_vf1(prepare_ifaces):
 	request_ipv6(VM2, IPXE_MODE)
+
+
+def make_dhcpv6_pkt(msg_class, vm, iaid=0xBEEF0001):
+	DUID = DUID_LL(lladdr=vm.mac)
+	return (Ether(dst=ipv6_multicast_mac) / IPv6(dst=gateway_ipv6) / UDP() /
+	        msg_class(trid=random.randint(0, 16777215)) /
+	        DHCP6OptIA_NA(iaid=iaid, T1=0, T2=0) /
+	        DHCP6OptClientId(duid=DUID))
+
+
+@pytest.fixture(scope="function")
+def ipv4only_iface(prepare_ifaces, grpc_client):
+	interface_init(VM4.tap)
+	VM4.ul_ipv6 = grpc_client.addinterface(VM4.name, VM4.pci, VM4.vni, VM4.ip, "::")
+	yield VM4
+	grpc_client.delinterface(VM4.name)
+
+
+def test_dhcpv6_noaddrsavail_solicit(ipv4only_iface):
+	answer = srp1(make_dhcpv6_pkt(DHCP6_Solicit, VM4),
+	              iface=VM4.tap, type=ETH_P_IPV6, timeout=sniff_timeout)
+	validate_checksums(answer)
+	assert DHCP6_Reply in answer
+	assert DHCP6OptStatusCode in answer
+	assert answer[DHCP6OptStatusCode].statuscode == 2, \
+		f"Expected NOADDRSAVAIL (2), got {answer[DHCP6OptStatusCode].statuscode}"
+
+def test_dhcpv6_noaddrsavail_request(ipv4only_iface):
+	answer = srp1(make_dhcpv6_pkt(DHCP6_Request, VM4, iaid=0xBEEF0002),
+	              iface=VM4.tap, type=ETH_P_IPV6, timeout=sniff_timeout)
+	validate_checksums(answer)
+	assert DHCP6_Reply in answer
+	assert DHCP6OptStatusCode in answer
+	assert answer[DHCP6OptStatusCode].statuscode == 2, \
+		f"Expected NOADDRSAVAIL (2), got {answer[DHCP6OptStatusCode].statuscode}"
+
+def test_dhcpv6_noaddrsavail_confirm_dropped(ipv4only_iface):
+	pkt = (Ether(dst=ipv6_multicast_mac) / IPv6(dst=gateway_ipv6) / UDP() /
+	       DHCP6_Confirm(trid=random.randint(0, 16777215)))
+	answer = srp1(pkt, iface=VM4.tap, type=ETH_P_IPV6, timeout=sniff_timeout)
+	assert answer is None, "Expected no reply for DHCP6_Confirm on IPv4-only interface"


### PR DESCRIPTION
address #794 

Instead of dropping the Solicit, reply with NoAddrsAvail (RFC 8415 §18.3.2). The guest gets an explicit "no address for you" and stops retrying, while still keeping its link-local address and IPv6 default route from the RA.

There are other approaches such as:
1) Per-interface M bit based on own_ipv6. Requires providing the port into dp_ipv6_fill_ra() (both solicited and periodic paths), and testing that no VF sees the wrong flag. Larger blast radius for the same outcome.

2) Drop RS entirely for no-IPv6 interfaces. Guest waits ~12 s for RA before giving up, then has no IPv6 default route at all.  Also asymmetric with IPv4 (which always ARPs).

To completely disable IPv6 for a VM without IPv6 configured, it is the best to address it via ignition to disable interfaces' IPv6 inside VM.