### PR TITLE
Introduce 'ok-to-test' label to guard and run job in base repo's context

### DIFF
--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/**'
       - '**/*.md'
   pull_request:
+    types: [labeled, opened, synchronize, reopened]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
@@ -20,6 +21,10 @@ on:
 jobs:
   buildAndPushTester:
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
fixing failed testing workflow for forked repo:
 
 **Problem**: 
     publish-docker-tester.yml unconditionally pushes to GHCR on every PR. When a PR comes from a fork, GitHub runs the workflow in the fork's restricted context — the GITHUB_TOKEN has no write access to ironcore-dev packages, so the push fails.
     The tester image must be built from PR code and pushed to GHCR before the test job can pull it by SHA. Unlike metalnet, there's no way to skip the push and still run tests.
    
 **Fix**:
    Gate the job on a `ok-to-test` label for fork PRs. When a maintainer applies the label, GitHub runs the workflow as a labeled event — always in the base repo's context with full GHCR write access. Internal PRs (same repo) continue to run automatically.