### PR TITLE
Use artifacts to store compiled tester image

### DIFF
--- a/.github/workflows/publish-docker-tester.yml
+++ b/.github/workflows/publish-docker-tester.yml
@@ -37,26 +37,6 @@ jobs:
           else
            echo "DOCKER_IMAGE_SHA=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        id: meta
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/dpservice-tester
-          tags: |
-            type=semver,pattern={{version}}
-            type=schedule
-            type=raw,${{ env.DOCKER_IMAGE_SHA }}
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=sha
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: ${{env.platforms}}
       # workaround for self-hosted runner
       # https://github.com/mumoshu/actions-runner-controller-ci/commit/e91c8c0f6ca82aa7618010c6d2f417aa46c4a4bf
       - name: Set up Docker Context for Buildx
@@ -71,24 +51,38 @@ jobs:
         with:
           version: latest
           endpoint: ${{ env.CONTEXT_NAME }} # self-hosted
-      - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push tester
+      - name: Build tester image
         timeout-minutes: 60
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{env.platforms}}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          load: true
+          tags: dpservice-tester:${{ env.DOCKER_IMAGE_SHA }}
           target: tester
-          secrets: |
-            "github_token=${{ secrets.BOT_PAT }}"
+      - name: Save tester image as tar
+        run: docker save dpservice-tester:${{ env.DOCKER_IMAGE_SHA }} | gzip > /tmp/dpservice-tester.tar.gz
+      - name: Upload tester image artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dpservice-tester-${{ github.run_id }}
+          path: /tmp/dpservice-tester.tar.gz
+          retention-days: 1
+          overwrite: true
+      - name: Push tester image to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag and push to GHCR
+        if: github.event_name == 'push'
+        run: |
+          docker tag dpservice-tester:${{ env.DOCKER_IMAGE_SHA }} ghcr.io/${{ github.repository_owner }}/dpservice-tester:${{ env.DOCKER_IMAGE_SHA }}
+          docker push ghcr.io/${{ github.repository_owner }}/dpservice-tester:${{ env.DOCKER_IMAGE_SHA }}
+
   test:
     runs-on: [ self-hosted, dpdk ]
     needs: buildAndPushTester
@@ -101,11 +95,20 @@ jobs:
           else
             echo "DOCKER_IMAGE_SHA=${{ github.sha }}" >> $GITHUB_ENV
           fi
+      - name: Download tester image artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dpservice-tester-${{ github.run_id }}
+          path: /tmp
+      - name: Remove stale tester images
+        run: docker images --format '{{.Repository}}:{{.Tag}}' | grep '^dpservice-tester:' | xargs -r docker rmi || true
+      - name: Load tester image
+        run: docker load < /tmp/dpservice-tester.tar.gz && rm /tmp/dpservice-tester.tar.gz
       # dpservice-bin tests
       - name: Run tests
         id: run_tests
         run: |
-          docker run --rm --privileged --mount type=bind,source=/dev/hugepages,target=/dev/hugepages ghcr.io/ironcore-dev/dpservice-tester:${{ env.DOCKER_IMAGE_SHA }}
+          docker run --rm --privileged --mount type=bind,source=/dev/hugepages,target=/dev/hugepages dpservice-tester:${{ env.DOCKER_IMAGE_SHA }}
       - name: Docker cleanup
         if: always()
         run: |
@@ -117,7 +120,7 @@ jobs:
           ref: ${{ env.DOCKER_IMAGE_SHA }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       - name: Run dpservice
-        run: docker run --rm --entrypoint ./dp_service.py --privileged -p1337:1337 --mount type=bind,source=/dev/hugepages,target=/dev/hugepages ghcr.io/ironcore-dev/dpservice-tester:${{ env.DOCKER_IMAGE_SHA }} --no-init &
+        run: docker run --rm --entrypoint ./dp_service.py --privileged -p1337:1337 --mount type=bind,source=/dev/hugepages,target=/dev/hugepages dpservice-tester:${{ env.DOCKER_IMAGE_SHA }} --no-init &
       - name: Wait for gRPC port
         run: timeout 15 bash -c 'until echo > /dev/tcp/localhost/1337 2>/dev/null; do sleep 1; done' 2>/dev/null
       - name: Setup Go Environment
@@ -133,3 +136,6 @@ jobs:
         if: always()
         run: |
           for i in $(docker ps -q); do docker stop $i; done
+      - name: Remove tester image
+        if: always()
+        run: docker rmi dpservice-tester:${{ env.DOCKER_IMAGE_SHA }} || true


### PR DESCRIPTION
Follow the suggestion from @mkalcok, use artifacts to store resulted tester image.