### PR TITLE
ci: pin GH actions to a specific commit hash

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -15,7 +15,7 @@ jobs:
   checkpatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
@@ -37,7 +37,7 @@ jobs:
           else
            echo "DOCKER_IMAGE_SHA=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta
         with:
           images: |
@@ -53,7 +53,7 @@ jobs:
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt:latest
           platforms: ${{env.platforms}}
@@ -67,19 +67,19 @@ jobs:
           echo "CONTEXT_NAME=$CONTEXT_NAME" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         timeout-minutes: 5
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           version: latest
           endpoint: ${{ env.CONTEXT_NAME }} # self-hosted
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push tester
         timeout-minutes: 60
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{env.platforms}}
@@ -112,7 +112,7 @@ jobs:
           for i in $(docker ps -q); do docker stop $i; done
       # dpservice-go tests
       - name: Run checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.DOCKER_IMAGE_SHA }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
@@ -121,7 +121,7 @@ jobs:
       - name: Wait for gRPC port
         run: timeout 15 bash -c 'until echo > /dev/tcp/localhost/1337 2>/dev/null; do sleep 1; done' 2>/dev/null
       - name: Setup Go Environment
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go/dpservice-go/go.mod'
       - name: Run dpservice-go tests

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta
         with:
           images: |
@@ -49,7 +49,7 @@ jobs:
             latest=${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt:latest
           platforms: ${{env.platforms}}
@@ -64,12 +64,12 @@ jobs:
 
       - name: Set up Docker Buildx
         timeout-minutes: 5
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           version: latest
           endpoint: ${{ env.CONTEXT_NAME }} # self-hosted
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build and push
         timeout-minutes: 95
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{ env.platforms }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Labels PRs based on branch, title, files, and body patterns
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         if: github.event_name == 'pull_request_target'
         with:
           config-name: release-drafter.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       # or a release branch
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         with:
           config-name: release-drafter.yml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pinning to a hash is more stable than pinning to a tag, because tags are potentially mutable. It also protects us better if any of the actions gets compromised in the future.

