### PR TITLE
Process pending sync messages before becoming active

### DIFF
--- a/src/dpdk_layer.c
+++ b/src/dpdk_layer.c
@@ -151,9 +151,12 @@ static int graph_main_loop(__rte_unused void *arg)
 	}
 
 	// In standby mode (no packet processing), gRPC requests still need processing
+	// The walk needs to be the last thing done in this loop, so that sync messages that
+	// arrived during the sleep are still processed in backup mode; leaving them in the
+	// receive queue would get them rejected by the sync node once this dpservice is active
 	while (!force_quit && standing_by) {
-		rte_graph_walk(graph);
 		nanosleep(&standby_sleep, NULL);
+		rte_graph_walk(graph);
 	}
 
 	if (!force_quit) {


### PR DESCRIPTION
The standby loop in graph_main_loop() walked the graph and then slept, with the loop condition evaluated after the sleep, so when the active lock is released during the 1 ms nanosleep(), the loop exits without a final walk.

Sync messages that arrived in that window are read only after sync_node_switch_mode() is done and thus get rejected as "Invalid sync message for active dpservice", losing PORT_MAC, NAT_CREATE, NAT_DELETE and VIRTSVC_CONN updates.

When the sleep is amplified, it is easy to reprodude using the test suite.

Fixes #805 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standby processing so messages received during standby are handled before activation.
  * Reduced delays when transitioning from standby to active operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->