### PR TITLE
Fix testing workflow and make critical workflow actions SHA-pinned

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -15,7 +15,7 @@ jobs:
   checkpatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
@@ -72,14 +72,14 @@ jobs:
           version: latest
           endpoint: ${{ env.CONTEXT_NAME }} # self-hosted
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push tester
         timeout-minutes: 60
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{env.platforms}}
@@ -112,7 +112,7 @@ jobs:
           for i in $(docker ps -q); do docker stop $i; done
       # dpservice-go tests
       - name: Run checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.DOCKER_IMAGE_SHA }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/**'
       - '**/*.md'
   pull_request:
+    types: [labeled, opened, synchronize, reopened]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
@@ -20,6 +21,10 @@ on:
 jobs:
   buildAndPushTester:
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: docker/metadata-action@v6
         id: meta
@@ -69,7 +69,7 @@ jobs:
           version: latest
           endpoint: ${{ env.CONTEXT_NAME }} # self-hosted
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build and push
         timeout-minutes: 95
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{ env.platforms }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Labels PRs based on branch, title, files, and body patterns
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         if: github.event_name == 'pull_request_target'
         with:
           config-name: release-drafter.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       # or a release branch
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         with:
           config-name: release-drafter.yml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR contains workflow enhancement and fix from two perspective:

1) straightforward SHA-pinning for workflow actions

2) fixing failed testing workflow for forked repo:
   _Problem_: 
     publish-docker-tester.yml unconditionally pushes to GHCR on every PR. When a PR comes from a fork, GitHub runs the workflow in the fork's restricted context — the GITHUB_TOKEN has no write access to ironcore-dev packages, so the push fails.
    
     The tester image must be built from PR code and pushed to GHCR before the test job can pull it by SHA. Unlike metalnet, there's no way to skip the push and still run tests.
    
    _Fix_:
    Gate the job on a `ok-to-test` label for fork PRs. When a maintainer applies the label, GitHub runs the workflow as a labeled event — always in the base repo's context with full GHCR write access. Internal PRs (same repo) continue to run automatically.