### PR TITLE
ci: fix fork PR support in workflow checkouts

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: Run checkpatch download
         continue-on-error: true

--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -26,7 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'release' && github.ref || github.event_name == 'push' && github.ref || github.event_name == 'pull_request' && github.event.pull_request.head.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           fetch-depth: 0
       - name: Determine SHA for Docker Image
         id: get_sha
@@ -114,6 +115,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.DOCKER_IMAGE_SHA }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       - name: Run dpservice
         run: docker run --rm --entrypoint ./dp_service.py --privileged -p1337:1337 --mount type=bind,source=/dev/hugepages,target=/dev/hugepages ghcr.io/ironcore-dev/dpservice-tester:${{ env.DOCKER_IMAGE_SHA }} --no-init &
       - name: Wait for gRPC port

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
Current CI/CD does not support running on forked repo, which is inconvenient for reviewing contributions from outside the org.

 - checkpatch, publish-docker-tester: pass head.sha + head.repo.full_name to actions/checkout so fork branches resolve correctly. Fixes 'branch or tag ... could not be found' failures on fork-triggered PRs.

  - size-label: switch to pull_request_target so the token has write scope on the base repo's labels (fixes 403 Resource not accessible).

 Fork PRs from non-members require maintainer approval (already configured in project setting) before these workflows run, keeping the self-hosted dpdk runner safe.

