### PR TITLE
ci: Set Dependabot's cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       k8s:
@@ -24,6 +26,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       gh-actions:
@@ -35,6 +39,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       docker:


### PR DESCRIPTION
Dependabot won't bump packages to versions that are less than 7 days old.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a seven-day waiting period between automated dependency update pull requests for Go modules, GitHub Actions, and Docker dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->